### PR TITLE
Move profile IO into background threads

### DIFF
--- a/src/whylogs/app/logger.py
+++ b/src/whylogs/app/logger.py
@@ -60,7 +60,7 @@ class Logger:
         dataset_name: str,
         dataset_timestamp: Optional[datetime.datetime] = None,
         session_timestamp: Optional[datetime.datetime] = None,
-        tags: Dict[str, str] = {},
+        tags: Dict[str, str] = None,
         metadata: Dict[str, str] = None,
         writers=List[Writer],
         verbose: bool = False,
@@ -72,6 +72,8 @@ class Logger:
         constraints: DatasetConstraints = None,
     ):
         """"""
+        if tags is None:
+            tags = {}
         self._active = True
 
         if session_timestamp is None:
@@ -247,16 +249,13 @@ class Logger:
 
         for writer in self.writers:
             # write full profile
-
             if self.full_profile_check():
-
                 if rotation_suffix is None:
                     writer.write(self._profiles[-1]["full_profile"])
                 else:
                     writer.write(self._profiles[-1]["full_profile"], rotation_suffix)
 
             if self.segments is not None:
-
                 for hashseg, each_seg_prof in self._profiles[-1]["segmented_profiles"].items():
                     seg_suffix = hashseg
                     full_suffix = "_" + seg_suffix

--- a/src/whylogs/app/session.py
+++ b/src/whylogs/app/session.py
@@ -337,6 +337,9 @@ class Session:
                     logger.close()
                 self.remove_logger(key)
 
+        for w in self.writers:
+            w.close()
+
         if self.use_whylabs_writer:
             from whylogs.whylabs_client.wrapper import end_session
 

--- a/src/whylogs/app/utils.py
+++ b/src/whylogs/app/utils.py
@@ -1,0 +1,52 @@
+import asyncio
+import atexit
+import logging
+import threading
+from functools import partial, wraps
+from typing import List
+
+_NO_ASYNC = "WHYLOGS_NO_ASYNC"
+
+_logger = logging.getLogger(__name__)
+
+_threads: List[threading.Thread] = []
+
+
+def _do_wrap(func):
+    @wraps(func)
+    async def run(*args, loop=None, executor=None, **kwargs):
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        pfunc = partial(func, *args, **kwargs)
+        return await loop.run_in_executor(executor, pfunc)
+
+    return run
+
+
+def async_wrap(func, *args, **kwargs):
+    """
+
+    Args:
+        func: the coroutine to run in an asyncio loop
+
+    Returns:
+        threading.Thread: an thread for the coroutine
+    """
+    thread = threading.Thread(target=func, args=args, kwargs=kwargs)
+    thread.start()
+
+    _threads.append(thread)
+    return thread
+
+
+@atexit.register
+def _wait_for_children():
+    """
+    Wait for the child process to complete. This is to ensure that we write out the log files before the parent
+    process finishes
+    """
+    for t in _threads:
+        try:
+            t.join()
+        except:  # noqa
+            _logger.exception("Failed to await task")

--- a/src/whylogs/app/writers.py
+++ b/src/whylogs/app/writers.py
@@ -5,8 +5,9 @@ import json
 import os
 import typing
 from abc import ABC, abstractmethod
+from logging import getLogger
 from string import Template
-from typing import List
+from typing import List, Optional
 
 from google.protobuf.message import Message
 from smart_open import open
