### PR TITLE
Fix model metric model_type switching and update tests

### DIFF
--- a/examples/Logging.ipynb
+++ b/examples/Logging.ipynb
@@ -3,16 +3,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import os.path\n",
     "import pandas as pd"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "In this notebook, we will explore how to generate logs using the whylogs Python library. \n",
     "\n",
@@ -23,147 +22,149 @@
     "To generate logs using Python, we will import the whylogs library, initialize a logging session with whylogs, read in our raw data from file, and pass this data to our session.\n",
     "\n",
     "First, import the relevant session and logger functions."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "from whylogs import get_or_create_session"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "session = get_or_create_session()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "We will now download an example dataset from Lending Club, an online financial lending platform. The dataset is located in the package's `notebooks/` folder for now.\n",
     "\n",
     "Feel free to use the below cell to orient yourself and guide `data_file` to the correct filepath."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "print(\"Current working directory:\", os.getcwd())"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "source": [],
    "outputs": [],
-   "source": []
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
    "source": [
     "data_file = \"data/lending_club_1000.csv\""
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "scrolled": true
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
    "source": [
     "data = pd.read_csv(os.path.join(data_file))\n",
     "data"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "scrolled": true
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "We should see a Pandas dataframe containing the 1000 rows of our Lending Club data sample.\n",
     "\n",
     "Now that we have the raw data, we can pass it into the whylogs logger. It is often useful to pass a string label such as \"demo.data\" along with the dataset for future reference.\n",
     "\n",
     "The `log_dataframe` function will profile the given dataset using the whylogs library. When we capture the logger response, we can interact with the generated profiles."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "profile = session.log_dataframe(data, 'test.data')\n",
     "print(profile)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "The flat summary, histograms, and frequency information can be found inside this summary object. \n",
     "\n",
     "For more information about the contents of these objects, consult the `Analysis.ipynb` notebook."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "summary = profile.flat_summary()\n",
     "flat_summary = summary['summary']\n",
     "flat_summary"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "print(flat_summary[\"column\"].unique())"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "histograms = summary['hist']\n",
     "histograms[\"delinq_amnt\"]"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "frequencies = summary['frequent_strings']\n",
-    "frequencies['num_sats']"
-   ]
+    "frequent_strings = [key for key in frequencies.keys()]\n",
+    "print(frequent_strings)\n",
+    "frequencies[frequent_strings[0]]"
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Additional options for our whylogs session\n",
     "We chose the most simple configuration above, but there are a number of convenient options that can be set.\n",
@@ -175,64 +176,64 @@
     "**Flat and JSON summaries:** By default, we produce a flat summary in the CSV format along with histogram and frequency summaries in the JSON format.\n",
     "\n",
     "You can see these configuration options and others paired with the session in the `session.config` object."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "source": [],
    "outputs": [],
-   "source": []
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Display and resetting the session\n",
     "\n",
     "There is also a convenience function to send the internal Python logs to stdout."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "from whylogs.logs import display_logging\n",
     "display_logging('debug')"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "When you are done with your session, run the `reset_session` function."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "from whylogs.app.session import reset_default_session\n",
     "reset_default_session()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "source": [],
    "outputs": [],
-   "source": []
+   "metadata": {}
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "name": "python3",
+   "display_name": "Python 3.8.10 64-bit"
   },
   "language_info": {
    "codemirror_mode": {
@@ -244,7 +245,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.10"
+  },
+  "interpreter": {
+   "hash": "916dbcbb3f70747c44a77c7bcd40155683ae19c65e1c03b4aa3499c5328201f1"
   }
  },
  "nbformat": 4,

--- a/src/whylogs/core/metrics/model_metrics.py
+++ b/src/whylogs/core/metrics/model_metrics.py
@@ -60,6 +60,13 @@ class ModelMetrics:
             model_type=message.modelType,
         )
 
