### PR TITLE
Add missing jsonschema dependency, add requests, relax python range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,16 @@ whylogs = 'whylogs.cli:main'
 whylogs-demo = 'whylogs.cli:demo_main'
 
 [tool.poetry.dependencies]
-python = ">=3.6.1,<3.10"
+python = ">=3.6.1,<3.11"
 click = ">=7.1.2"
+jsonschema = ">=3.2.0"
 python-dateutil = ">=2.8.1"
 protobuf = ">=3.15.5"
 pyyaml = ">=5.3.1"
 pandas = ">=1.0.0"
 marshmallow = ">=3.7.1"
 numpy = ">=1.18.0"
+requests = ">=2.22.0"
 whylabs-client = "^0.1.1.dev0"
 whylabs-datasketches = ">=2.2.0b1"
 boto3 = ">=1.14.1"


### PR DESCRIPTION
## Description

jsonschema is used in whylogs constraints but this dependency was not added to pyproject.toml which means that dependency is not correctly modeled and an install of whylogs won't pull down jsonschema.

Also added missing requests package, and increased the upper range on python.

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    