### PR TITLE
Fix strings as arrays pd.isnull bug

### DIFF
--- a/src/whylogs/core/columnprofile.py
+++ b/src/whylogs/core/columnprofile.py
@@ -125,6 +125,9 @@ class ColumnProfile:
             # for bool type first
             self.counters.increment_bool()
 
+        if TypedDataConverter._is_array_like(typed_data):
+            return
+
         self.number_tracker.track(typed_data)
 
         self.constraints.update(typed_data)

--- a/tests/unit/core/test_columnprofile.py
+++ b/tests/unit/core/test_columnprofile.py
@@ -50,7 +50,7 @@ def test_string_as_arrays_does_not_throw():
     data = "[0,0]"  # this string will be parsed as an array
     c.track(data)
     summary: ColumnSummary = c.to_summary()
-    assert summary.schema.inferred_type.type == InferredType.Type.NULL
+    assert summary.schema.inferred_type.type == InferredType.Type.UNKNOWN
 
 
 def test_mostly_nulls_inferred_type_not_null():

--- a/tests/unit/core/test_columnprofile.py
+++ b/tests/unit/core/test_columnprofile.py
@@ -44,6 +44,15 @@ def test_all_nulls_inferred_type_null(data, nulls_expected, expected_type):
     assert summary.schema.inferred_type.type == expected_type
 
 
+def test_string_as_arrays_does_not_throw():
+    InferredType.Type
+    c = ColumnProfile("col")
+    data = "[0,0]"  # this string will be parsed as an array
+    c.track(data)
+    summary: ColumnSummary = c.to_summary()
+    assert summary.schema.inferred_type.type == InferredType.Type.NULL
+
+
 def test_mostly_nulls_inferred_type_not_null():
     Type = InferredType.Type
     c = ColumnProfile("col")


### PR DESCRIPTION
## Description

If a string contained valid yaml representing an array we could end up passing that to string tracker which can't handle arrays. skip these trackers on parsed arrays until we have first class support for tracking complex types as column values.

### General Checklist

* [x] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    