### PR TITLE
Enable pickling via protobuf

### DIFF
--- a/src/whylogs/app/logger.py
+++ b/src/whylogs/app/logger.py
@@ -94,6 +94,10 @@ class Logger:
             self.session_timestamp = datetime.datetime.now(datetime.timezone.utc)
         else:
             self.session_timestamp = session_timestamp
+        if dataset_timestamp is None:
+            self.dataset_timestamp = datetime.datetime.now(datetime.timezone.utc)
+        else:
+            self.dataset_timestamp = dataset_timestamp
         self.dataset_name = dataset_name
         self.writers = writers
         self.metadata_writer = metadata_writer

--- a/src/whylogs/app/session.py
+++ b/src/whylogs/app/session.py
@@ -173,6 +173,11 @@ class Session:
         if not self._active:
             raise RuntimeError("Session is already closed. Cannot create more loggers")
 
+        # Explicitly set the default timezone to utc if none was provided. Helps with equality testing
+        # profiles by making sure dates are the same whether they're supplied or deserizlied from protobuf.
+        if dataset_timestamp is not None and dataset_timestamp.tzinfo is None:
+            dataset_timestamp = dataset_timestamp.replace(tzinfo=datetime.timezone.utc)
+
         logger_key = str(
             _LoggerKey(
                 dataset_name=dataset_name,

--- a/src/whylogs/core/datasetprofile.py
+++ b/src/whylogs/core/datasetprofile.py
@@ -110,6 +110,13 @@ class DatasetProfile:
         # Store Name attribute
         self._tags["name"] = name
 
+    def __getstate__(self):
+        return self.serialize_delimited()
+
+    def __setstate__(self, serialized_profile):
+        profile = DatasetProfile.parse_delimited_single(serialized_profile)[1]
+        self.__dict__.update(profile.__dict__)
+
     @property
     def name(self):
         return self._tags["name"]

--- a/src/whylogs/core/datasetprofile.py
+++ b/src/whylogs/core/datasetprofile.py
@@ -96,10 +96,12 @@ class DatasetProfile:
             metadata = {}
         if session_id is None:
             session_id = uuid4().hex
-
+        if dataset_timestamp is None:
+            self.dataset_timestamp = datetime.datetime.now(datetime.timezone.utc)
+        else:
+            self.dataset_timestamp = dataset_timestamp
         self.session_id = session_id
         self.session_timestamp = session_timestamp
-        self.dataset_timestamp = dataset_timestamp
         self._tags = dict(tags)
         self._metadata = metadata.copy()
         self.columns = columns

--- a/src/whylogs/util/time.py
+++ b/src/whylogs/util/time.py
@@ -33,6 +33,6 @@ def from_utc_ms(utc: Optional[int]) -> Optional[datetime.datetime]:
     dt : datetime.datetime
         Datetime object
     """
-    if utc is None:
+    if utc is None or utc == 0:
         return None
     return datetime.datetime.fromtimestamp(utc / 1000.0, tz=datetime.timezone.utc)

--- a/tests/core/test_datasetprofile.py
+++ b/tests/core/test_datasetprofile.py
@@ -1,0 +1,62 @@
+import datetime
+import io
+import pickle
+
+from whylogs.app import Session
+from whylogs.core.datasetprofile import DatasetProfile
+
+
+def profiles_eq(profile1: DatasetProfile, profile2: DatasetProfile):
+    assert set(profile1.columns) == set(profile2.columns)
+    assert profile1.constraints == profile2.constraints
+    assert profile1.dataset_timestamp == profile2.dataset_timestamp
+    assert profile1.session_id == profile2.session_id
+    assert profile1.to_summary() == profile2.to_summary()
+    assert profile1.name == profile2.name
+
+
+def test_pickle_with_dataset_timestamp():
+    session = Session("project", "pipeline", writers=[])
+    dt = datetime.datetime.fromtimestamp(1634939335, tz=datetime.timezone.utc)
+    logger = session.logger("", dataset_timestamp=dt)
+
+    logger.log_csv(
+        io.StringIO(
+            """a,b,c
+    1,1,1
+    1,1,2
+    4,4,3
+    """
+        )
+    )
+
+    profile = logger.profile
+    pickled_profile = pickle.dumps(profile)
+    unpickled_profile: DatasetProfile = pickle.loads(pickled_profile)
+
+    profiles_eq(profile, unpickled_profile)
+
+
+def test_serder_with_dataset_timezone():
+    session = Session("project", "pipeline", writers=[])
+    dt = datetime.datetime.fromtimestamp(1634939335, tz=datetime.timezone.utc)
+    logger = session.logger("", dataset_timestamp=dt)
+
+    logger.log_csv(
+        io.StringIO(
+            """a,b,c
+    1,1,1
+    1,1,2
+    4,4,3
+    """
+        )
+    )
+
+    profile = logger.profile
+    deserialized_profile = DatasetProfile.parse_delimited_single(profile.serialize_delimited())[1]
+
+    assert profile.dataset_timestamp == deserialized_profile.dataset_timestamp
+
+    assert set(profile.columns) == set(deserialized_profile.columns)
+    assert profile.constraints == deserialized_profile.constraints
+    assert profile.dataset_timestamp == deserialized_profile.dataset_timestamp

--- a/tests/unit/app/test_session.py
+++ b/tests/unit/app/test_session.py
@@ -50,9 +50,12 @@ def test_session_profile(df):
 
 
 def test_profile_df(df):
+    import datetime
+
     session = get_or_create_session()
-    log_profile = session.log_dataframe(df)
-    profile = session.profile_dataframe(df)
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    log_profile = session.log_dataframe(df, dataset_timestamp=dt)
+    profile = session.profile_dataframe(df, dataset_timestamp=dt)
 
     assert log_profile.name == profile.name
     assert log_profile.dataset_timestamp == profile.dataset_timestamp


### PR DESCRIPTION
## Description

We were never able to pickle our dataset profile objects. Our
integration work with Ray made this a pressing issue since Ray depends
heavily on calling pickle on objects. This change will enable pickle by
serializing/deserializing to/from protobuf.

In doing this, I stumbled upon other actual issues, like we apparently
don't deserialize from protobuf correctly in certain cases, like when we
have no set dataset_timestamp. It ends up as a 1970 date. I have two
tests that are omitted that I'm going to work on next to fix that
issue.





### General Checklist

* [x] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [x] (optional) Please add a label to your PR

    