### PR TITLE
#130 - Do not depend on PIL on import of whylogs

### DIFF
--- a/examples/segments_logging.py
+++ b/examples/segments_logging.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import time
-from whylogs.core.datasetprofile import dataframe_profile
 from whylogs import get_or_create_session
 
 if __name__ == "__main__":
@@ -13,14 +12,14 @@ if __name__ == "__main__":
     #logger with two specific segments
     with session.logger(
         "segment", segments=[
-        [{"key": "home_ownership", "value": "RENT"}],[{"key": "home_ownership", "value": "MORTGAGE"}]], cache=1
+        [{"key": "home_ownership", "value": "RENT"}],[{"key": "home_ownership", "value": "MORTGAGE"}]], cache_size=1
     ) as logger:
         print(session.get_config())
         logger.log_dataframe(df)
         profile_seg = logger.segemented_profiles
 
     # logger with rotation with time and single key segment
-    with session.logger("rotated_segments", segments=["home_ownership"], with_rotation_time="s", cache=1) as logger:
+    with session.logger("rotated_segments", segments=["home_ownership"], with_rotation_time="s", cache_size=1) as logger:
         print(session.get_config())
         logger.log_dataframe(df)
         time.sleep(2)
@@ -28,7 +27,7 @@ if __name__ == "__main__":
         profile_seg = logger.segemented_profiles
 
 # logger with rotation with time and two keys segment
-    with session.logger("rotated_seg_two_keys", segments=["home_ownership", "sub_grade"], with_rotation_time="s", cache=1) as logger:
+    with session.logger("rotated_seg_two_keys", segments=["home_ownership", "sub_grade"], with_rotation_time="s", cache_size=1) as logger:
         print(session.get_config())
         logger.log_csv("data/lending_club_1000.csv")
         time.sleep(2)
@@ -36,7 +35,7 @@ if __name__ == "__main__":
         profile_seg = logger.segemented_profiles
 
 # logger 
-    with session.logger("rotated_seg_two_keys", segments=["home_ownership"], profile_full_dataset=True, with_rotation_time="s", cache=1) as logger:
+    with session.logger("rotated_seg_two_keys", segments=["home_ownership"], profile_full_dataset=True, with_rotation_time="s", cache_size=1) as logger:
         print(session.get_config())
         logger.log_csv("data/lending_club_1000.csv")
         time.sleep(2)

--- a/scripts/dataset_logging.py
+++ b/scripts/dataset_logging.py
@@ -1,10 +1,4 @@
 import pandas as pd
-import time
-from PIL import Image
-from PIL.ExifTags import TAGS
-from whylogs.core.datasetprofile import dataframe_profile
-
-from whylogs.io.local_dataset import LocalDataset
 from whylogs import get_or_create_session
 
 
@@ -13,7 +7,7 @@ if __name__ == "__main__":
     session = get_or_create_session()
 
     with session.logger(
-        "dataset_1", cache=1
+        "dataset_1", cache_size=1
     ) as logger:
 
         profile = logger.profile

--- a/scripts/session_dataloging.py
+++ b/scripts/session_dataloging.py
@@ -1,13 +1,14 @@
-import pandas as pd
 import time
-from whylogs.core.datasetprofile import dataframe_profile
+
+import pandas as pd
+
 from whylogs import get_or_create_session
 
 if __name__ == "__main__":
     df = pd.read_csv("data/lending-club-accepted-10.csv")
 
     session = get_or_create_session()
-    with session.logger("test", with_rotation_time="s", cache=1) as logger:
+    with session.logger("test", with_rotation_time="s", cache_size=1) as logger:
         logger.log_dataframe(df)
         time.sleep(2)
         logger.log_dataframe(df)

--- a/src/whylogs/app/config.py
+++ b/src/whylogs/app/config.py
@@ -126,7 +126,7 @@ class SessionConfig:
             "h" for hours
             "d" for days
 
-    cache: int default =1, sets how many dataprofiles to cache in logger during rotation
+    cache_size: int default =1, sets how many dataprofiles to cache in logger during rotation
     segments: List 
     """
 
@@ -137,16 +137,14 @@ class SessionConfig:
         writers: List[WriterConfig],
         verbose: bool = False,
         with_rotation_time: str = None,
-        cache: int = 1,
-        segments: Optional[Union[List[str], List[SegmentTags]]] = None,
-        full_dataset_profile: bool = True,
+        cache_size: int = 1,
     ):
         self.project = project
         self.pipeline = pipeline
         self.verbose = verbose
         self.writers = writers
         self.with_rotation_time = with_rotation_time
-        self.cache = cache
+        self.cache_size = cache_size
 
     def to_yaml(self, stream=None):
         """

