### PR TITLE
change .utcnow() to .now(datetime.timezone.utc) to fix UTC timestamps

### DIFF
--- a/scripts/profiler.py
+++ b/scripts/profiler.py
@@ -187,7 +187,7 @@ def run(
     )
     profiles = {}
     for record in reader:
-        dt = record.get(datetime_col, datetime.utcnow())
+        dt = record.get(datetime_col, datetime.now(datetime.timezone.utc))
         assert isinstance(dt, datetime)
         dt_str = dt.strftime(OUTPUT_DATE_FORMAT)
         try:

--- a/src/whylogs/app/logger.py
+++ b/src/whylogs/app/logger.py
@@ -235,7 +235,6 @@ class Logger:
         rotate with time add a suffix
         """
         current_time = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
-        print("time in logger: ", current_time)
         # get the time that this current logging rotation started
         sequence_start = self.rotate_at - self.interval
         time_tuple = datetime.datetime.fromtimestamp(sequence_start)

--- a/src/whylogs/app/logger.py
+++ b/src/whylogs/app/logger.py
@@ -213,7 +213,7 @@ class Logger:
         else:
             raise TypeError("Invalid rotation interval, expected integer followed by one of 's', 'm', 'h', or 'd'")
         # time in seconds
-        current_time = int(datetime.datetime.utcnow().timestamp())
+        current_time = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
         self.interval = interval * self.interval_multiplier
         self.rotate_at = self.rotate_when(current_time)
 
@@ -227,14 +227,15 @@ class Logger:
         if self.with_rotation_time is None:
             return False
 
-        current_time = int(datetime.datetime.utcnow().timestamp())
+        current_time = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
         return current_time >= self.rotate_at
 
     def _rotate_time(self):
         """
         rotate with time add a suffix
         """
-        current_time = int(datetime.datetime.utcnow().timestamp())
+        current_time = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        print("time in logger: ", current_time)
         # get the time that this current logging rotation started
         sequence_start = self.rotate_at - self.interval
         time_tuple = datetime.datetime.fromtimestamp(sequence_start)

--- a/src/whylogs/core/datasetprofile.py
+++ b/src/whylogs/core/datasetprofile.py
@@ -722,7 +722,7 @@ def dataframe_profile(df: pd.DataFrame, name: str = None, timestamp: datetime.da
     if name is None:
         name = "dataset"
     if timestamp is None:
-        timestamp = datetime.datetime.utcnow()
+        timestamp = datetime.datetime.now(datetime.timezone.utc)
     elif not isinstance(timestamp, datetime.datetime):
         # Assume UTC epoch seconds
         timestamp = datetime.datetime.utcfromtimestamp(float(timestamp))
@@ -758,7 +758,7 @@ def array_profile(
     if name is None:
         name = "dataset"
     if timestamp is None:
-        timestamp = datetime.datetime.utcnow()
+        timestamp = datetime.datetime.now(datetime.timezone.utc)
     prof = DatasetProfile(name, timestamp)
     prof.track_array(x, columns)
     return prof

--- a/src/whylogs/mlflow/model_wrapper.py
+++ b/src/whylogs/mlflow/model_wrapper.py
@@ -19,7 +19,7 @@ class ModelWrapper(object):
         self.model = model
         self.session = whylogs.get_or_create_session("/opt/ml/model/" + WHYLOGS_YML)
         self.ylog = self.create_logger()
-        self.last_upload_time = datetime.datetime.utcnow()
+        self.last_upload_time = datetime.datetime.now(datetime.timezone.utc)
         atexit.register(self.ylog.close)
 
     def create_logger(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def profile_lending_club():
     import datetime
     from uuid import uuid4
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     session_id = uuid4().hex
     df = pd.read_csv(os.path.join(_MY_DIR, os.pardir, "testdata", "lending_club_1000.csv"))
     profile = DatasetProfile(name="test", session_id=session_id, session_timestamp=now)

--- a/tests/unit/app/test_log_rotation.py
+++ b/tests/unit/app/test_log_rotation.py
@@ -27,7 +27,7 @@ def test_no_log_rotation(tmpdir):
 def test_log_rotation_parsing():
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
         l = Logger(session_id="", dataset_name="testing")
-        now = int(datetime.datetime.utcnow().timestamp())
+        now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
         l._set_rotation(with_rotation_time="s")
         assert l.interval == 1
         assert l.rotate_at == now + 1

--- a/tests/unit/core/statistics/test_hllsketch.py
+++ b/tests/unit/core/statistics/test_hllsketch.py
@@ -75,7 +75,7 @@ def test_datetime_tracking():
         datetime(2020, 2, 3),
         datetime(2020, 2, 3, tzinfo=pytz.UTC),
         datetime(2020, 2, 3, 21, 28, 31),
-        datetime.utcnow(),
+        datetime.now(datetime.timezone.utc),
     ]
     for v in vals:
         hll.update(v)

--- a/tests/unit/core/statistics/test_hllsketch.py
+++ b/tests/unit/core/statistics/test_hllsketch.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import datetime
 from enum import Enum
 
 import pytest
@@ -71,11 +71,11 @@ def test_protobuf_then_merge():
 def test_datetime_tracking():
     hll = hllsketch.HllSketch()
     vals = [
-        datetime(2020, 2, 3),
-        datetime(2020, 2, 3),
-        datetime(2020, 2, 3, tzinfo=pytz.UTC),
-        datetime(2020, 2, 3, 21, 28, 31),
-        datetime.now(datetime.timezone.utc),
+        datetime.datetime(2020, 2, 3),
+        datetime.datetime(2020, 2, 3),
+        datetime.datetime(2020, 2, 3, tzinfo=pytz.UTC),
+        datetime.datetime(2020, 2, 3, 21, 28, 31),
+        datetime.datetime.now(datetime.timezone.utc),
     ]
     for v in vals:
         hll.update(v)

--- a/tests/unit/core/test_annotation_profiling.py
+++ b/tests/unit/core/test_annotation_profiling.py
@@ -19,7 +19,7 @@ TEST_DATA_PATH = os.path.abspath(
 
 def test_track_bb_annotation():
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     shared_session_id = uuid4().hex
 
     test_annotation_path = os.path.join(TEST_DATA_PATH, "files", "yolo_bounding_box.jsonl")
@@ -51,7 +51,7 @@ def test_track_bb_annotation():
 
 def test_track_json_annotation():
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     shared_session_id = uuid4().hex
     len(BB_ATTRIBUTES)
 

--- a/tests/unit/core/test_datasetprofile.py
+++ b/tests/unit/core/test_datasetprofile.py
@@ -31,7 +31,7 @@ def test_all_zeros_returns_summary_with_stats():
 
 
 def test_empty_valid_datasetprofiles_empty():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     shared_session_id = uuid4().hex
     x1 = DatasetProfile(
         name="test",
@@ -56,7 +56,7 @@ def test_empty_valid_datasetprofiles_empty():
 
 
 def test_merge_different_columns():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     shared_session_id = uuid4().hex
     x1 = DatasetProfile(
         name="test",
@@ -88,7 +88,7 @@ def test_merge_different_columns():
 
 
 def test_merge_lhs_no_profile():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     shared_session_id = uuid4().hex
     x1 = DatasetProfile(
         name="test",
@@ -115,7 +115,7 @@ def test_merge_lhs_no_profile():
 
 
 def test_merge_rhs_no_profile():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     shared_session_id = uuid4().hex
     x1 = DatasetProfile(
         name="test",
@@ -142,7 +142,7 @@ def test_merge_rhs_no_profile():
 
 
 def test_merge_same_columns():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     shared_session_id = uuid4().hex
     x1 = DatasetProfile(
         name="test",
@@ -172,7 +172,7 @@ def test_merge_same_columns():
 
 
 def test_protobuf_round_trip():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     tags = {"k1": "rock", "k2": "scissors", "k3": "paper"}
     original = DatasetProfile(
         name="test",
@@ -198,7 +198,7 @@ def test_protobuf_round_trip():
 
 
 def test_non_string_tag_raises_assert_error():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     tags = {"key": "value"}
     x = DatasetProfile("test", now, tags=tags)
     x.validate()
@@ -213,7 +213,7 @@ def test_non_string_tag_raises_assert_error():
 
 
 def test_mismatched_tags_raises_assertion_error():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     x1 = DatasetProfile("test", now, tags={"key": "foo"})
     x2 = DatasetProfile("test", now, tags={"key": "bar"})
     try:
@@ -224,7 +224,7 @@ def test_mismatched_tags_raises_assertion_error():
 
 
 def test_mismatched_tags_merge_succeeds():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     x1 = DatasetProfile("test", now, tags={"key": "foo"})
     x2 = DatasetProfile("test2", now, tags={"key": "bar"})
 
@@ -265,7 +265,7 @@ def test_parse_delimited_from_java_multiple():
 
 
 def test_write_delimited_single():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     original = DatasetProfile(
         name="test",
@@ -287,7 +287,7 @@ def test_write_delimited_single():
 
 
 def test_write_delimited_multiple():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     original = DatasetProfile(
         name="test",
@@ -360,7 +360,7 @@ def test_dataframe_profile():
 
 
 def test_track():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     original = DatasetProfile(
         name="test",
@@ -378,7 +378,7 @@ def test_track():
 
 
 def test_errors():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     original = DatasetProfile(
         name="test",
@@ -392,7 +392,7 @@ def test_errors():
 
 
 def test_flat_summary():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     original = DatasetProfile(
         name="test",
@@ -407,7 +407,7 @@ def test_flat_summary():
 
 
 def test_chunk_iterator():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     original = DatasetProfile(
         name="test",
@@ -427,7 +427,7 @@ def test_chunk_iterator():
 
 
 def test_array():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     original = DatasetProfile(
         name="test",

--- a/tests/unit/core/test_image_profiling.py
+++ b/tests/unit/core/test_image_profiling.py
@@ -20,7 +20,7 @@ TEST_DATA_PATH = os.path.abspath(
 
 
 def test_track_image():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     shared_session_id = uuid4().hex
     num_image_features = len(_IMAGE_FEATURES)
     num_metadata_features = len(_METADATA_DEFAULT_ATTRIBUTES)
@@ -50,7 +50,7 @@ def test_track_image():
 
 
 def test_track_PIL_img():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     shared_session_id = uuid4().hex
     num_image_features = len(_IMAGE_FEATURES)
     num_metadata_features = len(_METADATA_DEFAULT_ATTRIBUTES)

--- a/tests/unit/viz/test_viz.py
+++ b/tests/unit/viz/test_viz.py
@@ -6,7 +6,7 @@ from whylogs.viz import ProfileVisualizer
 
 
 def test_viz():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     session_id = uuid4().hex
     x1 = DatasetProfile(
         name="test",
@@ -70,7 +70,7 @@ def test_viz_token_length(profile_lending_club):
 
 def test_viz_char_pos(profile_lending_club):
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     profile_lending_club.dataset_timestamp = now
     viz = ProfileVisualizer()
     viz.set_profiles([profile_lending_club])


### PR DESCRIPTION
## Description

Update all calls to `utcnow` to use the timezone-aware `now(datetime.timezone.utc)`

### General Checklist

* [x] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [x] Documentation updated
* [x] (optional) Please add a label to your PR

    