### PR TITLE
Add warning on larger dataframe logging, add perf test and fixture for conditional tests w/ --load

### DIFF
--- a/src/whylogs/core/datasetprofile.py
+++ b/src/whylogs/core/datasetprofile.py
@@ -268,11 +268,19 @@ class DatasetProfile:
         # workaround for CUDF due to https://github.com/rapidsai/cudf/issues/6743
         if cudfDataFrame is not None and isinstance(df, cudfDataFrame):
             df = df.to_pandas()
+        element_count = df.size
+        large_df = element_count > 200000
+        if large_df:
+            logger.warning(f"About to log a dataframe with {element_count} elements, logging might take some time to complete.")
+        count = 0
         for col in df.columns:
             col_str = str(col)
 
             x = df[col].values
             for xi in x:
+                count = count + 1
+                if large_df and (count % 200000 == 0):
+                    logger.warning(f"Logged {count} elements out of {element_count}")
                 self.track(col_str, xi, character_list=None, token_method=None)
 
     def to_properties(self):

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -3,14 +3,30 @@ import sys
 
 import pytest
 
-import whylogs
-
 _MY_DIR = os.path.realpath(os.path.dirname(__file__))
 # Allow import of the test utilities packages
 sys.path.insert(0, os.path.join(_MY_DIR, os.pardir, "helpers"))
 # Test the parent package
 sys.path.insert(0, os.path.join(_MY_DIR, os.pardir))
 # Verify whylogs is importable
+
+
+def pytest_addoption(parser):
+    parser.addoption("--load", action="store_true", default=False, help="run load tests")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "load: mark test as load to skip running with unit tests")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--load"):
+        # --integ specified on command line: do not skip integ tests
+        return
+    skip_load_test = pytest.mark.skip(reason="need --load option to run")
+    for item in items:
+        if "load" in item.keywords:
+            item.add_marker(skip_load_test)
 
 
 @pytest.fixture(scope="session")

--- a/tests/component/test_performance_log_dataframe.py
+++ b/tests/component/test_performance_log_dataframe.py
@@ -1,0 +1,110 @@
+import cProfile
+import json
+import os
+import pstats
+from logging import getLogger
+from shutil import rmtree
+from time import sleep
+from typing import List
+
+import pandas as pd
+import pytest
+
+from whylogs import DatasetProfile
+from whylogs.app.config import SessionConfig, WriterConfig
+from whylogs.app.session import get_or_create_session, session_from_config
+from whylogs.app.writers import writer_from_config
+from whylogs.util import time
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
+TEST_LOGGER = getLogger(__name__)
+
+
+def count_features(json_profile_filename):
+    if not os.path.isfile(json_profile_filename):
+        raise ValueError(f"{json_profile_filename} is not a json file but trying to open it to count features")
+    profile = get_json_profile(json_profile_filename)
+    if profile and profile.get("columns"):
+        return len(profile["columns"].keys())
+    return 0
+
+
+def get_json_profile(json_profile_filename):
+    profile = {}
+    if os.path.exists(json_profile_filename) and os.stat(json_profile_filename).st_size > 0:
+        with open(json_profile_filename) as profile_file:
+            profile = json.load(profile_file)
+    return profile
+
+
+def assert_all_elements_equal(data: List):
+    if not data or len(data) == 1:
+        return True
+    first = data[0]
+    for element in iter(data):
+        assert first[0] == element[0], f"Found differing feature counts: {first[0]} vs {element[0]} in files {first[1]} and {element[1]}"
+
+
+@pytest.mark.load
+def test_log_rotation_concurrency(tmpdir):
+    log_rotation_interval = "1s"
+    sleep_interval = 2
+
+    test_path = tmpdir.mkdir("log_rotation_concurrency_repro")
+    writer_config = WriterConfig("local", ["json"], test_path.realpath(), filename_template="dataset_summary-$dataset_timestamp")
+
+    # Load the full lending club 1000 csv, to get a chance at hitting the bug.
+    csv_path = os.path.join(script_dir, "lending_club_1000.csv")
+    full_df = pd.read_csv(csv_path)
+
+    # full_df has shape (1000, 151) so create a test df with 4x size by iteratively appending to self 2 times
+    for _ in range(2):
+        full_df = full_df.append(full_df)
+
+    TEST_LOGGER.info(f"test dataframe has shape {full_df.shape}")
+
+    # Create a whylogs logging session
+    session_config = SessionConfig("project", "pipeline", writers=[writer_config])
+    session = session_from_config(session_config)
+
+    TEST_LOGGER.info(f"Running rotate log test with {log_rotation_interval} flush intervals and {sleep_interval}s pause")
+    profiler = cProfile.Profile()
+    profiler.enable()
+    with session.logger(tags={"datasetId": "model-1"}, with_rotation_time=log_rotation_interval) as ylog:
+        ylog.log_dataframe(full_df)  # Log a larger dataframe to increase chance of rotation before seeing all columns
+        sleep(sleep_interval)
+        ylog.log_dataframe(full_df.head(n=2))  # Log a smaller dataframe to get more features before rotation
+        sleep(sleep_interval)
+    profiler.disable()
+    stats = pstats.Stats(profiler).sort_stats("cumulative")
+    TEST_LOGGER.info(stats.print_stats(10))
+
+    output_files = []
+    for root, subdir, file_names in os.walk(test_path):
+        if not file_names:
+            continue
+        if subdir:
+            for directory in subdir:
+                for file in file_names:
+                    full_file_path = os.path.join(root, directory, file)
+                    output_files += [full_file_path]
+        else:
+            for file in file_names:
+                full_file_path = os.path.join(root, file)
+                output_files += [full_file_path]
+
+    assert len(output_files) > 0, "No output files were generated during stress test"
+    TEST_LOGGER.debug(f"Generated {len(output_files)} dataset summary files.")
+
+    feature_counts = []
+    for filename in output_files:
+        feature_count = count_features(filename)
+        if feature_count > 0:
+            feature_counts.append((count_features(filename), filename))
+
+    assert len(feature_counts) > 0, f"feature counts are all empty, we expect some empty files with aggressive log rotation but not all empty!"
+    TEST_LOGGER.info(f"Feature counts all same, first file with features was {feature_counts[0]}")
+    TEST_LOGGER.debug(f"There were {len(feature_counts)} files with features.")
+    assert_all_elements_equal(feature_counts)
+    rmtree(test_path, ignore_errors=True)
+    TEST_LOGGER.debug(f"End cleaning up test directory {test_path}")