@@ -23,9 +24,12 @@ from ..core.datasetprofile import (
 from ..util import time
 from ..util.protobuf import message_to_json
 from .config import WriterConfig
+from .utils import async_wrap
 
 DEFAULT_PATH_TEMPLATE = "$name/$session_id"
 DEFAULT_FILENAME_TEMPLATE = "dataset_profile"
+
+logger = getLogger(__name__)
 
 
 class Writer(ABC):
@@ -66,6 +70,7 @@ class Writer(ABC):
         self.path_template = Template(path_template)
         self.filename_template = Template(filename_template)
 
+        self._pending_threads = []
         self.formats = []
         if "all" in formats:
             for fmt in OutputFormat.__members__.values():
@@ -79,7 +84,11 @@ class Writer(ABC):
                     self.formats.append(fmt_)
 
         self.output_path = output_path
-        self.rotation_suffix = None
+
+    def close(self):
+        for t in self._pending_threads:
+            t.join()
+        self._pending_threads.clear()
 
     @abstractmethod
     def write(self, profile: DatasetProfile, rotation_suffix: str = None):
@@ -99,15 +108,15 @@ class Writer(ABC):
         path = self.path_template.substitute(**kwargs)
         return path
 
-    def file_name(self, profile: DatasetProfile, file_extension: str):
+    def file_name(self, profile: DatasetProfile, file_extension: str, rotation_suffix: Optional[str] = None):
         """
         For a given DatasetProfile, generate an output filename based on the
         templating defined in `self.filename_template`
         """
         kwargs = self.template_params(profile)
         file_name = self.filename_template.substitute(**kwargs)
-        if self.rotation_suffix is not None:
-            return file_name + self.rotation_suffix + file_extension
+        if rotation_suffix is not None:
+            return file_name + rotation_suffix + file_extension
         else:
             return file_name + file_extension
 
@@ -166,29 +175,31 @@ class LocalWriter(Writer):
             raise FileNotFoundError(f"Path does not exist: {output_path}")
         super().__init__(output_path, formats, path_template, filename_template)
 
-    def write(self, profile: DatasetProfile, rotation_suffix: str = None):
+    def write(self, profile: DatasetProfile, rotation_suffix: Optional[str] = None):
         """
         Write a dataset profile to disk
         """
-        self.rotation_suffix = rotation_suffix
+        t = async_wrap(self._do_write, profile, rotation_suffix)
+        self._pending_threads.append(t)
+
+    def _do_write(self, profile, rotation_suffix: Optional[str] = None):
         for fmt in self.formats:
             if fmt == OutputFormat.json:
-                self._write_json(profile)
+                self._write_json(profile, rotation_suffix)
             elif fmt == OutputFormat.flat:
-                self._write_flat(profile)
+                self._write_flat(profile, rotation_suffix=rotation_suffix)
             elif fmt == OutputFormat.protobuf:
-                self._write_protobuf(profile)
+                self._write_protobuf(profile, rotation_suffix)
             else:
                 raise ValueError(f"Unsupported format: {fmt}")
-        self.rotation_suffix = None
 
-    def _write_json(self, profile: DatasetProfile):
+    def _write_json(self, profile: DatasetProfile, rotation_suffix: Optional[str] = None):
         """
         Write a JSON summary of the dataset profile to disk
         """
         path = self.ensure_path(os.path.join(self.path_suffix(profile), "json"))
 
-        output_file = os.path.join(path, self.file_name(profile, ".json"))
+        output_file = os.path.join(path, self.file_name(profile, ".json", rotation_suffix))
 
         path = os.path.join(self.output_path, self.path_suffix(profile))
         os.makedirs(path, exist_ok=True)
@@ -198,7 +209,7 @@ class LocalWriter(Writer):
         with open(output_file, "wt") as f:
             f.write(message_to_json(summary))
 
-    def _write_flat(self, profile: DatasetProfile, indent: int = 4):
+    def _write_flat(self, profile: DatasetProfile, indent: int = 4, rotation_suffix: Optional[str] = None):
         """
         Write output data for flat format
 
@@ -215,25 +226,26 @@ class LocalWriter(Writer):
 
         flat_table_path = self.ensure_path(os.path.join(self.path_suffix(profile), "flat_table"))
         summary_df = get_dataset_frame(summary)
-        summary_df.to_csv(os.path.join(flat_table_path, self.file_name(profile, ".csv")), index=False)
+        summary_df.to_csv(os.path.join(flat_table_path, self.file_name(profile, ".csv", rotation_suffix)), index=False)
 
-        frequent_numbers_path = self.ensure_path(os.path.join(self.path_suffix(profile), "freq_numbers"))
+        _suffix = rotation_suffix or ""
+        frequent_numbers_path = self.ensure_path(os.path.join(self.path_suffix(profile), f"freq_numbers{_suffix}"))
         json_flat_file = self.file_name(profile, ".json")
         with open(os.path.join(frequent_numbers_path, json_flat_file), "wt") as f:
             hist = flatten_dataset_frequent_numbers(summary)
             json.dump(hist, f, indent=indent)
 
-        frequent_strings_path = self.ensure_path(os.path.join(self.path_suffix(profile), "frequent_strings"))
+        frequent_strings_path = self.ensure_path(os.path.join(self.path_suffix(profile), f"frequent_strings{_suffix}"))
         with open(os.path.join(frequent_strings_path, json_flat_file), "wt") as f:
             frequent_strings = flatten_dataset_frequent_strings(summary)
             json.dump(frequent_strings, f, indent=indent)
 
-        histogram_path = self.ensure_path(os.path.join(self.path_suffix(profile), "histogram"))
+        histogram_path = self.ensure_path(os.path.join(self.path_suffix(profile), f"histogram{_suffix}"))
         with open(os.path.join(histogram_path, json_flat_file), "wt") as f:
             histogram = flatten_dataset_histograms(summary)
             json.dump(histogram, f, indent=indent)
 
-    def _write_protobuf(self, profile: DatasetProfile):
+    def _write_protobuf(self, profile: DatasetProfile, rotation_suffix: Optional[str] = None):
         """
         Write a protobuf serialization of the DatasetProfile to disk
         """
@@ -241,7 +253,7 @@ class LocalWriter(Writer):
 
         protobuf: Message = profile.to_protobuf()
 
-        with open(os.path.join(path, self.file_name(profile, ".bin")), "wb") as f:
+        with open(os.path.join(path, self.file_name(profile, ".bin", rotation_suffix)), "wb") as f:
             f.write(protobuf.SerializeToString())
 
     def ensure_path(self, suffix: str, addition_part: typing.Optional[str] = None) -> str:
@@ -276,20 +288,21 @@ class S3Writer(Writer):
         """
         Write a dataset profile to S3
         """
-        self.rotation_suffix = rotation_suffix
+        t = async_wrap(self._do_write, profile, rotation_suffix)
+        self._pending_threads.append(t)
 
+    def _do_write(self, profile, rotation_suffix: str = None):
         for fmt in self.formats:
             if fmt == OutputFormat.json:
-                self._write_json(profile)
+                self._write_json(profile, rotation_suffix)
             elif fmt == OutputFormat.flat:
-                self._write_flat(profile)
+                self._write_flat(profile, rotation_suffix=rotation_suffix)
             elif fmt == OutputFormat.protobuf:
-                self._write_protobuf(profile)
+                self._write_protobuf(profile, rotation_suffix)
             else:
                 raise ValueError(f"Unsupported format: {fmt}")
-        self.rotation_suffix = None
 
-    def _write_json(self, profile: DatasetProfile):
+    def _write_json(self, profile: DatasetProfile, rotation_suffix: Optional[str] = None):
         """
         Write a dataset profile JSON summary to disk
         """
@@ -297,14 +310,14 @@ class S3Writer(Writer):
             self.output_path,
             self.path_suffix(profile),
             "json",
-            self.file_name(profile, ".json"),
+            self.file_name(profile, ".json", rotation_suffix),
         )
 
         summary = profile.to_summary()
         with open(output_file, "wt") as f:
             f.write(message_to_json(summary))
 
-    def _write_flat(self, profile: DatasetProfile, indent: int = 4):
+    def _write_flat(self, profile: DatasetProfile, indent: int = 4, rotation_suffix: Optional[str] = None):
         """
         Write output data for flat format
 
@@ -319,28 +332,29 @@ class S3Writer(Writer):
 
         flat_table_path = os.path.join(self.output_path, self.path_suffix(profile), "flat_table")
         summary_df = get_dataset_frame(summary)
-        with open(os.path.join(flat_table_path, self.file_name(profile, ".csv")), "wt") as f:
+        with open(os.path.join(flat_table_path, self.file_name(profile, ".csv", rotation_suffix)), "wt") as f:
             summary_df.to_csv(f, index=False)
 
         json_flat_file = self.file_name(profile, ".json")
+        _suffix = rotation_suffix or ""
 
-        frequent_numbers_path = os.path.join(self.output_path, self.path_suffix(profile), "freq_numbers")
+        frequent_numbers_path = os.path.join(self.output_path, self.path_suffix(profile), f"freq_numbers{_suffix}")
         with open(os.path.join(frequent_numbers_path, json_flat_file), "wt") as f:
             hist = flatten_dataset_histograms(summary)
             json.dump(hist, f, indent=indent)
 
-        frequent_strings_path = os.path.join(self.output_path, self.path_suffix(profile), "frequent_strings")
+        frequent_strings_path = os.path.join(self.output_path, self.path_suffix(profile), f"frequent_strings{_suffix}")
         with open(os.path.join(frequent_strings_path, json_flat_file), "wt") as f:
             frequent_strings = flatten_dataset_frequent_strings(summary)
             json.dump(frequent_strings, f, indent=indent)
 
-        histogram_path = os.path.join(self.output_path, self.path_suffix(profile), "histogram")
+        histogram_path = os.path.join(self.output_path, self.path_suffix(profile), f"histogram{_suffix}")
 
         with open(os.path.join(histogram_path, json_flat_file), "wt") as f:
             histogram = flatten_dataset_histograms(summary)
             json.dump(histogram, f, indent=indent)
 
-    def _write_protobuf(self, profile: DatasetProfile):
+    def _write_protobuf(self, profile: DatasetProfile, rotation_suffix: Optional[str] = None):
         """
         Write a datasetprofile protobuf serialization to S3
         """
@@ -348,7 +362,7 @@ class S3Writer(Writer):
 
         protobuf: Message = profile.to_protobuf()
 
-        with open(os.path.join(path, self.file_name(profile, ".bin")), "wb") as f:
+        with open(os.path.join(path, self.file_name(profile, ".bin", rotation_suffix)), "wb") as f:
             f.write(protobuf.SerializeToString())
 
 
@@ -357,11 +371,11 @@ class WhyLabsWriter(Writer):
         """
         Write a dataset profile to WhyLabs
         """
-        self.rotation_suffix = rotation_suffix
-        self._write_protobuf(profile)
-        self.rotation_suffix = None
+        t = async_wrap(self._write_protobuf, profile, rotation_suffix)
+        self._pending_threads.append(t)
 
-    def _write_protobuf(self, profile: DatasetProfile):
+    @staticmethod
+    def _write_protobuf(profile: DatasetProfile):
         """
         Write a protobuf profile to WhyLabs
         """

--- a/src/whylogs/whylabs_client/wrapper.py
+++ b/src/whylogs/whylabs_client/wrapper.py
@@ -37,6 +37,7 @@ def start_session() -> None:
 
 
 def upload_profile(dataset_profile: DatasetProfile) -> None:
+    dataset_timestamp = None
     try:
         client = _get_whylabs_client()
 
@@ -48,28 +49,26 @@ def upload_profile(dataset_profile: DatasetProfile) -> None:
         dataset_timestamp = int(dataset_timestamp.timestamp() * 1000)
 
         # TODO: stop shifting dataset timestamps once we update the merger
-        upload_response = client.create_dataset_profile_upload(_session_token, dataset_timestamp=dataset_timestamp - 24 * 60 * 60 * 1000)
+        shifted_timestamp = dataset_timestamp - 24 * 60 * 60 * 1000
+        upload_response = client.create_dataset_profile_upload(_session_token, dataset_timestamp=shifted_timestamp)
         upload_url = upload_response.get("upload_url")
 
         with open(profile_path, "rb") as f:
             requests.put(upload_url, f.read())
 
         _logger.debug(f"Uploaded a profile for timestamp {dataset_timestamp} to WhyLabs session {_session_token}")
-
-    except Exception:
+    except:  # noqa
         _logger.exception(f"Failed to upload profile for timestamp {dataset_timestamp}")
 
 
 def end_session() -> str:
+    global _session_token
     try:
-        global _session_token
         client = _get_whylabs_client()
         res = client.close_session(_session_token)
         _logger.debug(f"Closed session {_session_token}, returning the URL")
         return res.get("whylabs_url")
-
-    except Exception:
+    except:  # noqa
         _logger.exception(f"Failed to close session {_session_token}")
-
     finally:
         _session_token = None

--- a/tests/component/app/test_logger.py
+++ b/tests/component/app/test_logger.py
@@ -67,19 +67,18 @@ def test_log_dataframe(tmpdir, df_lending_club):
     WriterConfig.from_yaml(yaml_data)
 
     session_config = SessionConfig("project", "pipeline", writers=[writer_config])
-    session = session_from_config(session_config)
+    with session_from_config(session_config) as session:
+        with session.logger("lendingclub") as logger:
+            assert logger is not None
+            logger.log_dataframe(df_lending_club)
+            profile = logger.profile
+            assert profile is not None
 
-    with session.logger("lendingclub") as logger:
-        assert logger is not None
-        logger.log_dataframe(df_lending_club)
-        profile = logger.profile
-        assert profile is not None
+            summary = profile.flat_summary()
 
-        summary = profile.flat_summary()
+            flat_summary = summary["summary"]
 
-        flat_summary = summary["summary"]
-
-        assert len(flat_summary) == 151
+            assert len(flat_summary) == 151
 
     output_files = []
     for root, subdirs, files in os.walk(p):
@@ -89,11 +88,11 @@ def test_log_dataframe(tmpdir, df_lending_club):
 
 def test_log_csv(tmpdir):
     csv_path = os.path.join(script_dir, os.pardir, "lending_club_1000.csv")
-    session = get_or_create_session()
-    with session.logger("csvtest") as logger:
-        logger.log_csv(csv_path)
-        summary = logger.profile.flat_summary()
-        flat_summary = summary["summary"]
+    with get_or_create_session() as session:
+        with session.logger("csvtest") as logger:
+            logger.log_csv(csv_path)
+            summary = logger.profile.flat_summary()
+            flat_summary = summary["summary"]
 
         assert len(flat_summary) == 151
 
@@ -120,6 +119,7 @@ def test_log_multiple_calls(tmpdir, df_lending_club):
     for i in range(0, 5):
         with session.logger(dataset_timestamp=now + datetime.timedelta(days=i)) as logger:
             logger.log_dataframe(df_lending_club)
+    session.close()
 
     output_files = []
     for root, subdirs, files in os.walk(p):

--- a/tests/unit/app/test_log_rotation.py
+++ b/tests/unit/app/test_log_rotation.py
@@ -50,117 +50,117 @@ def test_log_rotation_parsing():
 
 def test_log_rotation_seconds(tmpdir):
     output_path = tmpdir.mkdir("whylogs")
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
     yaml_data = writer_config.to_yaml()
     WriterConfig.from_yaml(yaml_data)
 
     session_config = SessionConfig("project", "pipeline", writers=[writer_config])
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
-        session = session_from_config(session_config)
-        with session.logger("test", with_rotation_time="s", cache_size=1) as logger:
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
-            frozen_time.tick(delta=datetime.timedelta(seconds=1))
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
-            frozen_time.tick(delta=datetime.timedelta(seconds=1))
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
+        with session_from_config(session_config) as session:
+            with session.logger("test", with_rotation_time="s", cache_size=1) as logger:
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)
+                frozen_time.tick(delta=datetime.timedelta(seconds=1))
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)
+                frozen_time.tick(delta=datetime.timedelta(seconds=1))
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)
     output_files = []
     for root, subdirs, files in os.walk(output_path):
         output_files += files
     assert len(output_files) == 3
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
 
 
 def test_log_rotation_minutes(tmpdir):
     output_path = tmpdir.mkdir("whylogs")
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
     yaml_data = writer_config.to_yaml()
     WriterConfig.from_yaml(yaml_data)
 
     session_config = SessionConfig("project", "pipeline", writers=[writer_config])
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
-        session = session_from_config(session_config)
-        with session.logger("test", with_rotation_time="m", cache_size=1) as logger:
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
-            frozen_time.tick(delta=datetime.timedelta(minutes=2))
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
-            frozen_time.tick(delta=datetime.timedelta(minutes=2))
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
+        with session_from_config(session_config) as session:
+            with session.logger("test", with_rotation_time="m", cache_size=1) as logger:
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)
+                frozen_time.tick(delta=datetime.timedelta(minutes=2))
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)
+                frozen_time.tick(delta=datetime.timedelta(minutes=2))
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)
     output_files = []
     for root, subdirs, files in os.walk(output_path):
         output_files += files
     assert len(output_files) == 3
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
 
 
 def test_log_rotation_days(tmpdir):
     output_path = tmpdir.mkdir("whylogs")
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
     yaml_data = writer_config.to_yaml()
     WriterConfig.from_yaml(yaml_data)
 
     session_config = SessionConfig("project", "pipeline", writers=[writer_config])
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
-        session = session_from_config(session_config)
-        with session.logger("test", with_rotation_time="d", cache_size=1) as logger:
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
-            frozen_time.tick(delta=datetime.timedelta(days=1))
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
-            frozen_time.tick(delta=datetime.timedelta(days=2))
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
+        with session_from_config(session_config) as session:
+            with session.logger("test", with_rotation_time="d", cache_size=1) as logger:
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)
+                frozen_time.tick(delta=datetime.timedelta(days=1))
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)
+                frozen_time.tick(delta=datetime.timedelta(days=2))
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)
     output_files = []
     for root, subdirs, files in os.walk(output_path):
         output_files += files
     assert len(output_files) == 3
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
 
 
 def test_log_rotation_hour(tmpdir):
     output_path = tmpdir.mkdir("whylogs")
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
     yaml_data = writer_config.to_yaml()
     WriterConfig.from_yaml(yaml_data)
 
     session_config = SessionConfig("project", "pipeline", writers=[writer_config])
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
-        session = session_from_config(session_config)
-        with session.logger("test", with_rotation_time="h", cache_size=1) as logger:
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
-            frozen_time.tick(delta=datetime.timedelta(hours=3))
-            logger.log(feature_name="E", value=4)
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
+        with session_from_config(session_config) as session:
+            with session.logger("test", with_rotation_time="h", cache_size=1) as logger:
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)
+                frozen_time.tick(delta=datetime.timedelta(hours=3))
+                logger.log(feature_name="E", value=4)
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)
 
     output_files = []
     for root, subdirs, files in os.walk(output_path):
         output_files += files
     assert len(output_files) == 2
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
 
 
 def test_incorrect_rotation_time():
 
     with pytest.raises(TypeError):
