### PR TITLE
Fix bug where numpy dtypes were not recognized as numbers

### DIFF
--- a/src/whylogs/core/columnprofile.py
+++ b/src/whylogs/core/columnprofile.py
@@ -101,8 +101,7 @@ class ColumnProfile:
             # Note: bools are sub-classes of ints in python, so we should check
             # for bool type first
             self.counters.increment_bool()
-        elif isinstance(typed_data, (float, int)):
-            self.number_tracker.track(typed_data)
+        self.number_tracker.track(typed_data)
 
     def to_summary(self):
         """

--- a/src/whylogs/core/statistics/numbertracker.py
+++ b/src/whylogs/core/statistics/numbertracker.py
@@ -4,6 +4,7 @@ TODO:
 """
 import datasketches
 import pandas as pd
+import numbers
 
 from whylogs.core.statistics.datatypes import FloatTracker, IntTracker, VarianceTracker
 from whylogs.core.statistics.thetasketch import ThetaSketch
@@ -82,8 +83,10 @@ class NumberTracker:
         number : int, float
             A numeric value
         """
-        if pd.isnull(number):
+        if pd.isnull(number) or not isinstance(number, numbers.Real):
+            # XXX: this type checking may still be fragile in python.
             return
+        print("tracking")
         self.variance.update(number)
         self.theta_sketch.update(number)
         self.frequent_numbers.update(number)

--- a/src/whylogs/core/statistics/numbertracker.py
+++ b/src/whylogs/core/statistics/numbertracker.py
@@ -83,7 +83,11 @@ class NumberTracker:
         number : int, float
             A numeric value
         """
-        if pd.isnull(number) or not isinstance(number, numbers.Real):
+        if (
+            pd.isnull(number)
+            or (not isinstance(number, numbers.Real))
+            or isinstance(number, bool)
+        ):
             # XXX: this type checking may still be fragile in python.
             return
         self.variance.update(number)

--- a/src/whylogs/core/statistics/numbertracker.py
+++ b/src/whylogs/core/statistics/numbertracker.py
@@ -86,7 +86,6 @@ class NumberTracker:
         if pd.isnull(number) or not isinstance(number, numbers.Real):
             # XXX: this type checking may still be fragile in python.
             return
-        print("tracking")
         self.variance.update(number)
         self.theta_sketch.update(number)
         self.frequent_numbers.update(number)

--- a/tests/helpers/testutil.py
+++ b/tests/helpers/testutil.py
@@ -1,3 +1,6 @@
+TEST_BUCKET = "whylabs-isaac"
+
+
 def frequent_items_to_dict(x: list):
     d = {}
     for xi in x:

--- a/tests/helpers/testutil.py
+++ b/tests/helpers/testutil.py
@@ -1,6 +1,3 @@
-TEST_BUCKET = "whylabs-isaac"
-
-
 def frequent_items_to_dict(x: list):
     d = {}
     for xi in x:

--- a/tests/unit/core/test_columnprofile.py
+++ b/tests/unit/core/test_columnprofile.py
@@ -5,6 +5,26 @@ from testutil import compare_frequent_items
 
 from whylogs.core import ColumnProfile
 from whylogs.util.protobuf import message_to_dict
+import numpy as np
+import pandas as pd
+
+
+def test_all_numeric_types_get_tracked_by_number_tracker():
+
+    all_values = [
+        [1.0, 2.0, 3.0],
+        [1, 2, 3],
+        np.arange(4),
+        np.linspace(1, 2, 5),
+        pd.Series(np.arange(3)),
+        np.zeros(3, dtype=np.int32),
+        np.zeros(3, dtype=np.int16),
+    ]
+    for values in all_values:
+        c = ColumnProfile("test")
+        for v in values:
+            c.track(v)
+        assert c.number_tracker.count == len(values)
 
 
 def test_all_nulls_inferred_type_null():


### PR DESCRIPTION
This manifested as numpy int64 values NOT being treated as numbers,
therefore not being tracked, and therefore not generating quantiles.