### PR TITLE
bugfix: Handle non-string labels when serializing confusion matrix

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,7 @@ exclude =
     docs
     src/whylogs/proto
     tests
+    .venv
 max-line-length = 160
 extend-ignore = E203, W503
 max-complexity = 20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.isort]
 profile = "black"
 multi_line_output = 3
-skip = ["src/whylogs/proto/"]
+skip = ["src/whylogs/proto/", ".venv"]
 
 [tool.black]
 line-length = 160

--- a/src/whylogs/core/metrics/confusion_matrix.py
+++ b/src/whylogs/core/metrics/confusion_matrix.py
@@ -121,7 +121,7 @@ class ConfusionMatrix:
             TYPE: Description
         """
         return ScoreMatrixMessage(
-            labels=self.labels,
+            labels=[str(i) for i in self.labels],
             prediction_field=self.prediction_field,
             target_field=self.target_field,
             score_field=self.score_field,

--- a/tests/unit/app/test_logger_metrics.py
+++ b/tests/unit/app/test_logger_metrics.py
@@ -28,3 +28,53 @@ def test_log_metrics(tmpdir):
         assert metrics_profile is not None
         assert len(metrics_profile.metrics.confusion_matrix.labels) == num_labels
     shutil.rmtree(output_path, ignore_errors=True)
+
+
+def test_log_metrics_with_numerical_labels(tmpdir):
+    output_path = tmpdir.mkdir("whylogs")
+    shutil.rmtree(output_path, ignore_errors=True)
+    writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
+    yaml_data = writer_config.to_yaml()
+    WriterConfig.from_yaml(yaml_data)
+
+    session_config = SessionConfig("project", "pipeline", writers=[writer_config])
+
+    session = session_from_config(session_config)
+    targets = [1.0, 2.0, 3.0]
+
+    predictions = [1.0, 2.0, 3.0]
+    scores = [0.2, 0.5, 0.6]
+    with session.logger("metrics_test") as logger:
+        logger.log_metrics(targets, predictions, scores)
+
+        profile = logger.profile
+        metrics_profile = profile.model_profile
+
+        assert metrics_profile is not None
+        assert len(metrics_profile.metrics.confusion_matrix.labels) == 3
+    shutil.rmtree(output_path, ignore_errors=True)
+
+
+def test_log_metrics_with_boolean_labels(tmpdir):
+    output_path = tmpdir.mkdir("whylogs")
+    shutil.rmtree(output_path, ignore_errors=True)
+    writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
+    yaml_data = writer_config.to_yaml()
+    WriterConfig.from_yaml(yaml_data)
+
+    session_config = SessionConfig("project", "pipeline", writers=[writer_config])
+
+    session = session_from_config(session_config)
+    targets = [True, False, True]
+
+    predictions = [False, True, False]
+    scores = [0.2, 0.5, 0.6]
+    with session.logger("metrics_test") as logger:
+        logger.log_metrics(targets, predictions, scores)
+
+        profile = logger.profile
+        metrics_profile = profile.model_profile
+
+        assert metrics_profile is not None
+        assert len(metrics_profile.metrics.confusion_matrix.labels) == 2
+    shutil.rmtree(output_path, ignore_errors=True)

--- a/tests/unit/app/test_segments.py
+++ b/tests/unit/app/test_segments.py
@@ -3,10 +3,10 @@ import json
 import os
 import shutil
 
+import pandas as pd
 import pytest
 from freezegun import freeze_time
 from pandas import util
-import pandas as pd
 
 from whylogs.app.config import SessionConfig, WriterConfig
 from whylogs.app.session import session_from_config
@@ -22,12 +22,12 @@ def test_segments(df_lending_club, tmpdir):
     session_config = SessionConfig("project", "pipeline", writers=[writer_config])
     with session_from_config(session_config) as session:
         with session.logger(
-                "test",
-                segments=[
-                    [{"key": "home_ownership", "value": "RENT"}],
-                    [{"key": "home_ownership", "value": "MORTGAGE"}],
-                ],
-                cache_size=1,
+            "test",
+            segments=[
+                [{"key": "home_ownership", "value": "RENT"}],
+                [{"key": "home_ownership", "value": "MORTGAGE"}],
+            ],
+            cache_size=1,
         ) as logger:
             logger.log_dataframe(df_lending_club)
             profile = logger.profile
@@ -36,10 +36,8 @@ def test_segments(df_lending_club, tmpdir):
 
     assert profile is None
     assert len(profiles) == 2
-    assert profiles[list(profiles.keys())[0]].tags["segment"] == json.dumps(
-        [{"key": "home_ownership", "value": "RENT"}])
-    assert profiles[list(profiles.keys())[1]].tags["segment"] == json.dumps(
-        [{"key": "home_ownership", "value": "MORTGAGE"}])
+    assert profiles[list(profiles.keys())[0]].tags["segment"] == json.dumps([{"key": "home_ownership", "value": "RENT"}])
+    assert profiles[list(profiles.keys())[1]].tags["segment"] == json.dumps([{"key": "home_ownership", "value": "MORTGAGE"}])
     check_segment = profiles[list(profiles.keys())[1]]
     assert mortage_segment == check_segment
 
@@ -95,11 +93,11 @@ def test_segments_with_rotation(df_lending_club, tmpdir):
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
         session = session_from_config(session_config)
         with session.logger(
-                "test",
-                with_rotation_time="s",
-                segments=["home_ownership"],
-                profile_full_dataset=True,
-                cache_size=1,
+            "test",
+            with_rotation_time="s",
+            segments=["home_ownership"],
+            profile_full_dataset=True,
+            cache_size=1,
         ) as logger:
             logger.log_dataframe(df_lending_club)
             frozen_time.tick(delta=datetime.timedelta(seconds=1))
@@ -128,8 +126,7 @@ def test_one_segment(tmpdir, image_files):
 
     session = session_from_config(session_config)
 
-    df = pd.DataFrame(data={'x': [1], 'y': [4],
-                            'z': [0.1]})
+    df = pd.DataFrame(data={"x": [1], "y": [4], "z": [0.1]})
     with session.logger("segment_test", segments=["x", "y"]) as logger:
         logger.log_segments(df)
         assert len(logger.segmented_profiles) == 1
@@ -146,8 +143,7 @@ def test_log_multiple_segments(tmpdir, image_files):
 
     session = session_from_config(session_config)
 
-    df = pd.DataFrame(data={'x': [1, 2, 3, 1, 2, 3, 1, 2, 3], 'y': [4, 5, 6, 5, 6, 4, 6, 4, 5],
-                            'z': [0.1, 0.2, 0.3, 0.1, 0.2, 0.3, 0.1, 0.2, 0.3]})
+    df = pd.DataFrame(data={"x": [1, 2, 3, 1, 2, 3, 1, 2, 3], "y": [4, 5, 6, 5, 6, 4, 6, 4, 5], "z": [0.1, 0.2, 0.3, 0.1, 0.2, 0.3, 0.1, 0.2, 0.3]})
     with session.logger("image_test", segments=["x", "y"]) as logger:
         logger.log_segments(df)
         assert len(logger.segmented_profiles) == 9


### PR DESCRIPTION
## Description

Address this issue:

```
  File "/Users/user/.pyenv/versions/monitor/lib/python3.7/site-packages/whylogs/core/model_profile.py", line 114, in to_protobuf
    return ModelProfileMessage(output_fields=self.output_fields, metrics=self.metrics.to_protobuf())
  File "/Users/user/.pyenv/versions/monitor/lib/python3.7/site-packages/whylogs/core/metrics/model_metrics.py", line 47, in to_protobuf
    scoreMatrix=self.confusion_matrix.to_protobuf() if self.confusion_matrix else None,
  File "/Users/user/.pyenv/versions/monitor/lib/python3.7/site-packages/whylogs/core/metrics/confusion_matrix.py", line 128, in to_protobuf
    scores=[nt.to_protobuf() if nt else NumberTracker.to_protobuf(NumberTracker()) for nt in np.ravel(self.confusion_matrix)],
TypeError: 0 has type int, but expected one of: bytes, unicode
```

Also, add unit test

### General Checklist

* [x] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [x] (optional) Please add a label to your PR

    