### PR TITLE
accept magnitude and units in with_rotation_time param

### DIFF
--- a/src/whylogs/app/logger.py
+++ b/src/whylogs/app/logger.py
@@ -169,13 +169,13 @@ class Logger:
             interval = 1 if m.group(1) == '' else int(m.group(1))
             if m.group(2) == 's':
                 self.suffix = "%Y-%m-%d_%H-%M-%S"
-            elif m.group(2)  == 'm':
+            elif m.group(2) == 'm':
                 interval *= 60  # one minute
                 self.suffix = "%Y-%m-%d_%H-%M"
-            elif m.group(2)  == 'h':
+            elif m.group(2) == 'h':
                 interval *= 60 * 60  # one hour
                 self.suffix = "%Y-%m-%d_%H"
-            elif m.group(2)  == 'd':
+            elif m.group(2) == 'd':
                 interval *= 60 * 60 * 24  # one day
                 self.suffix = "%Y-%m-%d"
             else:

--- a/src/whylogs/app/logger.py
+++ b/src/whylogs/app/logger.py
@@ -5,6 +5,7 @@ import datetime
 import hashlib
 import json
 import logging
+import re
 from typing import List, Optional, Dict, Union, Callable, AnyStr
 from typing.io import IO
 from pathlib import Path
@@ -17,8 +18,6 @@ from whylogs.core import DatasetProfile, TrackImage, METADATA_DEFAULT_ATTRIBUTES
 from whylogs.core.statistics.constraints import DatasetConstraints
 from whylogs.io import LocalDataset
 
-
-TIME_ROTATION_VALUES = ["s", "m", "h", "d"]
 
 # TODO upgrade to Classes
 SegmentTag = Dict[str, any]
@@ -38,10 +37,11 @@ class Logger:
     :param tags: Optional. Dictionary of key, value for aggregating data upstream
     :param metadata: Optional. Dictionary of key, value. Useful for debugging (associated with every single dataset profile)
     :param writers: Optional. List of Writer objects used to write out the data
-    :param with_rotation_time: Optional. Combined with `interval` to create new output logs at regular intervals, \
-            "s" for seconds, "m" for minutes, "h" for hours, "d" for days \
+    :param with_rotation_time: Optional. Log rotation interval, \
+            consisting of digits with unit specification, e.g. 30s, 2h, d.\
+            units are seconds ("s"), minutes ("m"), hours, ("h"), or days ("d") \
             Output filenames will have a suffix reflecting the rotation interval.
-    :param interval: Rotation interval multiplier, defaults to 1.
+    :param interval: Deprecated: Interval multiplier for `with_rotation_time`, defaults to 1.
     :param verbose: enable debug logging
     :param cache_size: dataprofiles to cache
     :param segments: define either a list of segment keys or a list of segments tags: [  {"key":<featurename>,"value": <featurevalue>},... ]
@@ -87,9 +87,8 @@ class Logger:
 
         self._profiles = []
         self._intialize_profiles(dataset_timestamp)
-        # intialize to seconds in the day
-        self.interval = interval
-        self.with_rotation_time = with_rotation_time
+        self.interval_multiplier = interval                     # deprecated, rotation interval multiplier
+        self.with_rotation_time = with_rotation_time            # rotation interval specification
         self._set_rotation(with_rotation_time)
 
     def __enter__(self):
@@ -163,24 +162,27 @@ class Logger:
         if with_rotation_time is not None:
             self.with_rotation_time = with_rotation_time.lower()
 
-            if self.with_rotation_time == 's':
-                interval = 1  # one second
+            m = re.match(r'^(\d*)([smhd])$', with_rotation_time.lower())
+            if m is None:
+                raise TypeError("Invalid rotation interval, expected integer followed by one of 's', 'm', 'h', or 'd'")
+
+            interval = 1 if m.group(1) == '' else int(m.group(1))
+            if m.group(2) == 's':
                 self.suffix = "%Y-%m-%d_%H-%M-%S"
