### PR TITLE
Allow manual rerun of failed upload workflow

### DIFF
--- a/.github/workflows/push_release.yml
+++ b/.github/workflows/push_release.yml
@@ -4,6 +4,10 @@ name: Upload Python Package
 on:
   release:
     types: [ released, prereleased]
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Reason for rerun'
 
 jobs:
   deploy:


### PR DESCRIPTION
## Description

Allow rerun of failed workflow to upload release.

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    