### PR TITLE
Use github env variable for version

### DIFF
--- a/.github/workflows/push_release.yml
+++ b/.github/workflows/push_release.yml
@@ -73,6 +73,10 @@ jobs:
       uses: abatilo/actions-poetry@v2.0.0
       with:
         poetry-version: 1.1.5
+    - name: set VERSION github env var
+      run: |
+        # from refs/tags/v1.2.3 get 1.2.3
+        echo "VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')" >> $GITHUB_ENV
     - name: install bump2version
       run: |
         pip install bump2version
@@ -80,17 +84,17 @@ jobs:
       run: |
         # from refs/tags/v1.2.3 get 1.2.3
         VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
-        echo $VERSION
+        echo $env.VERSION
         # git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         # git config --local user.name "github-actions[bot]"
-        poetry run bump2version patch --verbose  --no-tag --new-version $VERSION
+        poetry run bump2version patch --verbose  --no-tag --new-version $env.VERSION
         
     - name: Create Pull Request
       id: cpr
       uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: Update version ${{ VERSION }}
+        commit-message: Update version ${{ env.VERSION }}
         committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
         author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
         signoff: false


### PR DESCRIPTION
## Description

Use env variable for version info, so we don't need to keep recomputing it and so it works in the commit-message for the version bump PR.

See https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-an-environment-variable for more details.

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    