### PR TITLE
Change total row number computation

### DIFF
--- a/src/whylogs/core/datasetprofile.py
+++ b/src/whylogs/core/datasetprofile.py
@@ -123,8 +123,6 @@ class DatasetProfile:
 
         self.model_profile = model_profile
 
-        self.column_row_dict = dict()
-
         # Store Name attribute
         self._tags["name"] = name
 
@@ -167,8 +165,7 @@ class DatasetProfile:
 
     @property
     def total_row_number(self):
-        dict_counts = self.column_row_dict.values() if len(self.column_row_dict) else [0]
-        return max(dict_counts)
+        return max([col_prof.counters.count for col_prof in self.columns.values()])
 
     def add_output_field(self, field: Union[str, List[str]]):
         if self.model_profile is None:
@@ -264,11 +261,6 @@ class DatasetProfile:
             constraints = None if self.constraints is None else self.constraints[column_name]
             prof = ColumnProfile(column_name, constraints=constraints)
             self.columns[column_name] = prof
-
-            self.column_row_dict[column_name] = 0
-
-        # updating the map for every column name with increasing the number of tracked values
-        self.column_row_dict[column_name] += 1
 
         prof.track(data, character_list=None, token_method=None)
 

--- a/src/whylogs/core/datasetprofile.py
+++ b/src/whylogs/core/datasetprofile.py
@@ -165,7 +165,8 @@ class DatasetProfile:
 
     @property
     def total_row_number(self):
-        return max([col_prof.counters.count for col_prof in self.columns.values()])
+        column_counts = [col_prof.counters.count for col_prof in self.columns.values()] if len(self.columns) else [0]
+        return max(column_counts)
 
     def add_output_field(self, field: Union[str, List[str]]):
         if self.model_profile is None:


### PR DESCRIPTION
## Description

<!-- Description of changes -->
Changed the way of computing the total_row_number used for the Table shape constraints, using each column profile counters tracker instead of creating and updating a separate dictionary. This as well addresses the concern of merging two dataset profiles and possibility of inconsistencies when using a separate dictionary for tracking the total row number.

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    