+    # Model type is initialized only if the metric model type is None or UNKNOWN
+    def init_or_get_model_type(self, scores) -> ModelType:
+        if self.model_type is None or self.model_type == ModelType.UNKNOWN:
+            # If scores are passed in then treat the model as CLASSIFICATION
+            self.model_type = ModelType.REGRESSION if scores is None else ModelType.CLASSIFICATION
+        return self.model_type
+
     def compute_confusion_matrix(
         self,
         predictions: List[Union[str, int, bool, float]],

--- a/src/whylogs/core/metrics/regression_metrics.py
+++ b/src/whylogs/core/metrics/regression_metrics.py
@@ -1,8 +1,6 @@
 import math
 from typing import List
 
-from sklearn.utils.multiclass import type_of_target
-
 from whylogs.proto import RegressionMetricsMessage
 
 SUPPORTED_TYPES = "regression"
@@ -27,14 +25,7 @@ class RegressionMetrics:
         Args:
             predictions (List[float]):
             targets (List[float]):
-
-        Raises:
-            NotImplementedError: in case targets do not fall into continuous support
-            ValueError: incase missing validation or predictions
         """
-        tgt_type = type_of_target(targets)
-        if tgt_type not in ("continuous"):
-            raise NotImplementedError(f"target type: {tgt_type} not supported for these metrics")
 
         # need to vectorize this
         for idx, target in enumerate(targets):

--- a/tests/unit/core/test_columnprofile.py
+++ b/tests/unit/core/test_columnprofile.py
@@ -98,7 +98,7 @@ def test_protobuf():
 
     assert c1.string_tracker.length.count == 0
     assert len(c1.string_tracker.char_pos_tracker.character_list) == 56
-    msg2 = c1.to_protobuf()
+    c1.to_protobuf()
 
 
 def test_summary():

--- a/tests/unit/core/test_model_profile.py
+++ b/tests/unit/core/test_model_profile.py
@@ -1,3 +1,5 @@
+from pytest import raises
+
 from whylogs.core.model_profile import ModelProfile
 from whylogs.proto import ModelProfileMessage, ModelType
 
@@ -17,10 +19,9 @@ def test_model_profile_2():
     scores_1 = [0.1, 0.2, 0.4]
 
     mod_prof = ModelProfile()
-
+    assert scores_1 is not None
+    mod_prof.compute_metrics(targets=targets_1, predictions=predictions_1, scores=scores_1)
     assert mod_prof.output_fields == []
-
-    mod_prof.compute_metrics(predictions_1, targets_1, scores_1)
     assert mod_prof.metrics is not None
     assert mod_prof.metrics.confusion_matrix is not None
     message = mod_prof.to_protobuf()
@@ -29,6 +30,43 @@ def test_model_profile_2():
     assert mod_prof.metrics.confusion_matrix is not None
     assert mod_prof.metrics.confusion_matrix.labels is not None
     assert model_profile.metrics.confusion_matrix.labels == mod_prof.metrics.confusion_matrix.labels
+
+
+def test_model_profile_infered_type_integers_with_scores_is_classification():
+    targets_1 = [1, 2, 2]
+    predictions_1 = [219.0, 70.0, 202.0]
+    scores_1 = [1, 1, 1]
+
+    mod_prof = ModelProfile()
+    mod_prof.compute_metrics(targets_1, predictions_1, scores_1)
+
+    assert mod_prof.metrics is not None
+    assert mod_prof.metrics.confusion_matrix is not None
+    assert mod_prof.metrics.model_type == ModelType.CLASSIFICATION
+
+
+def test_model_profile_infered_type_without_scores_is_regression():
+    targets_1 = [1, 2, 2]
+    predictions_1 = [219.0, 70.0, 202.0]
+
+    mod_prof = ModelProfile()
+    mod_prof.compute_metrics(targets_1, predictions_1)
+
+    assert mod_prof.metrics is not None
+    assert mod_prof.metrics.confusion_matrix is None
+    assert mod_prof.metrics.model_type == ModelType.REGRESSION
+
+
+def test_model_profile_infered_type_no_change():
+    targets_1 = [2, 3, 4]
+    predictions_1 = [10.0, 9.0, 8.0]
+    scores_1 = [0.9, 0.8, 1]
+
+    mod_prof = ModelProfile()
+    assert mod_prof.metrics is not None
+    mod_prof.metrics.model_type = ModelType.CLASSIFICATION
+    mod_prof.compute_metrics(targets_1, predictions_1, scores_1)
+    assert mod_prof.metrics.model_type == ModelType.CLASSIFICATION
 
 
 def test_merge_profile():
@@ -41,7 +79,7 @@ def test_merge_profile():
     assert mod_prof.output_fields == []
     mod_prof.add_output_field("predictions")
 
-    mod_prof.compute_metrics(predictions_1, targets_1, scores_1)
+    mod_prof.compute_metrics(targets_1, predictions_1, scores_1)
     assert mod_prof.metrics is not None
 
     mod_prof_2 = ModelProfile()
@@ -66,12 +104,14 @@ def test_merge_profile_nlp():
     predictions_1 = ["cat is dog", "dog is dog", "dog pig"]
 
     mod_prof = ModelProfile()
-    mod_prof.model_type = ModelType.NLP
+    mod_prof.metrics.model_type = ModelType.NLP
 
     assert mod_prof.output_fields == []
     mod_prof.add_output_field("monologue")
 
-    mod_prof.compute_metrics(predictions_1, targets_1)
+    with raises(NotImplementedError):
+        mod_prof.compute_metrics(targets_1, predictions_1)
+
     assert mod_prof.metrics is not None
 
     mod_prof_2 = ModelProfile()


### PR DESCRIPTION
## Description

Fixes #301 by avoiding mutation of model metric's model_type via when log_metrics() is called post model type initialization and removing some of the automatic model type from data inference code in favor of relying more on the method called. E.g. callers should either pass in scores parameter and/or set the model_type to log classification metrics.

Removed some of the NLP model metrics code as that is not fully implemented yet to simplify the behavior.

Added some new tests and updated the model profile tests.

### General Checklist

* [x ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ x] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ x] (optional) Please add a label to your PR

    