### PR TITLE
Fix README in pypi

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.5
+current_version = 0.4.7-dev0
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ src.python.pyc := $(shell find ./src -type f -name "*.pyc")
 src.proto.dir := ./proto/src
 src.proto := $(shell find $(src.proto.dir) -type f -name "*.proto")
 
-version := 0.4.5
+version := 0.4.7-dev0
 
 dist.dir := dist
 egg.dir := .eggs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,7 @@ copyright = "2020, WhyLabs, Inc"
 # built documents.
 #
 # The short X.Y version.
-version = "0.4.5"
+version = "0.4.7-dev0"
 # The full version, including alpha/beta/rc tags.
 release = ""  # Is set by calling `setup.py docs`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "whylogs"
-version = "0.4.5"
+version = "0.4.7-dev0"
 description = "Profile and monitor your ML data pipeline end-to-end"
 authors = ["WhyLabs.ai <support@whylabs.ai>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,10 @@ include = [
   "CODE_OF_CONDUCT.md",
   "DEVELOPMENT.md"
 ]
-
+readme = "README.md"
+repository = "https://github.com/whylabs/whylogs"
+homepage = "https://docs.whylabs.ai"
+keywords = ["machine learning", "data profiling", "data quality", "data logging"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: Apple Public Source License",

--- a/src/whylogs/_version.py
+++ b/src/whylogs/_version.py
@@ -1,3 +1,3 @@
 """WhyLabs version number."""
 
-__version__ = "0.4.5"
+__version__ = "0.4.7-dev0"


### PR DESCRIPTION
The images are broken so we'll need to figure out a solution long term.

https://github.com/pypa/warehouse/issues/5246

```
PyPI does not support rendering from the package path itself, as it is not an image host.
```

We'll need to host link images from GitHub

Already published the dev version here: https://pypi.org/project/whylogs/0.4.7.dev0/