### PR TITLE
Fix whylogs init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 
+[tool.poetry.scripts]
+whylogs = 'whylogs.cli:main'
+whylogs-demo = 'whylogs.cli:demo_main'
+
 [tool.poetry.dependencies]
 python = ">=3.6.1,<3.10"
 click = ">=7.1.2"


### PR DESCRIPTION
## Description

Fix #311 by adding poetry scripts section to our pyproject.toml file and referencing the whylogs cli scripts.

Previously the whylogs cli and whylogs-demo were referenced in the setup.cfg as entry points, looks like it might have been missed when migrating to poetry.

You can verify this works locally by running

`poetry install && poetry run whylogs init`

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [x] (optional) Please add a label to your PR

    