### PR TITLE
ColumnProfile frequent items and cardinality trackers ignore nulls

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -82,3 +82,4 @@ virtualenv==20.0.31
 wcwidth==0.2.5
 webencodings==0.5.1
 whylabs-datasketches==2.0.0b6
+ipdb >= 0.13.3

--- a/src/whylogs/core/columnprofile.py
+++ b/src/whylogs/core/columnprofile.py
@@ -8,6 +8,8 @@ from whylogs.core.types import TypedDataConverter
 from whylogs.proto import ColumnMessage, ColumnSummary, InferredType
 from whylogs.util.dsketch import FrequentItemsSketch
 
+import pandas as pd
+
 _TYPES = InferredType.Type
 _NUMERIC_TYPES = {_TYPES.FRACTIONAL, _TYPES.INTEGRAL}
 _UNIQUE_COUNT_BOUNDS_STD = 1
@@ -88,8 +90,10 @@ class ColumnProfile:
 
         # TODO: Implement real typed data conversion
         typed_data = TypedDataConverter.convert(value)
-        self.cardinality_tracker.update(typed_data)
-        self.frequent_items.update(typed_data)
+
+        if not pd.isnull(typed_data):
+            self.cardinality_tracker.update(typed_data)
+            self.frequent_items.update(typed_data)
         dtype = TypedDataConverter.get_type(typed_data)
         self.schema_tracker.track(dtype)
 

--- a/tests/unit/core/statistics/test_numbertracker.py
+++ b/tests/unit/core/statistics/test_numbertracker.py
@@ -1,5 +1,5 @@
 import pytest
-from helpers.testutil import compare_frequent_items
+from testutil import compare_frequent_items
 
 from whylogs.core.statistics import NumberTracker
 

--- a/tests/unit/core/test_columnprofile.py
+++ b/tests/unit/core/test_columnprofile.py
@@ -9,8 +9,9 @@ from whylogs.util.protobuf import message_to_dict
 
 def test_frequent_items_do_not_track_nulls():
     import numpy as np
+
     data = [None, np.nan, None]
-    c = ColumnProfile('col')
+    c = ColumnProfile("col")
     for val in data:
         c.track(val)
     assert c.frequent_items.to_summary() is None

--- a/tests/unit/core/test_columnprofile.py
+++ b/tests/unit/core/test_columnprofile.py
@@ -1,10 +1,22 @@
 import json
 
 import pytest
-from helpers.testutil import compare_frequent_items
+from testutil import compare_frequent_items
 
 from whylogs.core import ColumnProfile
 from whylogs.util.protobuf import message_to_dict
+
+
+def test_frequent_items_do_not_track_nulls():
+    import numpy as np
+    data = [None, np.nan, None]
+    c = ColumnProfile('col')
+    for val in data:
+        c.track(val)
+    assert c.frequent_items.to_summary() is None
+    assert c.frequent_items.is_empty()
+    assert c.cardinality_tracker.is_empty()
+    assert c.cardinality_tracker.to_summary() is None
 
 
 def test_track():

--- a/tests/unit/util/test_dsketch_frequentitems.py
+++ b/tests/unit/util/test_dsketch_frequentitems.py
@@ -2,7 +2,7 @@ import json
 
 import datasketches
 import numpy as np
-from helpers.testutil import compare_frequent_items
+from testutil import compare_frequent_items
 
 from whylogs.util import dsketch
 

--- a/tests/unit/util/test_dsketch_frequentnumbers.py
+++ b/tests/unit/util/test_dsketch_frequentnumbers.py
@@ -1,6 +1,6 @@
 import datasketches
 import pytest
-from helpers.testutil import compare_frequent_items
+from testutil import compare_frequent_items
 
 from whylogs.util import dsketch
 


### PR DESCRIPTION
This fixes an unintended behavior where null values are tracked as frequent items by column profiles.