-        session = get_or_create_session()
-        with session.logger("test2", with_rotation_time="W2") as logger:
-            df = util.testing.makeDataFrame()
-            logger.log_dataframe(df)
+        with get_or_create_session() as session:
+            with session.logger("test2", with_rotation_time="W2") as logger:
+                df = util.testing.makeDataFrame()
+                logger.log_dataframe(df)

--- a/tests/unit/app/test_logger_image.py
+++ b/tests/unit/app/test_logger_image.py
@@ -8,7 +8,7 @@ from whylogs.app.session import session_from_config
 
 def test_log_image(tmpdir, image_files):
     output_path = tmpdir.mkdir("whylogs")
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
     yaml_data = writer_config.to_yaml()
     WriterConfig.from_yaml(yaml_data)
@@ -25,12 +25,12 @@ def test_log_image(tmpdir, image_files):
         profile = logger.profile
         columns = profile.columns
         assert len(columns) == 19
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
 
 
 def test_log_pil_image(tmpdir, image_files):
     output_path = tmpdir.mkdir("whylogs")
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
     yaml_data = writer_config.to_yaml()
     WriterConfig.from_yaml(yaml_data)
@@ -48,4 +48,4 @@ def test_log_pil_image(tmpdir, image_files):
         profile = logger.profile
         columns = profile.columns
         assert len(columns) == 19
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)

