### PR TITLE
Support logging live prediction with whylogs for MLFlow's sklearn

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.13-dev1
+current_version = 0.1.13-dev2
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.13-dev2
+current_version = 0.1.13-dev3
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.13-dev0
+current_version = 0.1.13-dev1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,8 @@ servedocs: docs ## compile the docs watching for changes
 release: dist ## package and upload a release
 	twine upload dist/*
 
-dist: clean ## builds source and wheel package
+dist: clean-build build-proto ## builds source and wheel package
+	python setup.py build
 	python setup.py sdist
 	python setup.py bdist_wheel
 	ls -l dist

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,7 +119,7 @@ copyright = "2020, WhyLabs, Inc"
 # built documents.
 #
 # The short X.Y version.
-version = " 0.1.13-dev1"
+version = " 0.1.13-dev2"
 # The full version, including alpha/beta/rc tags.
 release = ""  # Is set by calling `setup.py docs`
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,7 +119,7 @@ copyright = "2020, WhyLabs, Inc"
 # built documents.
 #
 # The short X.Y version.
-version = " 0.1.13-dev0"
+version = " 0.1.13-dev1"
 # The full version, including alpha/beta/rc tags.
 release = ""  # Is set by calling `setup.py docs`
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,7 +119,7 @@ copyright = "2020, WhyLabs, Inc"
 # built documents.
 #
 # The short X.Y version.
-version = " 0.1.13-dev2"
+version = " 0.1.13-dev3"
 # The full version, including alpha/beta/rc tags.
 release = ""  # Is set by calling `setup.py docs`
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 name = whylogs
-version = 0.1.13-dev0
+version = 0.1.13-dev1
 description = Add a short description here!
 author = Andy Dang🤖
 author-email = andy@whylabs.ai

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,9 @@ install_requires =
     botocore>=1.17.44
 # very important: s3fs pulls in aiobotocore, which locks boto3
     s3fs==0.4.2
+setup_requires =
+    pytest-runner
+    setuptools
 
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
@@ -91,9 +94,6 @@ console_scripts =
     whylogs = whylogs.cli:main
     whylogs-demo = whylogs.cli:demo_main
 
-[test]
-# py.test options when running `python setup.py test`
-
 [tool:pytest]
 # Options for py.test:
 # Specify command line options as you would do when invoking py.test directly.
@@ -111,6 +111,7 @@ testpaths = tests
 
 [aliases]
 dists = bdist_wheel
+test = pytest
 
 [bdist_wheel]
 # Use this option if your package is pure-python

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 name = whylogs
-version = 0.1.13-dev1
+version = 0.1.13-dev2
 description = Profile and monitor your ML data pipeline end-to-end
 author = WhyLabs.ai
 author-email = support@whylabs.ai

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,7 @@ testing =
     wheel
     setuptools_black
     coverage==5.3  # Required for pycharm to run tests with coverage
+    sklearn
 viz =
     matplotlib
 mlflow =
@@ -92,8 +93,6 @@ console_scripts =
 
 [test]
 # py.test options when running `python setup.py test`
-# addopts = --verbose
-extras = True
 
 [tool:pytest]
 # Options for py.test:

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 name = whylogs
-version = 0.1.13-dev2
+version = 0.1.13-dev3
 description = Profile and monitor your ML data pipeline end-to-end
 author = WhyLabs.ai
 author-email = support@whylabs.ai

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,22 +5,24 @@
 [metadata]
 name = whylogs
 version = 0.1.13-dev1
-description = Add a short description here!
-author = Andy Dang🤖
-author-email = andy@whylabs.ai
-license = mit
+description = Profile and monitor your ML data pipeline end-to-end
+author = WhyLabs.ai
+author-email = support@whylabs.ai
+license = apache-2.0
 long-description = file: README.md
 long-description-content-type = text/markdown; charset=UTF-8; variant=GFM
-url = https://github.com/pyscaffold/pyscaffold/
+url = https://github.com/whylabs/whylogs-python/
 project-urls =
-    Documentation = https://pyscaffold.org/
+    Documentation = https://whylogs.readthedocs.io/
 # Change if running only on Windows, Mac or Linux (comma-separated)
 platforms = any
 # Add here all kinds of additional classifiers as defined under
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 classifiers =
-    Development Status :: 4 - Beta
+    Development Status :: 3 - Alpha
+    License :: OSI Approved :: Apple Public Source License
     Programming Language :: Python
+    Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
 zip_safe = False
@@ -28,8 +30,6 @@ packages = find:
 include_package_data = True
 package_dir =
     =src
-# DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
-setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
     click>=7.1.2
@@ -140,15 +140,3 @@ exclude =
     tests
 max-line-length = 160
 max-complexity = 20
-
-
-[pyscaffold]
-# PyScaffold's parameters when the project was created.
-# This will be used when updating. Do not change!
-version = 3.2.3
-package = whylogs
-extensions =
-    tox
-    travis
-    markdown
-    pyproject

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,6 @@
 """
     Setup file for whylogs_python.
     Use setup.cfg to configure your project.
-
-    This file was generated with PyScaffold 3.2.3.
-    PyScaffold helps you to put up the scaffold of your new Python project.
-    Learn more under: https://pyscaffold.org/
 """
 
 import subprocess
@@ -72,4 +68,4 @@ class BuildProto(_clean):
 
 
 if __name__ == "__main__":
-    setup(cmdclass={"proto": BuildProto}, use_pyscaffold=True)
+    setup(cmdclass={"proto": BuildProto})

--- a/src/whylogs/_version.py
+++ b/src/whylogs/_version.py
@@ -1,3 +1,3 @@
 """WhyLabs version number."""
 
-__version__ = "0.1.13-dev1"
+__version__ = "0.1.13-dev2"

--- a/src/whylogs/_version.py
+++ b/src/whylogs/_version.py
@@ -1,3 +1,3 @@
 """WhyLabs version number."""
 
-__version__ = "0.1.13-dev0"
+__version__ = "0.1.13-dev1"

--- a/src/whylogs/_version.py
+++ b/src/whylogs/_version.py
@@ -1,3 +1,3 @@
 """WhyLabs version number."""
 
-__version__ = "0.1.13-dev2"
+__version__ = "0.1.13-dev3"

--- a/src/whylogs/app/config.py
+++ b/src/whylogs/app/config.py
@@ -249,23 +249,19 @@ def load_config(path_to_config: str = None):
             "opt":   os.path.join("/opt/whylogs/", WHYLOGS_YML),
         }
 
-        location_found = None
-
-        for k, fpath in cfg_candidates.items():
-            logger.debug(f"Attempting to load config file: {fpath}")
-            if fpath is None or not os.path.isfile(fpath):
+        for k, f_path in cfg_candidates.items():
+            logger.debug(f"Attempting to load config file: {f_path}")
+            if f_path is None or not os.path.isfile(f_path):
                 continue
 
             try:
-                with open(fpath, "rt") as f:
+                with open(f_path, "rt") as f:
                     session_config = SessionConfig.from_yaml(f)
-                    location_found = {k, fpath}
                     return session_config
             except IOError as e:
                 logger.warning("Failed to load YAML config", e)
                 pass
     else:
-        print("here")
         try:
             with open(path_to_config, "rt") as f:
                 session_config = SessionConfig.from_yaml(f)

--- a/src/whylogs/app/session.py
+++ b/src/whylogs/app/session.py
@@ -158,7 +158,7 @@ class Session:
         """
         Perform statistics caluclations and log a pandas dataframe
 
-        :param df: the dataframe to profile 
+        :param df: the dataframe to profile
         :param dataset_name: name of the dataset
         :param dataset_timestamp: the timestamp for the dataset
         :param session_timestamp: the timestamp for the session. Override the default one

--- a/src/whylogs/app/session.py
+++ b/src/whylogs/app/session.py
@@ -322,7 +322,7 @@ def reset_default_session():
     _session = session_from_config(config)
 
 
-def get_or_create_session():
+def get_or_create_session(path_to_config: Optional[str] = None):
     """
     Retrieve the current active global session.
 
@@ -332,17 +332,16 @@ def get_or_create_session():
     If an active session exists, return the session without loading new
     config.
 
-    Returns
-    -------
-    session : Session
-        The global active session
+    :return: The global active session
+    :rtype: Session
+    :type path_to_config: str
     """
     global _session
     if _session is not None and _session.is_active():
         _getLogger(__name__).debug(
             "Active session found, ignoring session kwargs")
     else:
-        config = load_config()
+        config = load_config(path_to_config)
         if config is None:
             print("WARN: Missing config")
             writer = WriterConfig(

--- a/src/whylogs/cli/cli.py
+++ b/src/whylogs/cli/cli.py
@@ -37,13 +37,12 @@ def _set_up_logger():
 )
 def cli(verbose):
     """
-Welcome to whylogs CLI!
+    Welcome to whylogs CLI!
 
-Supported basic commands:
+    Supported basic commands:
 
-- whylogs init : create a new whylogs project configuration
-
-"""
+    - whylogs init : create a new whylogs project configuration
+    """
     logger = _set_up_logger()
     if verbose:
         logger.setLevel(logging.DEBUG)

--- a/src/whylogs/cli/demo_cli.py
+++ b/src/whylogs/cli/demo_cli.py
@@ -200,13 +200,12 @@ def profile_csv(session_config: SessionConfig, project_dir: str) -> str:
 )
 def cli(verbose):
     """
-Welcome to whylogs Demo CLI!
+    Welcome to whylogs Demo CLI!
 
-Supported commands:
+    Supported commands:
 
-- whylogs-demo init : create a demo whylogs project with example data and notebooks
-
-"""
+    - whylogs-demo init : create a demo whylogs project with example data and notebooks
+    """
     logger = _set_up_logger()
     if verbose:
         logger.setLevel(logging.DEBUG)

--- a/src/whylogs/mlflow/model_wrapper.py
+++ b/src/whylogs/mlflow/model_wrapper.py
@@ -1,52 +1,25 @@
 import atexit
-import os
-import tempfile
 
 import whylogs
-import boto3
 import datetime
+
+from whylogs.app.config import WHYLOGS_YML
 
 
 class ModelWrapper(object):
     def __init__(self, model):
         self.model = model
-        self.session = whylogs.get_or_create_session()
-        self.s3 = boto3.client("s3")
-        self.temp_dir = tempfile.gettempdir()
-        self.bucket = os.environ['WHYLOGS_S3_BUCKET']
-        self.prefix = os.environ['WHYLOGS_S3_PREFIX']
-        self.dataset_name = os.environ['WHYLOGS_DATASET_NAME'] or 'live-model'
-        self.current_batch_timestamp = _get_utc_hour()
+        self.session = whylogs.get_or_create_session("/opt/ml/model/" + WHYLOGS_YML)
         self.logger = self.create_logger()
         self.last_upload_time = datetime.datetime.utcnow()
-        atexit.register(self.upload_whylogs)
+        atexit.register(self.logger.close)
 
     def create_logger(self):
-        return self.session.logger(self.dataset_name, dataset_timestamp=self.current_batch_timestamp)
+        # TODO: support different rotation mode and support custom name here
+        return self.session.logger('live', with_rotation_time='m')
 
-    def predict(self, input):
-        now = datetime.datetime.utcnow()
-        delta = now - self.last_upload_time
-        if delta.total_seconds() > 15:
-            self.upload_whylogs()
-        current_hour = _get_utc_hour()
-        if current_hour > self.current_batch_timestamp:
-            # TODO: whylogs to support log rotation. See #106
-            self.current_batch_timestamp = current_hour
-            self.upload_whylogs()
-            self.logger.close()
-            self.logger = self.create_logger()
-        self.logger.log_dataframe(input)
-        return self.model.predict(input)
-
-    def upload_whylogs(self):
-        tmp_path = os.path.join(self.temp_dir, 'data.bin')
-        self.logger.profile.write_protobuf(tmp_path)
-        output = f"{self.prefix}/{self.current_batch_timestamp.timestamp()}-profile.bin"
-        self.s3.upload_file(tmp_path, self.bucket, output)
-        self.last_upload_time = datetime.datetime.now()
-
-
-def _get_utc_hour():
-    now = datetime.datetime.utcnow()
-    return now.replace(minute=0, hour=0, second=0, microsecond=0)
+    def predict(self, df):
+        self.logger.log_dataframe(df)
+        output = self.model.predict(df)
+        self.logger.log_dataframe(df)
+        return output

--- a/src/whylogs/mlflow/model_wrapper.py
+++ b/src/whylogs/mlflow/model_wrapper.py
@@ -1,0 +1,52 @@
+import atexit
+import os
+import tempfile
+
+import whylogs
+import boto3
+import datetime
+
+
+class ModelWrapper(object):
+    def __init__(self, model):
+        self.model = model
+        self.session = whylogs.get_or_create_session()
+        self.s3 = boto3.client("s3")
+        self.temp_dir = tempfile.gettempdir()
+        self.bucket = os.environ['WHYLOGS_S3_BUCKET']
+        self.prefix = os.environ['WHYLOGS_S3_PREFIX']
+        self.dataset_name = os.environ['WHYLOGS_DATASET_NAME'] or 'live-model'
+        self.current_batch_timestamp = _get_utc_hour()
+        self.logger = self.create_logger()
+        self.last_upload_time = datetime.datetime.utcnow()
+        atexit.register(self.upload_whylogs)
+
+    def create_logger(self):
+        return self.session.logger(self.dataset_name, dataset_timestamp=self.current_batch_timestamp)
+
+    def predict(self, input):
+        now = datetime.datetime.utcnow()
+        delta = now - self.last_upload_time
+        if delta.total_seconds() > 15:
+            self.upload_whylogs()
+        current_hour = _get_utc_hour()
+        if current_hour > self.current_batch_timestamp:
+            # TODO: whylogs to support log rotation. See #106
+            self.current_batch_timestamp = current_hour
+            self.upload_whylogs()
+            self.logger.close()
+            self.logger = self.create_logger()
+        self.logger.log_dataframe(input)
+        return self.model.predict(input)
+
+    def upload_whylogs(self):
+        tmp_path = os.path.join(self.temp_dir, 'data.bin')
+        self.logger.profile.write_protobuf(tmp_path)
+        output = f"{self.prefix}/{self.current_batch_timestamp.timestamp()}-profile.bin"
+        self.s3.upload_file(tmp_path, self.bucket, output)
+        self.last_upload_time = datetime.datetime.now()
+
+
+def _get_utc_hour():
+    now = datetime.datetime.utcnow()
+    return now.replace(minute=0, hour=0, second=0, microsecond=0)

--- a/src/whylogs/mlflow/sklearn.py
+++ b/src/whylogs/mlflow/sklearn.py
@@ -1,0 +1,10 @@
+from .model_wrapper import ModelWrapper
+
+
+def _load_pyfunc(path: str):
+    import mlflow
+
+    # Load the Sklearn function
+    model = mlflow.sklearn._load_pyfunc(path)
+
+    return ModelWrapper(model)

--- a/tests/unit/mlflow/test_patcher.py
+++ b/tests/unit/mlflow/test_patcher.py
@@ -81,3 +81,21 @@ def test_assert_log_artifact_is_called_twice(tmpdir):
 
         assert log_artifact.call_count == 2
     whylogs.mlflow.disable_mlflow()
+
+
+def test_sklearn_model_log(tmpdir):
+    import whylogs
+    import mlflow
+    from sklearn.linear_model import ElasticNet
+    from whylogs.mlflow import patcher as whylogs_patcher
+
+    set_up_mlflow(mlflow, tmpdir)
+    with mock.patch.object(whylogs_patcher, "new_model_log") as new_log_func:
+        whylogs.enable_mlflow()
+
+        with mlflow.start_run():
+            model = ElasticNet(alpha=0.5, l1_ratio=0.5, random_state=42)
+            mlflow.sklearn.log_model(model, "model", registered_model_name="TestModel")
+
+        assert new_log_func.call_count == 1
+    whylogs.mlflow.disable_mlflow()


### PR DESCRIPTION
Tested manually with
```
import mlflow
whylogs.enable_mlflow()
mlflow.set_tracking_uri("http://localhost:5000")

# Build model here

mlflow.sagemaker.deploy(
    app_name="demo", 
    model_uri="runs:/c5759e1dc5bf48e7bfe6be1ec4951d7a/model", 
    execution_role_arn="<arn>",
    mode="replace")
```