### PR TITLE
Update autoflake parameters to remove unused imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ lint: ## Check code for lint errors.
 
 lint-fix: ## Automatically fix linting issues.
 	@$(call i, Running the linter)
-	poetry run autoflake --in-place --remove-unused-variables $(src.python) $(tst.python) $(tst.notebooks.python)
+	poetry run autoflake --in-place --remove-all-unused-imports --remove-unused-variables $(src.python) $(tst.python) $(tst.notebooks.python)
 
 format: ## Check style formatting.
 	@$(call i, Checking import formatting)

--- a/src/whylogs/proto/__init__.py
+++ b/src/whylogs/proto/__init__.py
@@ -3,6 +3,6 @@ Auto-generated protobuf class definitions.
 
 Protobuf allows us to serialize/deserialize classes across languages
 """
-from .constraints_pb2 import *
-from .messages_pb2 import *
-from .summaries_pb2 import *
+from .constraints_pb2 import * # noqa
+from .messages_pb2 import * # noqa
+from .summaries_pb2 import * # noqa

--- a/tests/component/test_performance_log_dataframe.py
+++ b/tests/component/test_performance_log_dataframe.py
@@ -10,11 +10,8 @@ from typing import List
 import pandas as pd
 import pytest
 
-from whylogs import DatasetProfile
 from whylogs.app.config import SessionConfig, WriterConfig
-from whylogs.app.session import get_or_create_session, session_from_config
-from whylogs.app.writers import writer_from_config
-from whylogs.util import time
+from whylogs.app.session import session_from_config
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 TEST_LOGGER = getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import sys
 import pandas as pd
 import pytest
 
-import whylogs
 from whylogs.core.datasetprofile import DatasetProfile
 
 _MY_DIR = os.path.realpath(os.path.dirname(__file__))

--- a/tests/unit/app/test_segments.py
+++ b/tests/unit/app/test_segments.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 from pandas import util
 
 from whylogs.app.config import SessionConfig, WriterConfig
-from whylogs.app.logger import _TAG_KEY, _TAG_PREFIX, _TAG_VALUE
+from whylogs.app.logger import _TAG_PREFIX, _TAG_VALUE
 from whylogs.app.session import session_from_config
 
 

--- a/tests/unit/app/test_session.py
+++ b/tests/unit/app/test_session.py
@@ -3,8 +3,6 @@ from pandas import util
 
 from whylogs.app.config import SessionConfig
 from whylogs.app.session import (
-    Session,
-    get_logger,
     get_or_create_session,
     get_session,
     reset_default_session,

--- a/tests/unit/app/test_writers.py
+++ b/tests/unit/app/test_writers.py
@@ -4,7 +4,6 @@ import boto3
 import pytest
 from moto import mock_s3
 from moto.s3.responses import DEFAULT_REGION_NAME
-from smart_open import open
 
 from whylogs.app import WriterConfig
 from whylogs.app.config import load_config

--- a/tests/unit/core/metrics/test_nlp_metrics.py
+++ b/tests/unit/core/metrics/test_nlp_metrics.py
@@ -1,7 +1,6 @@
 import pytest
 
 from whylogs.core.metrics.nlp_metrics import NLPMetrics
-from whylogs.proto import NLPMetricsMessage
 
 
 def test_nlp_metrics():

--- a/tests/unit/core/statistics/test_numbertracker.py
+++ b/tests/unit/core/statistics/test_numbertracker.py
@@ -1,5 +1,4 @@
 import pytest
-from testutil import compare_frequent_items
 
 from whylogs.core.statistics import NumberTracker
 

--- a/tests/unit/core/test_annotation_profiling.py
+++ b/tests/unit/core/test_annotation_profiling.py
@@ -4,7 +4,7 @@ import os
 from uuid import uuid4
 
 from whylogs.core.annotation_profiling import BB_ATTRIBUTES, TrackBB
-from whylogs.core.datasetprofile import DatasetProfile, array_profile, dataframe_profile
+from whylogs.core.datasetprofile import DatasetProfile
 
 TEST_DATA_PATH = os.path.abspath(
     os.path.join(

--- a/tests/unit/core/test_columnprofile.py
+++ b/tests/unit/core/test_columnprofile.py
@@ -7,8 +7,6 @@ from whylogs.core.statistics.hllsketch import HllSketch
 from whylogs.proto import ColumnMessage, ColumnSummary, InferredType
 from whylogs.util.protobuf import message_to_dict
 
-from ...helpers.testutil import compare_frequent_items
-
 
 def test_all_numeric_types_get_tracked_by_number_tracker():
     all_values = [

--- a/tests/unit/core/test_image_profiling.py
+++ b/tests/unit/core/test_image_profiling.py
@@ -4,9 +4,8 @@ from uuid import uuid4
 
 from PIL import Image
 
-from whylogs.core.datasetprofile import DatasetProfile, array_profile, dataframe_profile
+from whylogs.core.datasetprofile import DatasetProfile
 from whylogs.core.image_profiling import _METADATA_DEFAULT_ATTRIBUTES, TrackImage
-from whylogs.features import _IMAGE_FEATURES
 
 TEST_DATA_PATH = os.path.abspath(
     os.path.join(

--- a/tests/unit/io/test_local_dataset.py
+++ b/tests/unit/io/test_local_dataset.py
@@ -1,7 +1,5 @@
 import os
 
-from PIL.Image import Image as ImageType
-
 from whylogs.io.local_dataset import LocalDataset
 
 

--- a/tests/unit/util/test_protobuf.py
+++ b/tests/unit/util/test_protobuf.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from whylogs.proto import DatasetProperties, DoublesMessage, NumbersMessage
+from whylogs.proto import DoublesMessage
 from whylogs.util import protobuf
 
 _MY_DIR = os.path.realpath(os.path.dirname(__file__))


### PR DESCRIPTION
## Description

Small change to autoflake parameters so that when we run:
Make lint-fix

that will remove unused imports. Also updated files accordingly. This resolves #296

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    