--- a/src/whylogs/core/__init__.py
+++ b/src/whylogs/core/__init__.py
@@ -1,8 +1,10 @@
-"""
-This subpackage defines the core components of the whylogs python library.
-
-In particular, look at the `DatasetProfile` class
-"""
 from .columnprofile import ColumnProfile
 from .datasetprofile import DatasetProfile
-from .image_profiling import TrackImage, _METADATA_DEFAULT_ATTRIBUTES
+from .image_profiling import TrackImage, _METADATA_DEFAULT_ATTRIBUTES as METADATA_DEFAULT_ATTRIBUTES
+
+__ALL__ = [
+    ColumnProfile,
+    DatasetProfile,
+    TrackImage,
+    METADATA_DEFAULT_ATTRIBUTES,
+]

--- a/src/whylogs/core/image_profiling.py
+++ b/src/whylogs/core/image_profiling.py
@@ -1,20 +1,21 @@
+import logging
+from typing import Optional, Callable, List, Dict
 
-from PIL.Image import Image as ImageType
-from PIL.ExifTags import TAGS as eTAGs
-
-from PIL.TiffTags import TAGS
-from PIL.TiffImagePlugin import IFDRational
-from whylogs.core.datasetprofile import DatasetProfile
-
-from typing import Optional, Callable, List, Union, Dict
-import numpy as np
-
-from whylogs.features import _IMAGE_FEATURES
 from whylogs.features.transforms import Hue, Saturation, Brightness
 
+logger = logging.getLogger(__name__)
+
+try:
+    from PIL.Image import Image as ImageType
+
+    from PIL.TiffTags import TAGS
+    from PIL.TiffImagePlugin import IFDRational
+except ImportError as e:
+    ImageType = None
+    logger.debug(str(e))
+    logger.debug("Unable to load PIL; install pillow for image support")
 
 DEFAULT_IMAGE_FEATURES = [Hue(), Saturation(), Brightness()]
-
 
 _METADATA_DEFAULT_ATTRIBUTES = [
     "ImageWidth",
@@ -37,7 +38,7 @@ _METADATA_DEFAULT_ATTRIBUTES = [
 ]
 
 
-def image_loader(path: str = None)-> ImageType:
+def image_loader(path: str = None) -> ImageType:
     from PIL import Image
     with open(path, "rb") as file_p:
         img = Image.open(file_p).copy()
@@ -45,14 +46,13 @@ def image_loader(path: str = None)-> ImageType:
 
 
 class TrackImage:
-
     """
     This is a class that computes image features and visits profiles and so image features can be sketched.
 
     Attributes:
         feature_name (str): name given to this image feature, will prefix all image based features
-        feature_transforms (List[Callable]): Feature transforms to be apply to image data. 
-        img (PIL.Image): the PIL.Image 
+        feature_transforms (List[Callable]): Feature transforms to be apply to image data.
+        img (PIL.Image): the PIL.Image
         metadata_attributes (TYPE): metadata attributes to track
     """
 
@@ -98,7 +98,7 @@ class TrackImage:
             for each_profile in profiles:
 
                 each_profile.track_array(
-                    columns=[self.feature_name+transform_name], x=transformed_image)
+                    columns=[self.feature_name + transform_name], x=transformed_image)
 
                 if self.metadata_attributes == "all":
                     each_profile.track(metadata)
@@ -107,7 +107,7 @@ class TrackImage:
                     for each_attr in self.metadata_attributes:
                         attribute_value = metadata.get(each_attr, None)
                         each_profile.track(
-                            self.feature_name+each_attr, attribute_value)
+                            self.feature_name + each_attr, attribute_value)
 
 
 def get_pil_image_metadata(img: ImageType) -> Dict:
