### PR TITLE
Remove default metadata writer

### DIFF
--- a/src/whylogs/app/config.py
+++ b/src/whylogs/app/config.py
@@ -211,7 +211,7 @@ class SessionConfig:
         project: str,
         pipeline: str,
         writers: List[WriterConfig],
-        metadata: Optional[MetadataConfig] = False,
+        metadata: Optional[MetadataConfig] = None,
         verbose: bool = False,
         with_rotation_time: str = None,
         cache_size: int = 1,
@@ -221,8 +221,6 @@ class SessionConfig:
         self.pipeline = pipeline
         self.verbose = verbose
         self.writers = writers
-        if not metadata:
-            metadata = MetadataConfig(type="local", output_path="output", input_path="")
         self.metadata = metadata
         self.with_rotation_time = with_rotation_time
         self.cache_size = cache_size

--- a/src/whylogs/app/session.py
+++ b/src/whylogs/app/session.py
@@ -84,7 +84,7 @@ class Session:
         project: str,
         pipeline: str,
         writers: List[Writer],
-        metadata_writer: MetadataWriter,
+        metadata_writer: Optional[MetadataWriter] = None,
         verbose: bool = False,
         with_rotation_time: str = None,
         cache_size: int = None,
@@ -414,7 +414,9 @@ def session_from_config(config: SessionConfig) -> Session:
     Construct a whylogs session from a `SessionConfig`
     """
     writers = list(map(lambda x: writer_from_config(x), config.writers))
-    metadata_writer = metadata_from_config(config.metadata)
+    metadata_writer = None
+    if config.metadata:
+        metadata_writer = metadata_from_config(config.metadata)
     return Session(
         config.project,
         config.pipeline,


### PR DESCRIPTION
## Description

While metadata writer config was not required, a default one was being generated. We removed default local metadata writer. 
### General Checklist

* [x] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [x] Documentation updated
* [x] (optional) Please add a label to your PR

    