### PR TITLE
Fix missing ImagePixelWidth and reduce default set of image tracking

### DIFF
--- a/src/whylogs/core/image_profiling.py
+++ b/src/whylogs/core/image_profiling.py
@@ -17,22 +17,9 @@ DEFAULT_IMAGE_FEATURES = []
 
 
 _DEFAULT_TAGS_ATTRIBUTES = [
-    "ImageWidth",
-    "ImageLength",
-    "BitsPerSample",
-    "Compression",
-    "Quality",
-    "PhotometricInterpretation" "SamplesPerPixel",
-    "Model",
-    "Software",
-    "ResolutionUnit",
-    "X-Resolution",
-    "Y-Resolution",
-    "Orientation",
-    "RowsPerStrip",
-    "ExposureTime",
-    "BrightnessValue",
-    "Flash",
+    "ImagePixelWidth",
+    "ImagePixelLength",
+    "Colorspace",
 ]
 _IMAGE_HSV_CHANNELS = ["Hue", "Saturation", "Brightness"]
 _STATS_PROPERTIES = ["mean", "stddev"]
@@ -164,5 +151,4 @@ def image_based_metadata(img):
         "ImagePixelWidth": img.width,
         "ImagePixelHeight": img.height,
         "Colorspace": img.mode,
-        "ImageFormat": img.format,
     }

--- a/src/whylogs/core/image_profiling.py
+++ b/src/whylogs/core/image_profiling.py
@@ -18,7 +18,7 @@ DEFAULT_IMAGE_FEATURES = []
 
 _DEFAULT_TAGS_ATTRIBUTES = [
     "ImagePixelWidth",
-    "ImagePixelLength",
+    "ImagePixelHeight",
     "Colorspace",
 ]
 _IMAGE_HSV_CHANNELS = ["Hue", "Saturation", "Brightness"]

--- a/tests/unit/core/test_image_profiling.py
+++ b/tests/unit/core/test_image_profiling.py
@@ -72,7 +72,7 @@ def test_track_image():
 
     assert columns["Saturation.mean"].number_tracker.count == 2
     assert columns["Saturation.stddev"].number_tracker.count == 2
-    assert columns["ImagePixelWidth"].counters.count == 2
+    assert columns["ImagePixelHeight"].counters.count == 2
 
 
 def test_track_PIL_img():
@@ -96,5 +96,8 @@ def test_track_PIL_img():
     columns = profile_1.columns
     for feature_name in total_default_features:
         assert feature_name in columns, f"{feature_name} not in {columns}"
+    assert columns["Hue.mean"].number_tracker.count == 1
     assert columns["Saturation.mean"].number_tracker.count == 1
+    assert columns["Brightness.mean"].number_tracker.count == 1
     assert columns["ImagePixelWidth"].counters.count == 1
+    assert columns["ImagePixelHeight"].counters.count == 1

--- a/tests/unit/core/test_image_profiling.py
+++ b/tests/unit/core/test_image_profiling.py
@@ -8,6 +8,26 @@ from whylogs.core.datasetprofile import DatasetProfile, array_profile, dataframe
 from whylogs.core.image_profiling import _METADATA_DEFAULT_ATTRIBUTES, TrackImage
 from whylogs.features import _IMAGE_FEATURES
 
+METADATA_IMAGE_TAGS = {
+    "ImageWidth",
+    "ImageLength",
+    "BitsPerSample",
+    "Compression",
+    "Quality",
+    "PhotometricInterpretation",
+    "SamplesPerPixel",
+    "Model",
+    "Software",
+    "ResolutionUnit",
+    "X-Resolution",
+    "Y-Resolution",
+    "Orientation",
+    "RowsPerStrip",
+    "ExposureTime",
+    "BrightnessValue",
+    "Flash",
+}
+
 TEST_DATA_PATH = os.path.abspath(
     os.path.join(
         os.path.realpath(os.path.dirname(__file__)),
@@ -42,7 +62,7 @@ def test_track_image():
 
     assert columns["Saturation.mean"].number_tracker.count == 1
     assert columns["Saturation.stddev"].number_tracker.count == 1
-    assert columns["BitsPerSample"].counters.count == 1
+    assert columns["ImagePixelWidth"].counters.count == 1
 
     trackImage = TrackImage(test_image_path)
     trackImage(profile_1)
@@ -52,7 +72,7 @@ def test_track_image():
 
     assert columns["Saturation.mean"].number_tracker.count == 2
     assert columns["Saturation.stddev"].number_tracker.count == 2
-    assert columns["BitsPerSample"].counters.count == 2
+    assert columns["ImagePixelWidth"].counters.count == 2
 
 
 def test_track_PIL_img():
@@ -77,4 +97,4 @@ def test_track_PIL_img():
     for feature_name in total_default_features:
         assert feature_name in columns, f"{feature_name} not in {columns}"
     assert columns["Saturation.mean"].number_tracker.count == 1
-    assert columns["BitsPerSample"].counters.count == 1
+    assert columns["ImagePixelWidth"].counters.count == 1


### PR DESCRIPTION

## Description

Fixes #330 by adding ImagePixelWidth to the default set of image metadata tags we track.
- removed many of the default tags to reduce the noise when image tracking uses default settings.
- updated tests

### General Checklist

* [x] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [x] (optional) Please add a label to your PR

    