@@ -120,7 +120,7 @@ def get_pil_image_metadata(img: ImageType) -> Dict:
     Returns:
         Dict: of metadata
     """
-    metadata = {TAGS[k]:  "{}".format(v) if (isinstance(v, IFDRational)) else v
+    metadata = {TAGS[k]: "{}".format(v) if (isinstance(v, IFDRational)) else v
                 for k, v in dict(img.getexif()).items()
                 }
 
@@ -130,7 +130,6 @@ def get_pil_image_metadata(img: ImageType) -> Dict:
 
 
 def image_based_metadata(img):
-
     return {"ImagePixelWidth": img.width,
             "ImagePixelHeight": img.height,
             "Colorspace": img.mode,

--- a/src/whylogs/features/transforms.py
+++ b/src/whylogs/features/transforms.py
@@ -1,8 +1,18 @@
+import logging
 import numpy as np
-from typing import Union, Callable, List
-from PIL.Image import Image as ImageType
-from PIL import Image
-from PIL import ImageFilter
+
+from typing import Union, List
+
+logger = logging.getLogger(__name__)
+
+try:
+    from PIL import Image
+    from PIL import ImageFilter
+    from PIL.Image import Image as ImageType
+except ImportError as e:
+    ImageType = None
+    logger.debug(str(e))
+    logger.debug("Unable to load PIL; install pillow for image support")
 
 
 class ComposeTransforms:
@@ -29,12 +39,11 @@ class ComposeTransforms:
 
 
 class Brightness:
-
     """
      Outputs the Brightness of each pixel in the image
     """
 
-    def __call__(self, img: Union[ImageType, np.ndarray])->np.ndarray:
+    def __call__(self, img: Union[ImageType, np.ndarray]) -> np.ndarray:
         """
         Args:
             img (Union[Image, np.ndarray]): Either a PIL image or numpy array with int8 values
@@ -55,12 +64,11 @@ class Brightness:
 
 
 class Saturation:
-
     """Summary
     Outputs the saturation of each pixel in the image
     """
 
-    def __call__(self, img: Union[ImageType, np.ndarray])->np.ndarray:
+    def __call__(self, img: Union[ImageType, np.ndarray]) -> np.ndarray:
         """
         Args:
             img (Union[Image, np.ndarray]): Either a PIL image or numpy array with int8 values
@@ -79,7 +87,7 @@ class Saturation:
 
 class Hue:
 
-    def __call__(self, img: Union[ImageType, np.ndarray])->np.ndarray:
+    def __call__(self, img: Union[ImageType, np.ndarray]) -> np.ndarray:
         """
         Args:
             img (Union[Image, np.ndarray]): Either a PIL image or numpy array with int8 values
@@ -96,13 +104,12 @@ class Hue:
 
 
 class SimpleBlur:
-
     """Simple Blur Ammount computation based on variance of laplacian
-    Overall metric of how blurry is the image. No overall scale.  
+    Overall metric of how blurry is the image. No overall scale.
 
     """
 
