### PR TITLE
Remove use of deprecated pandas util.testing.makeDataFrame()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -71,6 +72,12 @@ def df_lending_club():
     # just the top 50
     df = pd.read_csv(os.path.join(_MY_DIR, os.pardir, "testdata", "lending_club_1000.csv"))
     return df.head(50)
+
+
+@pytest.fixture(scope="session")
+def df():
+    # create a simple test dataframe to replace deprecated pandas.util.testing.makeDataFrame which returns 4 columns with 30 rows of numeric values
+    return pd.DataFrame((np.random.rand(30, 4) - 0.5) * 3, columns=["A", "B", "C", "D"])
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/app/test_log_rotation.py
+++ b/tests/unit/app/test_log_rotation.py
@@ -5,7 +5,6 @@ from datetime import timezone
 
 import pytest
 from freezegun import freeze_time
-from pandas import util
 
 from whylogs.app.config import SessionConfig, WriterConfig
 from whylogs.app.logger import Logger
@@ -62,7 +61,7 @@ def test_log_rotation_parsing():
         l.close()
 
 
-def test_log_rotation_seconds(tmpdir):
+def test_log_rotation_seconds(tmpdir, df):
     output_path = tmpdir.mkdir("whylogs")
     shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
@@ -73,15 +72,11 @@ def test_log_rotation_seconds(tmpdir):
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
         with session_from_config(session_config) as session:
             with session.logger("test", with_rotation_time="s", cache_size=1) as logger:
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)
                 frozen_time.tick(delta=datetime.timedelta(seconds=1))
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)
                 frozen_time.tick(delta=datetime.timedelta(seconds=1))
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)
                 logger.close()
     output_files = []
@@ -91,7 +86,7 @@ def test_log_rotation_seconds(tmpdir):
     shutil.rmtree(output_path, ignore_errors=True)
 
 
-def test_log_rotation_minutes(tmpdir):
+def test_log_rotation_minutes(tmpdir, df):
     output_path = tmpdir.mkdir("whylogs")
     shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
@@ -102,15 +97,11 @@ def test_log_rotation_minutes(tmpdir):
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
         with session_from_config(session_config) as session:
             with session.logger("test", with_rotation_time="m", cache_size=1) as logger:
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)
                 frozen_time.tick(delta=datetime.timedelta(minutes=2))
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)
                 frozen_time.tick(delta=datetime.timedelta(minutes=2))
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)
                 logger.close()
     output_files = []
@@ -120,7 +111,7 @@ def test_log_rotation_minutes(tmpdir):
     shutil.rmtree(output_path, ignore_errors=True)
 
 
-def test_log_rotation_days(tmpdir):
+def test_log_rotation_days(tmpdir, df):
     output_path = tmpdir.mkdir("whylogs")
     shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
@@ -131,24 +122,20 @@ def test_log_rotation_days(tmpdir):
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
         with session_from_config(session_config) as session:
             with session.logger("test", with_rotation_time="d", cache_size=1) as logger:
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)
                 frozen_time.tick(delta=datetime.timedelta(days=1))
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)
                 frozen_time.tick(delta=datetime.timedelta(days=2))
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)
     output_files = []
-    for root, subdirs, files in os.walk(output_path):
+    for _, _, files in os.walk(output_path):
         output_files += files
     assert len(output_files) == 3
     shutil.rmtree(output_path, ignore_errors=True)
 
 
-def test_log_rotation_hour(tmpdir):
+def test_log_rotation_hour(tmpdir, df):
     output_path = tmpdir.mkdir("whylogs")
     shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
@@ -159,24 +146,21 @@ def test_log_rotation_hour(tmpdir):
     with freeze_time("2012-01-14 03:21:34", tz_offset=-4) as frozen_time:
         with session_from_config(session_config) as session:
             with session.logger("test", with_rotation_time="h", cache_size=1) as logger:
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)
                 frozen_time.tick(delta=datetime.timedelta(hours=3))
                 logger.log(feature_name="E", value=4)
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)
 
     output_files = []
-    for root, subdirs, files in os.walk(output_path):
+    for _, _, files in os.walk(output_path):
         output_files += files
     assert len(output_files) == 2
     shutil.rmtree(output_path, ignore_errors=True)
 
 
-def test_incorrect_rotation_time():
+def test_incorrect_rotation_time(df):
 
     with pytest.raises(TypeError):
         with get_or_create_session() as session:
             with session.logger("test2", with_rotation_time="W2") as logger:
-                df = util.testing.makeDataFrame()
                 logger.log_dataframe(df)

--- a/tests/unit/app/test_segments.py
+++ b/tests/unit/app/test_segments.py
@@ -5,7 +5,6 @@ import shutil
 import pandas as pd
 import pytest
 from freezegun import freeze_time
-from pandas import util
 
 from whylogs.app.config import SessionConfig, WriterConfig
 from whylogs.app.logger import _TAG_PREFIX, _TAG_VALUE
