### PR TITLE
Fix exception related to logging array like column values

### DIFF
--- a/src/whylogs/core/columnprofile.py
+++ b/src/whylogs/core/columnprofile.py
@@ -1,8 +1,6 @@
 """
 Defines the ColumnProfile class for tracking per-column statistics
 """
-import numpy as np
-import pandas as pd
 
 from whylogs.core.statistics import (
     CountersTracker,
@@ -103,11 +101,11 @@ class ColumnProfile:
         Add `value` to tracking statistics.
         """
         self.counters.increment_count()
-        if ColumnProfile._are_nulls(value):
+        if TypedDataConverter._are_nulls(value):
             self.schema_tracker.track(InferredType.Type.NULL)
             return
 
-        if ColumnProfile._is_array_like(value):
+        if TypedDataConverter._is_array_like(value):
             return
 
         # TODO: ignore this if we already know the data type
@@ -116,7 +114,7 @@ class ColumnProfile:
         # TODO: Implement real typed data conversion
         typed_data = TypedDataConverter.convert(value)
 
-        if not ColumnProfile._are_nulls(typed_data):
+        if not TypedDataConverter._are_nulls(typed_data):
             self.cardinality_tracker.update(typed_data)
             self.frequent_items.update(typed_data)
         dtype = TypedDataConverter.get_type(typed_data)
@@ -130,17 +128,6 @@ class ColumnProfile:
         self.number_tracker.track(typed_data)
 
         self.constraints.update(typed_data)
-
-    @staticmethod
-    def _is_array_like(value):
-        return isinstance(value, list) or isinstance(value, np.ndarray) or isinstance(value, pd.Series)
-
-    @staticmethod
-    def _are_nulls(value):
-        if ColumnProfile._is_array_like(value):
-            return all(pd.isnull(value))
-        else:
-            return pd.isnull(value)
 
     def _unique_count_summary(self) -> UniqueCountSummary:
         cardinality_summary = self.cardinality_tracker.to_summary(_UNIQUE_COUNT_BOUNDS_STD)

--- a/src/whylogs/core/types/typeddataconverter.py
+++ b/src/whylogs/core/types/typeddataconverter.py
@@ -64,7 +64,7 @@ class TypedDataConverter:
         dtype : TYPES
         """
         dtype = TYPES.UNKNOWN
-        if pd.isnull(typed_data):
+        if typed_data is None:
             dtype = TYPES.NULL
         elif isinstance(typed_data, bool):
             dtype = TYPES.BOOLEAN
@@ -74,4 +74,10 @@ class TypedDataConverter:
             dtype = TYPES.INTEGRAL
         elif isinstance(typed_data, str):
             dtype = TYPES.STRING
+        if isinstance(typed_data, list) or isinstance(typed_data, np.ndarray) or isinstance(typed_data, pd.Series):
+            if all(pd.isnull(typed_data)):
+                dtype = TYPES.NULL
+        elif pd.isnull(typed_data):
+            dtype = TYPES.NULL
+
         return dtype

--- a/src/whylogs/core/types/typeddataconverter.py
+++ b/src/whylogs/core/types/typeddataconverter.py
@@ -49,6 +49,17 @@ class TypedDataConverter:
         return data
 
     @staticmethod
+    def _is_array_like(value):
+        return isinstance(value, list) or isinstance(value, np.ndarray) or isinstance(value, pd.Series)
+
+    @staticmethod
+    def _are_nulls(value):
+        if TypedDataConverter._is_array_like(value):
+            return all(pd.isnull(value))
+        else:
+            return pd.isnull(value)
+
+    @staticmethod
     def get_type(typed_data):
         """
         Extract the data type of a value.  See `typeddataconvert.TYPES` for
@@ -74,10 +85,7 @@ class TypedDataConverter:
             dtype = TYPES.INTEGRAL
         elif isinstance(typed_data, str):
             dtype = TYPES.STRING
-        if isinstance(typed_data, list) or isinstance(typed_data, np.ndarray) or isinstance(typed_data, pd.Series):
-            if all(pd.isnull(typed_data)):
-                dtype = TYPES.NULL
-        elif pd.isnull(typed_data):
+        elif TypedDataConverter._are_nulls(typed_data):
             dtype = TYPES.NULL
 
         return dtype

--- a/tests/unit/core/test_columnprofile.py
+++ b/tests/unit/core/test_columnprofile.py
@@ -33,16 +33,6 @@ def test_all_numeric_types_get_tracked_by_number_tracker():
         assert c.number_tracker.count == len(values)
 
 
-@pytest.mark.parametrize("data,nulls_expected,_", _TEST_NULL_DATA)
-def test_are_nulls(data, nulls_expected, _):
-    null_count = 0
-    for val in data:
-        if ColumnProfile._are_nulls(val):
-            null_count += 1
-
-    assert null_count == nulls_expected
-
-
 @pytest.mark.parametrize("data,nulls_expected, expected_type", _TEST_NULL_DATA)
 def test_all_nulls_inferred_type_null(data, nulls_expected, expected_type):
     InferredType.Type

--- a/tests/unit/core/types/test_typeddataconverter.py
+++ b/tests/unit/core/types/test_typeddataconverter.py
@@ -1,4 +1,16 @@
+import numpy as np
+import pandas as pd
+import pytest
+
 from whylogs.core.types import TypedDataConverter
+
+_TEST_NULL_DATA = [
+    ([None, np.nan, None] * 3, 9),
+    ([pd.Series(data={"a": None, "b": None}, index=["x", "y"]), pd.Series(data={"c": None, "d": 1}, index=["x", "y"])], 2),
+    ([[None, np.nan], [np.nan], [None]], 3),
+    ([[None, 1], [None]], 1),
+    ([np.zeros(3)], 0),
+]
 
 
 def test_invalid_yaml_returns_string():
@@ -13,3 +25,13 @@ def test_invalid_yaml_returns_string():
         raise RuntimeError("Should raise exception")
     except yaml.scanner.ScannerError:
         pass
+
+
+@pytest.mark.parametrize("data,nulls_expected", _TEST_NULL_DATA)
+def test_are_nulls(data, nulls_expected):
+    null_count = 0
+    for val in data:
+        if TypedDataConverter._are_nulls(val):
+            null_count += 1
+
+    assert null_count == nulls_expected


### PR DESCRIPTION
## Description
Fixes #363 - whylogs should handle array like column values and log these as unknown types until we support these as first class types.

### General Checklist

* [x] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    