-            elif self.with_rotation_time == 'm':
-                interval = 60  # one minute
+            elif m.group(2)  == 'm':
+                interval *= 60  # one minute
                 self.suffix = "%Y-%m-%d_%H-%M"
-            elif self.with_rotation_time == 'h':
-                interval = 60 * 60  # one hour
+            elif m.group(2)  == 'h':
+                interval *= 60 * 60  # one hour
                 self.suffix = "%Y-%m-%d_%H"
-            elif self.with_rotation_time == 'd':
-                interval = 60 * 60 * 24  # one day
+            elif m.group(2)  == 'd':
+                interval *= 60 * 60 * 24  # one day
                 self.suffix = "%Y-%m-%d"
             else:
-                raise TypeError("Invalid choice of rotation time, valid choices are {}".format(
-                    TIME_ROTATION_VALUES))
+                raise TypeError("Invalid rotation interval, expected integer followed by one of 's', 'm', 'h', or 'd'")
             # time in seconds
             current_time = int(datetime.datetime.utcnow().timestamp())
-            self.interval = interval * self.interval
+            self.interval = interval * self.interval_multiplier
             self.rotate_at = self.rotate_when(current_time)
 
     def rotate_when(self, time):

--- a/tests/unit/app/test_log_rotation.py
+++ b/tests/unit/app/test_log_rotation.py
@@ -4,12 +4,50 @@ from pandas import util
 
 import time
 import os
+import datetime
 import shutil
 import datetime
 from freezegun import freeze_time
 
 from whylogs.app.session import session_from_config, get_or_create_session
+from whylogs.app.logger import Logger
 from whylogs.app.config import SessionConfig, WriterConfig
+
+def test_log_rotation_parsing():
+    with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
+        l = Logger(session_id="", dataset_name="testing")
+        now = int(datetime.datetime.utcnow().timestamp())
+        l._set_rotation(with_rotation_time="s")
+        assert l.interval == 1
+        assert l.rotate_at == now+1
+        l._set_rotation(with_rotation_time="m")
+        assert l.interval == 60
+        assert l.rotate_at == (now+l.interval)
+        l._set_rotation(with_rotation_time="h")
+        assert l.interval == 60*60
+        assert l.rotate_at == (now+l.interval)
+        l._set_rotation(with_rotation_time="d")
+        assert l.interval == 24*60*60
+        assert l.rotate_at == now+l.interval
+        l._set_rotation(with_rotation_time="30s")
+        assert l.interval == 30
+        assert l.rotate_at == now+l.interval
+        l._set_rotation(with_rotation_time="10m")
+        assert l.interval == 10*60
+        assert l.rotate_at == now+l.interval
+        l._set_rotation(with_rotation_time="10h")
+        assert l.interval == 10*60*60
+        assert l.rotate_at == now+l.interval
+        l._set_rotation(with_rotation_time="2d")
+        assert l.interval == 2*24*60*60
+        assert l.rotate_at == now+l.interval
+        # make sure bogus specifications get flagged.
+        with pytest.raises(TypeError):
+            l._set_rotation(with_rotation_time="-2d")
+        with pytest.raises(TypeError):
+            l._set_rotation(with_rotation_time="2")
+        with pytest.raises(TypeError):
+            l._set_rotation(with_rotation_time="s2")
 
 
 def test_log_rotation_seconds(tmpdir):


### PR DESCRIPTION
Modified with_rotation_time param to allow optional magnitude.
Does not break any of existing unit tests around log rotation.
Added unit test to explicitly exercise interval parsing.

```
    :param with_rotation_time: Optional. Log rotation interval, \
            consisting of digits with unit specification, e.g. 30s, 2h, d.\
            units are seconds ("s"), minutes ("m"), hours, ("h"), or days ("d") \
            Output filenames will have a suffix reflecting the rotation interval.
```
