### PR TITLE
Changed MATCH and NOMATCH to use re.compile instead of re.match. Chan…

### DIFF
--- a/src/whylogs/core/statistics/constraints.py
+++ b/src/whylogs/core/statistics/constraints.py
@@ -32,8 +32,8 @@ _value_funcs = {
     Op.NE: lambda x: lambda v: v != x,
     Op.GE: lambda x: lambda v: v >= x,
     Op.GT: lambda x: lambda v: v > x,  # assert incoming value 'v' is greater than some fixed value 'x'
-    Op.MATCH: lambda x: lambda v: re.match(x, v) is not None,
-    Op.NOMATCH: lambda x: lambda v: re.match(x, v) is None,
+    Op.MATCH: lambda x: lambda v: x.match(v) is not None,
+    Op.NOMATCH: lambda x: lambda v: x.match(v) is None,
 }
 
 _summary_funcs1 = {
@@ -91,7 +91,7 @@ class ValueConstraint:
         elif regex_pattern is not None and value is None:
             # Regex pattern
             self.regex_pattern = regex_pattern
-            self.func = _value_funcs[op](regex_pattern)
+            self.func = _value_funcs[op](re.compile(self.regex_pattern))
 
         else:
             raise ValueError("Value constraint must specify a numeric value or regex pattern, but not both")

--- a/tests/unit/core/statistics/test_constraints.py
+++ b/tests/unit/core/statistics/test_constraints.py
@@ -73,13 +73,13 @@ def test_value_constraints_pattern_match(df_lending_club, local_config_path):
     contains_state = ValueConstraint(Op.MATCH, regex_pattern=regex_state_abbreviation)
 
     regex_date = r"^[a-zA-Z]{3}-[0-9]{4}$"
-    contains_date = ValueConstraint(Op.NOMATCH, regex_pattern=regex_date)
+    not_contains_date = ValueConstraint(Op.NOMATCH, regex_pattern=regex_date)
 
     # just to test applying regex patterns on non-string values
     contains_state_loan_amnt = ValueConstraint(Op.MATCH, regex_pattern=regex_state_abbreviation)
 
     dc = DatasetConstraints(
-        None, value_constraints={"addr_state": [contains_state], "earliest_cr_line": [contains_date], "loan_amnt": [contains_state_loan_amnt]}
+        None, value_constraints={"addr_state": [contains_state], "earliest_cr_line": [not_contains_date], "loan_amnt": [contains_state_loan_amnt]}
     )
 
     config = load_config(local_config_path)


### PR DESCRIPTION
…ged name of constraint in test_constraints.py to not_contains_date.

## Description

Changed constraints regex pattern matching to use re.compile instead of re.match.
Relates to #322 

Changed constraint name in test_constraints.py to `not_contains_date`, since it's a NOMATCH assertion.

Both changes are from follow-ups from PR #317 

<!-- Description of changes -->

### General Checklist

* [x] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    