--- a/tests/unit/app/test_logger_metrics.py
+++ b/tests/unit/app/test_logger_metrics.py
@@ -6,7 +6,7 @@ from whylogs.app.session import session_from_config
 
 def test_log_metrics(tmpdir):
     output_path = tmpdir.mkdir("whylogs")
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
     yaml_data = writer_config.to_yaml()
     WriterConfig.from_yaml(yaml_data)
@@ -20,7 +20,6 @@ def test_log_metrics(tmpdir):
     scores = [0.2, 0.5, 0.6]
     num_labels = 3
     with session.logger("metrics_test") as logger:
-
         logger.log_metrics(targets, predictions, scores)
 
         profile = logger.profile
@@ -28,4 +27,4 @@ def test_log_metrics(tmpdir):
 
         assert metrics_profile is not None
         assert len(metrics_profile.metrics.confusion_matrix.labels) == num_labels
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)

--- a/tests/unit/app/test_segments.py
+++ b/tests/unit/app/test_segments.py
@@ -13,37 +13,39 @@ from whylogs.app.session import session_from_config
 
 def test_segments(df_lending_club, tmpdir):
     output_path = tmpdir.mkdir("whylogs")
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
     yaml_data = writer_config.to_yaml()
     WriterConfig.from_yaml(yaml_data)
 
     session_config = SessionConfig("project", "pipeline", writers=[writer_config])
