### PR TITLE
Fix bug that omits generated protobuf sources from builds

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.5-dev1
+current_version = 0.4.5-dev3
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 

--- a/Makefile
+++ b/Makefile
@@ -33,27 +33,27 @@ help:
 
 bump-patch: ## Bump the patch version (_._.X) everywhere it appears in the project
 	@$(call i, Bumping the patch number)
-	bumpversion patch --allow-dirty
+	poetry run bumpversion patch --allow-dirty
 
 bump-minor: ## Bump the minor version (_.X._) everywhere it appears in the project
 	@$(call i, Bumping the minor number)
-	bumpversion patch --allow-dirty
+	poetry run bumpversion patch --allow-dirty
 
 bump-major: ## Bump the major version (X._._) everywhere it appears in the project
 	@$(call i, Bumping the major number)
-	bumpversion patch --allow-dirty
+	poetry run bumpversion patch --allow-dirty
 
 bump-release: ## Convert the version into a release variant (_._._) everywhere it appears in the project
 	@$(call i, Bumping the major number)
-	bumpversion release --allow-dirty
+	poetry run bumpversion release --allow-dirty
 
 bump-dev: ## Convert the version into a dev variant (_._._-dev__) everywhere it appears in the project
 	@$(call i, Bumping the major number)
-	bumpversion dev --allow-dirty
+	poetry run bumpversion dev --allow-dirty
 
 bump-build: ## Bump the build number (_._._-____XX) everywhere it appears in the project
 	@$(call i, Bumping the major number)
-	bumpversion build --allow-dirty
+	poetry run bumpversion build --allow-dirty
 
 publish: clean dist ## Clean the project, generate new distribution files and publish them to pypi
 	@$(call i, Publishing the currently built dist to pypi)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ src.python.pyc := $(shell find ./src -type f -name "*.pyc")
 src.proto.dir := ./proto/src
 src.proto := $(shell find $(src.proto.dir) -type f -name "*.proto")
 
-version := 0.4.5-dev1
+version := 0.4.5-dev3
 
 dist.dir := dist
 egg.dir := .eggs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,7 @@ copyright = "2020, WhyLabs, Inc"
 # built documents.
 #
 # The short X.Y version.
-version = "0.4.5-dev1"
+version = "0.4.5-dev3"
 # The full version, including alpha/beta/rc tags.
 release = ""  # Is set by calling `setup.py docs`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [tool.poetry]
 name = "whylogs"
-version = "0.4.5-dev1"
+version = "0.4.5-dev3"
 description = "Profile and monitor your ML data pipeline end-to-end"
 authors = ["WhyLabs.ai <support@whylabs.ai>"]
 license = "Apache-2.0"
+include = ["src/whylogs/proto/*.py"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: Apple Public Source License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,14 @@ version = "0.4.5-dev3"
 description = "Profile and monitor your ML data pipeline end-to-end"
 authors = ["WhyLabs.ai <support@whylabs.ai>"]
 license = "Apache-2.0"
-include = ["src/whylogs/proto/*.py"]
+include = [
+  "src/whylogs/proto/*.py",
+  "README.md",
+  "CHANGELOG.rst",
+  "CODE_OF_CONDUCT.md",
+  "DEVELOPMENT.md"
+]
+
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: Apple Public Source License",

--- a/src/whylogs/_version.py
+++ b/src/whylogs/_version.py
@@ -1,3 +1,3 @@
 """WhyLabs version number."""
 
-__version__ = "0.4.5-dev1"
+__version__ = "0.4.5-dev3"


### PR DESCRIPTION
For some reason, poetry wasn't including the generated protobuf sources
in the wheel or the source tarballs. I couldn't find anything that was
excluding them so I ended up explicitly including them in the
pyproject.toml and that fixes the issue. 