-    def __call__(self, img: Union[ImageType, np.ndarray])->float:
+    def __call__(self, img: Union[ImageType, np.ndarray]) -> float:
         """
         Args:
             img (Union[Image, np.ndarray]): Either a PIL image or numpy array with int8 values

--- a/tests/unit/app/test_log_rotation.py
+++ b/tests/unit/app/test_log_rotation.py
@@ -8,7 +8,6 @@ import shutil
 import datetime
 from freezegun import freeze_time
 
-from whylogs.app.config import load_config
 from whylogs.app.session import session_from_config, get_or_create_session
 from whylogs.app.config import SessionConfig, WriterConfig
 
@@ -24,7 +23,7 @@ def test_log_rotation_seconds(tmpdir):
         "project", "pipeline", writers=[writer_config])
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
         session = session_from_config(session_config)
-        with session.logger("test", with_rotation_time='s', cache=1) as logger:
+        with session.logger("test", with_rotation_time='s', cache_size=1) as logger:
             df = util.testing.makeDataFrame()
             logger.log_dataframe(df)
             frozen_time.tick(delta=datetime.timedelta(seconds=1))
@@ -53,7 +52,7 @@ def test_log_rotation_minutes(tmpdir):
         "project", "pipeline", writers=[writer_config])
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
         session = session_from_config(session_config)
-        with session.logger("test", with_rotation_time='m', cache=1) as logger:
+        with session.logger("test", with_rotation_time='m', cache_size=1) as logger:
             df = util.testing.makeDataFrame()
             logger.log_dataframe(df)
             frozen_time.tick(delta=datetime.timedelta(minutes=2))
@@ -82,7 +81,7 @@ def test_log_rotation_days(tmpdir):
         "project", "pipeline", writers=[writer_config])
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
         session = session_from_config(session_config)
-        with session.logger("test", with_rotation_time='d', cache=1) as logger:
+        with session.logger("test", with_rotation_time='d', cache_size=1) as logger:
             df = util.testing.makeDataFrame()
             logger.log_dataframe(df)
             frozen_time.tick(delta=datetime.timedelta(days=1))
@@ -111,7 +110,7 @@ def test_log_rotation_hour(tmpdir):
         "project", "pipeline", writers=[writer_config])
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
         session = session_from_config(session_config)
-        with session.logger("test", with_rotation_time='h', cache=1) as logger:
+        with session.logger("test", with_rotation_time='h', cache_size=1) as logger:
             df = util.testing.makeDataFrame()
             logger.log_dataframe(df)
             frozen_time.tick(delta=datetime.timedelta(hours=3))

--- a/tests/unit/app/test_logger_image.py
+++ b/tests/unit/app/test_logger_image.py
@@ -1,12 +1,6 @@
-import pytest
-import unittest
-from pandas import util
-
 import shutil
-from whylogs.app.config import load_config
-from whylogs.app.session import session_from_config, get_or_create_session
+from whylogs.app.session import session_from_config
 from whylogs.app.config import SessionConfig, WriterConfig
-from freezegun import freeze_time
 from PIL import Image
 
 
@@ -45,7 +39,7 @@ def test_log_pil_image(tmpdir, image_files):
 
     session = session_from_config(session_config)
 
-    with session.logger("image_pil_test", with_rotation_time="s", cache=1) as logger:
+    with session.logger("image_pil_test", with_rotation_time="s", cache_size=1) as logger:
 
         for image_file_path in image_files:
             img = Image.open(image_file_path)

--- a/tests/unit/app/test_segments.py
+++ b/tests/unit/app/test_segments.py
@@ -1,15 +1,14 @@
+import datetime
+import json
 import os
 import shutil
+
 import pytest
 from freezegun import freeze_time
 from pandas import util
-import datetime
-import json
-import hashlib
 
-from whylogs.app.config import load_config
-from whylogs.app.session import session_from_config, get_or_create_session
 from whylogs.app.config import SessionConfig, WriterConfig
+from whylogs.app.session import session_from_config
 
 
 def test_segments(df_lending_club, tmpdir):
@@ -23,7 +22,7 @@ def test_segments(df_lending_club, tmpdir):
         "project", "pipeline", writers=[writer_config])
     session = session_from_config(session_config)
     with session.logger("test", segments=[[{"key": "home_ownership", "value": "RENT"}], [
-                                          {"key": "home_ownership", "value": "MORTGAGE"}]], cache=1) as logger:
+                                          {"key": "home_ownership", "value": "MORTGAGE"}]], cache_size=1) as logger:
         logger.log_dataframe(df_lending_club)
         profile = logger.profile
         assert profile is None
@@ -51,7 +50,7 @@ def test_segments_keys(df_lending_club, tmpdir):
         "project", "pipeline", writers=[writer_config])
     session = session_from_config(session_config)
     with session.logger("test", segments=["emp_title", "home_ownership"],
-                        cache=1) as logger:
+                        cache_size=1) as logger:
         logger.log_dataframe(df_lending_club)
         profiles = logger.segmented_profiles
         assert len(profiles) == 47
@@ -69,7 +68,7 @@ def test_segments_single_key(df_lending_club, tmpdir):
         "project", "pipeline", writers=[writer_config])
     session = session_from_config(session_config)
     with session.logger("test", segments=["home_ownership"],
-                        cache=1) as logger:
+                        cache_size=1) as logger:
         logger.log_dataframe(df_lending_club)
         profiles = logger.segmented_profiles
         assert len(profiles) == 4
@@ -92,7 +91,7 @@ def test_segments_with_rotation(df_lending_club, tmpdir):
         "project", "pipeline", writers=[writer_config])
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
         session = session_from_config(session_config)
-        with session.logger("test", with_rotation_time='s', segments=["home_ownership"], profile_full_dataset=True, cache=1) as logger:
+        with session.logger("test", with_rotation_time='s', segments=["home_ownership"], profile_full_dataset=True, cache_size=1) as logger:
             logger.log_dataframe(df_lending_club)
             frozen_time.tick(delta=datetime.timedelta(seconds=1))
             logger.log_dataframe(df_lending_club)


### PR DESCRIPTION
* Move PIL imports into local import (#130)
* Rename cache to cache_size to reflect what it actually represents
* Add some minor documentation

Tested by importing whylogs in an environment without PIL