-    session = session_from_config(session_config)
-    with session.logger(
-        "test",
-        segments=[
-            [{"key": "home_ownership", "value": "RENT"}],
-            [{"key": "home_ownership", "value": "MORTGAGE"}],
-        ],
-        cache_size=1,
-    ) as logger:
-        logger.log_dataframe(df_lending_club)
-        profile = logger.profile
-        assert profile is None
-        profiles = logger.segmented_profiles
-        assert len(profiles) == 2
-        assert profiles[list(profiles.keys())[0]].tags["segment"] == json.dumps([{"key": "home_ownership", "value": "RENT"}])
-        assert profiles[list(profiles.keys())[1]].tags["segment"] == json.dumps([{"key": "home_ownership", "value": "MORTGAGE"}])
-        mortage_segment = logger.get_segment([{"key": "home_ownership", "value": "MORTGAGE"}])
-        check_segment = profiles[list(profiles.keys())[1]]
-        assert mortage_segment == check_segment
-    shutil.rmtree(output_path)
+    with session_from_config(session_config) as session:
+        with session.logger(
+            "test",
+            segments=[
+                [{"key": "home_ownership", "value": "RENT"}],
+                [{"key": "home_ownership", "value": "MORTGAGE"}],
+            ],
+            cache_size=1,
+        ) as logger:
+            logger.log_dataframe(df_lending_club)
+            profile = logger.profile
+            profiles = logger.segmented_profiles
+            mortage_segment = logger.get_segment([{"key": "home_ownership", "value": "MORTGAGE"}])
+
+    assert profile is None
+    assert len(profiles) == 2
+    assert profiles[list(profiles.keys())[0]].tags["segment"] == json.dumps([{"key": "home_ownership", "value": "RENT"}])
+    assert profiles[list(profiles.keys())[1]].tags["segment"] == json.dumps([{"key": "home_ownership", "value": "MORTGAGE"}])
+    check_segment = profiles[list(profiles.keys())[1]]
+    assert mortage_segment == check_segment
+
+    shutil.rmtree(output_path, ignore_errors=True)
 
 
 def test_segments_keys(df_lending_club, tmpdir):
     output_path = tmpdir.mkdir("whylogs")
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
     yaml_data = writer_config.to_yaml()
     WriterConfig.from_yaml(yaml_data)
