### PR TITLE
Addresses #385 Bump log4j to 2.16.0 in java package

### DIFF
--- a/java/cli/build.gradle.kts
+++ b/java/cli/build.gradle.kts
@@ -29,8 +29,8 @@ dependencies {
     implementation(project(":core"))
 
     implementation("org.slf4j:slf4j-api:1.7.27")
-    implementation("org.apache.logging.log4j:log4j-core:2.15.0")
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.16.0")
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.16.0")
 
     implementation("org.apache.commons:commons-csv:1.8")
     implementation("commons-io:commons-io:2.6")


### PR DESCRIPTION
## Description

Update log4j dependency to 2.16.0

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    