### PR DESCRIPTION
* Also added a test to profile log_dataframe on a dataframe 4x size of lending club 1000 as a baseline for perf.
* Test does not pass but will output some statistics on most expensive calls.

Next would be to integrate the output stats better so we can track this perf over time in an automated way. By default this new test will be skipped when running tests.

## Description

When we add new trackers or features, these can increase the time it takes to log data frame but we didn't have tests to report that or get insight into where time is spent during a log_dataframe() call. Walking through onboarding scenario it can be too long for log_dataframe to return or report progress depending on the size and types of data chosen in an initial data frame. So the first step to addressing this scenario better is to measure what the time is and where time is spent when logging some benchmark datasets. Next we will add some warnings if the amount of data being logged in one call is large and is known to take significant time.

To run the test, include the --load parameter, e.g.

`
poetry run pytest tests/component -o log_cli=true -o log_level=INFO --load
`

```
63319106 function calls (63319047 primitive calls) in 38.848 seconds

   Ordered by: cumulative time
   List reduced from 386 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        2    0.002    0.001   34.841   17.421 /home/jamie/projects/whylogs/src/whylogs/app/logger.py:544(log_dataframe)
        2    0.319    0.160   34.839   17.420 /home/jamie/projects/whylogs/src/whylogs/core/datasetprofile.py:259(track_dataframe)
   604302    0.281    0.000   34.494    0.000 /home/jamie/projects/whylogs/src/whylogs/core/datasetprofile.py:203(track)
   604302    0.326    0.000   34.213    0.000 /home/jamie/projects/whylogs/src/whylogs/core/datasetprofile.py:230(track_datum)
   604302    1.864    0.000   33.860    0.000 /home/jamie/projects/whylogs/src/whylogs/core/columnprofile.py:100(track)
    97768    0.342    0.000   14.637    0.000 /home/jamie/projects/whylogs/src/whylogs/core/statistics/stringtracker.py:211(update)
    97768    1.717    0.000   13.014    0.000 /home/jamie/projects/whylogs/src/whylogs/core/statistics/stringtracker.py:40(update)
   435987    0.145    0.000   10.174    0.000 /home/jamie/projects/whylogs/src/whylogs/core/types/typeddataconverter.py:30(convert)
    97768    0.089    0.000    9.999    0.000 /home/jamie/.cache/pypoetry/virtualenvs/whylogs-dFpe3D9Y-py3.8/lib/python3.8/site-packages/yaml/__init__.py:154(safe_load)
    97768    0.163    0.000    9.910    0.000 /home/jamie/.cache/pypoetry/virtualenvs/whylogs-dFpe3D9Y-py3.8/lib/python3.8/site-packages/yaml/__init__.py:103(load)
```



### General Checklist

* [x] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [x] (optional) Please add a label to your PR

    