### PR TITLE
Fix whylogs init, add test-notebooks to make release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build.proto := $(patsubst $(src.proto.dir)/%.proto,$(build.proto.dir)/%_pb2.py,$
 
 default: dist
 
-release: format lint test dist ## Compile distribution files and run all tests and checks.
+release: format lint test dist test-notebooks ## Compile distribution files and run all tests and checks.
 
 pre-commit: format-fix lint-fix release
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 
+[tool.poetry.scripts]
+whylogs = 'whylogs.cli:main'
+whylogs-demo = 'whylogs.cli:demo_main'
+
 [tool.poetry.dependencies]
 python = ">=3.6.1,<3.10"
 click = ">=7.1.2"


### PR DESCRIPTION
## Description

Fix #311 by adding poetry scripts section to our pyproject.toml file and referencing the whylogs cli scripts.

Previously the whylogs cli and whylogs-demo were referenced in the setup.cfg as entry points, looks like it might have been missed when migrating to poetry.

You can verify this works locally by running

`poetry install && poetry run whylogs init`

Also added the test-notebooks to make release target to align with our github CI checks.

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [x] (optional) Please add a label to your PR

    