### PR TITLE
Add shadowJar to build task to fix generating bundled whylogs-spark jar

### DIFF
--- a/java/spark-bundle/build.gradle.kts
+++ b/java/spark-bundle/build.gradle.kts
@@ -35,6 +35,10 @@ tasks.compileJava {
     enabled = false
 }
 
+tasks.build {
+    dependsOn(shadowJar)
+}
+
 val shadowJar: ShadowJar by tasks
 shadowJar.dependsOn(":spark:build")
 shadowJar.apply {


### PR DESCRIPTION
## Description

Fixes #405 by adding shadowJar to build task for whylogs-spark bundled jar

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [x] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [x] (optional) Please add a label to your PR

    