### PR TITLE
Read prediction and target field names from regression metric protobuf

### DIFF
--- a/src/whylogs/core/metrics/regression_metrics.py
+++ b/src/whylogs/core/metrics/regression_metrics.py
@@ -118,7 +118,7 @@ class RegressionMetrics:
         if message.ByteSize() == 0:
             return None
 
-        reg_met = RegressionMetrics()
+        reg_met = RegressionMetrics(message.prediction_field, message.target_field)
         reg_met.count = message.count
         reg_met.sum_abs_diff = message.sum_abs_diff
         reg_met.sum_diff = message.sum_diff

--- a/tests/unit/core/metrics/test_model_metrics.py
+++ b/tests/unit/core/metrics/test_model_metrics.py
@@ -61,15 +61,35 @@ def tests_no_metrics_to_protobuf_regression():
     assert model_metrics.model_type == ModelType.REGRESSION
 
 
+def regression_metrics_eq(self, other):
+    # test for object attribute equality - only used for tests,
+    # defining __eq__ also renders object unhashable.
+    # so might be necessary to define __hash__ to behave sanely in dicts and sets,
+    if not isinstance(other, RegressionMetrics) or not isinstance(self, RegressionMetrics):
+        # don't attempt to compare against unrelated types
+        return NotImplemented
+
+    return (
+        self.prediction_field == other.prediction_field
+        and self.target_field == other.target_field
+        and self.count == other.count
+        and self.sum_abs_diff == other.sum_abs_diff
+        and self.sum_diff == other.sum_diff
+        and self.sum2_diff == other.sum2_diff
+    )
+
+
 def tests_model_metrics_to_protobuf_regression():
     regression_model = ModelMetrics(model_type=ModelType.REGRESSION)
 
     targets_1 = [0.1, 0.3, 0.4]
     predictions_1 = [0.5, 0.5, 0.5]
-    regression_model.compute_regression_metrics(predictions_1, targets_1)
+    regression_model.compute_regression_metrics(predictions=predictions_1, targets=targets_1, target_field="target", prediction_field="prediction")
+
     regression_message = regression_model.to_protobuf()
     model_metrics_from_message = ModelMetrics.from_protobuf(regression_message)
     assert model_metrics_from_message.model_type == ModelType.REGRESSION
+    assert regression_metrics_eq(model_metrics_from_message.regression_metrics, regression_model.regression_metrics)
 
 
 def test_merge_none():


### PR DESCRIPTION
## Description

- Read prediction and target field name from regression metric protobuf.  
- Enhance unit test to validate that all fields of regression metrics can correctly transition protobuf round-trip.

Without this fix, whylogs-java cannot read regression metrics written by whylogs-python.

### General Checklist

* [X ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    