### PR TITLE
Align segment tag handling in python with java, fix typos in example and tests

### DIFF
--- a/examples/segments_logging.py
+++ b/examples/segments_logging.py
@@ -8,6 +8,7 @@ if __name__ == "__main__":
     df = pd.read_csv("data/lending_club_1000.csv")
     print(df.head())
     session = get_or_create_session()
+    profile_seg = None
 
     # example with 4 seperate loggers
 
@@ -22,7 +23,7 @@ if __name__ == "__main__":
     ) as logger:
         print(session.get_config())
         logger.log_dataframe(df)
-        profile_seg = logger.segemented_profiles
+        profile_seg = logger.segmented_profiles
 
     # logger with rotation with time and single key segment
     with session.logger(
@@ -35,7 +36,7 @@ if __name__ == "__main__":
         logger.log_dataframe(df)
         time.sleep(2)
         logger.log_dataframe(df)
-        profile_seg = logger.segemented_profiles
+        profile_seg = logger.segmented_profiles
 
     # logger with rotation with time and two keys segment
     with session.logger(
@@ -48,7 +49,7 @@ if __name__ == "__main__":
         logger.log_csv("data/lending_club_1000.csv")
         time.sleep(2)
         logger.log_dataframe(df)
-        profile_seg = logger.segemented_profiles
+        profile_seg = logger.segmented_profiles
 
     # logger
     with session.logger(
@@ -62,7 +63,7 @@ if __name__ == "__main__":
         logger.log_csv("data/lending_club_1000.csv")
         time.sleep(2)
         logger.log_dataframe(df)
-        profile_seg = logger.segemented_profiles
+        profile_seg = logger.segmented_profiles
         full_profile = logger.profile
         # each segment profile has a tag associated with the segment
         for k, prof in profile_seg.items():

--- a/src/whylogs/app/logger.py
+++ b/src/whylogs/app/logger.py
@@ -28,6 +28,9 @@ from whylogs.proto import ModelType
 # TODO upgrade to Classes
 SegmentTag = Dict[str, any]
 Segment = List[SegmentTag]
+_TAG_PREFIX = "whylogs.tag."
+_TAG_KEY = "key"
+_TAG_VALUE = "value"
 
 logger = logging.getLogger(__name__)
 
@@ -578,6 +581,7 @@ class Logger:
         try:
             grouped_data = data.groupby(self.segments)
         except KeyError as e:
+            logger.exception(f"Failed to groupby {self.segments} over {data.head()} which resulted in {e}")
             raise e
 
         segments = grouped_data.groups.keys()
@@ -611,22 +615,23 @@ class Logger:
             self.log_df_segment(segment_df, segment_tag)
 
     def log_df_segment(self, df, segment: Segment):
-        segment = sorted(segment, key=lambda x: x["key"])
+        segment_key_values = sorted(segment, key=lambda x: x["key"])
+        segment_tags = Logger._prefix_segment_tags(segment_key_values)
 
-        segment_profile = self.get_segment(segment)
+        segment_profile = self.get_segment(segment_key_values)
 
         if segment_profile is None:
             segment_profile = DatasetProfile(
                 self.dataset_name,
                 dataset_timestamp=datetime.datetime.now(datetime.timezone.utc),
                 session_timestamp=self.session_timestamp,
-                tags={**self.tags, **{"segment": json.dumps(segment)}},
+                tags={**self.tags, **segment_tags},
                 metadata=self.metadata,
                 session_id=self.session_id,
                 constraints=self.constraints,
             )
             segment_profile.track_dataframe(df)
-            hashed_seg = hash_segment(segment)
+            hashed_seg = hash_segment(segment_key_values)
             self._profiles[-1]["segmented_profiles"][hashed_seg] = segment_profile
         else:
             segment_profile.track_dataframe(df)
@@ -636,6 +641,14 @@ class Logger:
         Return the boolean state of the logger
         """
         return self._active
+
+    @staticmethod
+    def _prefix_segment_tags(segment_key_values):
+        # prefix the tag values and extract dictionary entries for passing in a DatasetProfile in format backend expects
+        segment_tags = {}
+        for entry in segment_key_values:
+            segment_tags[_TAG_PREFIX + entry[_TAG_KEY]] = str(entry[_TAG_VALUE])
+        return segment_tags
 
 
 def hash_segment(seg: List[Dict]) -> str:


### PR DESCRIPTION


## Description

Other parts of whylogs use a tag prefix for segments, update the DatasetProfile to align. whylogs python encodes tags like this now:
```
{'whylogs.tag.home_ownership': 'MORTGAGE'}
```

rather than json encoding the segment tags as a string value, e.g.:

```
{'segment': '[{"key": "home_ownership", "value": "MORTGAGE"}]','}
```



### General Checklist

* [x] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    