@@ -88,7 +87,7 @@ def test_segments_single_key(df_lending_club, tmpdir):
     shutil.rmtree(output_path, ignore_errors=True)
 
 
-def test_segments_with_rotation(df_lending_club, tmpdir):
+def test_segments_with_rotation(df_lending_club, df, tmpdir):
     output_path = tmpdir.mkdir("whylogs")
     shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
@@ -110,18 +109,17 @@ def test_segments_with_rotation(df_lending_club, tmpdir):
             logger.log_dataframe(df_lending_club)
             frozen_time.tick(delta=datetime.timedelta(seconds=1))
 
-            df = util.testing.makeDataFrame()
             with pytest.raises(KeyError):
                 logger.log_dataframe(df)
         session.close()
     output_files = []
-    for root, subdirs, files in os.walk(output_path):
+    for _, _, files in os.walk(output_path):
         output_files += files
     assert len(output_files) == 8
     shutil.rmtree(output_path, ignore_errors=True)
 
 
-def test_one_segment(tmpdir, image_files):
+def test_one_segment(tmpdir):
     output_path = tmpdir.mkdir("whylogs")
     shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())
@@ -138,7 +136,7 @@ def test_one_segment(tmpdir, image_files):
         assert len(logger.segmented_profiles) == 1
 
 
-def test_log_multiple_segments(tmpdir, image_files):
+def test_log_multiple_segments(tmpdir):
     output_path = tmpdir.mkdir("whylogs")
     shutil.rmtree(output_path, ignore_errors=True)
     writer_config = WriterConfig("local", ["protobuf"], output_path.realpath())

--- a/tests/unit/app/test_session.py
+++ b/tests/unit/app/test_session.py
@@ -1,5 +1,4 @@
 import pytest
-from pandas import util
 
 from whylogs.app.config import SessionConfig
 from whylogs.app.session import (
@@ -26,11 +25,10 @@ def test_reset():
     assert global_session.project is not None
 
 
-def test_session_log_dataframe():
+def test_session_log_dataframe(df):
     pass
 
     session = session_from_config(SessionConfig("default-project", "default-pipeline", [], False))
-    df = util.testing.makeDataFrame()
     session.log_dataframe(df)
 
     assert session.logger() is not None
@@ -38,10 +36,9 @@ def test_session_log_dataframe():
     assert session.logger("default-project").dataset_name == "default-project"
 
 
-def test_session_profile():
+def test_session_profile(df):
 
     session = session_from_config(SessionConfig("default-project", "default-pipeline", [], False))
-    df = util.testing.makeDataFrame()
     profile = session.log_dataframe(df)
     assert profile is not None
 
@@ -51,9 +48,8 @@ def test_session_profile():
     assert len(flat_summary) == 4
 
 
-def test_profile_df():
+def test_profile_df(df):
     session = get_or_create_session()
-    df = util.testing.makeDataFrame()
     log_profile = session.log_dataframe(df)
     profile = session.profile_dataframe(df)
 
@@ -66,11 +62,10 @@ def test_profile_df():
     assert len(profile.tags) == 2
 
 
-def test_close_session():
+def test_close_session(df):
     session = get_or_create_session()
     session.close()
     assert session.is_active() == False
-    df = util.testing.makeDataFrame()
     log_profile = session.log_dataframe(df)
     assert log_profile == None
     profile = session.profile_dataframe(df)

--- a/tests/unit/core/test_datasetprofile.py
+++ b/tests/unit/core/test_datasetprofile.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 
 import numpy as np
 import pytest
-from pandas import util
 
 from whylogs.core.datasetprofile import DatasetProfile, array_profile, dataframe_profile
 from whylogs.core.model_profile import ModelProfile
@@ -341,9 +340,8 @@ def tests_timestamp():
     assert time_2 == int(time.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000.0)
 
 
-def test_dataframe_profile():
+def test_dataframe_profile(df):
     time = datetime.datetime.now()
-    df = util.testing.makeDataFrame()
 
     profile = DatasetProfile("test", time)
     profile.track_dataframe(df)

--- a/tests/unit/features/test_autosegmentation.py
+++ b/tests/unit/features/test_autosegmentation.py
@@ -20,7 +20,7 @@ def test_entropy_ints():
 
 
 def test_entropy_empty():
-    series = pd.Series([])
+    series = pd.Series([], dtype=float)
     res = _entropy(series, False)
 
     assert pytest.approx(res, 0.001) == 0

--- a/tests/unit/viz/test_viz.py
+++ b/tests/unit/viz/test_viz.py
@@ -79,9 +79,6 @@ def test_viz_char_pos(profile_lending_club):
 
 
 def test_viz_missing_values(profile_lending_club):
-
     viz = ProfileVisualizer()
-
     viz.set_profiles([profile_lending_club])
-
     viz.plot_missing_values("hardship_payoff_balance_amount")


### PR DESCRIPTION
## Description

- replace use of makeDataFrame() with a test fixture
- removes one of the warnings generated in whylogs from unit tests. 
 
Addresses #339 

### General Checklist

* [x] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    