@@ -54,12 +56,12 @@ def test_segments_keys(df_lending_club, tmpdir):
         logger.log_dataframe(df_lending_club)
         profiles = logger.segmented_profiles
         assert len(profiles) == 47
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
 
 
 def test_segments_single_key(df_lending_club, tmpdir):
     output_path = tmpdir.mkdir("whylogs")
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
     yaml_data = writer_config.to_yaml()
     WriterConfig.from_yaml(yaml_data)
@@ -75,12 +77,12 @@ def test_segments_single_key(df_lending_club, tmpdir):
         logger.log_dataframe(df_lending_club, segments=["home_ownership"])
         profiles = logger.segmented_profiles
         assert len(profiles) == 4
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
 
 
 def test_segments_with_rotation(df_lending_club, tmpdir):
     output_path = tmpdir.mkdir("whylogs")
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
     yaml_data = writer_config.to_yaml()
     WriterConfig.from_yaml(yaml_data)
@@ -107,4 +109,4 @@ def test_segments_with_rotation(df_lending_club, tmpdir):
     for root, subdirs, files in os.walk(output_path):
         output_files += files
     assert len(output_files) == 8
-    shutil.rmtree(output_path)
+    shutil.rmtree(output_path, ignore_errors=True)

--- a/tests/unit/app/test_writers.py
+++ b/tests/unit/app/test_writers.py
@@ -46,6 +46,7 @@ def test_s3_writer_bug(df_lending_club, moto_boto, s3_config_path):
 
     with session.logger("dataset_test_s3") as logger:
         logger.log_dataframe(df_lending_club)
+    session.close()
 
     client = boto3.client("s3")
     objects = client.list_objects(Bucket="mocked_bucket")
@@ -65,6 +66,7 @@ def test_s3_writer(df_lending_club, moto_boto, s3_all_config_path):
 
     with session.logger("dataset_test_s3") as logger:
         logger.log_dataframe(df_lending_club)
+    session.close()
 
     client = boto3.client("s3")
     objects = client.list_objects(Bucket="mocked_bucket")


### PR DESCRIPTION
Publish whylogs using background threads

This allows us to avoid blocking the main Python process when writing whylogs to disk.

 This is very important for latency sensitive applications such as
    real time model serving

 In addition, this change makes the Writer objects track these threads and wait for them
    when the session ends