### PR TITLE
Approach #2. Mapping constraint names to readable format

### DIFF
--- a/proto/src/constraints.proto
+++ b/proto/src/constraints.proto
@@ -128,6 +128,6 @@ message DatasetConstraintMsg {
   map<string, ValueConstraintMsgs> value_constraints = 2;
   map<string, SummaryConstraintMsgs> summary_constraints = 3;
   SummaryConstraintMsgs table_shape_constraints = 4;
-  map<string, ValueConstraintMsgs> multi_column_value_constraints = 5;
+  ValueConstraintMsgs multi_column_value_constraints = 5;
 }
 

--- a/src/whylogs/core/datasetprofile.py
+++ b/src/whylogs/core/datasetprofile.py
@@ -16,11 +16,7 @@ from smart_open import open
 from whylogs.core import ColumnProfile, MultiColumnProfile
 from whylogs.core.flatten_datasetprofile import flatten_summary
 from whylogs.core.model_profile import ModelProfile
-from whylogs.core.statistics.constraints import (
-    DatasetConstraints,
-    MultiColumnValueConstraints,
-    SummaryConstraints,
-)
+from whylogs.core.statistics.constraints import DatasetConstraints, SummaryConstraints
 from whylogs.core.summaryconverters import entropy_from_column_summary
 from whylogs.core.types import TypedDataConverter
 from whylogs.proto import (
@@ -101,7 +97,7 @@ class DatasetProfile:
         if columns is None:
             columns = {}
         if multi_columns is None:
-            multi_column_constraints = MultiColumnValueConstraints(constraints.multi_column_value_constraints) if constraints else None
+            multi_column_constraints = constraints.multi_column_value_constraints if constraints else None
             multi_columns = MultiColumnProfile(multi_column_constraints)
         if tags is None:
             tags = {}

--- a/src/whylogs/core/statistics/constraints.py
+++ b/src/whylogs/core/statistics/constraints.py
@@ -1272,7 +1272,7 @@ class MultiColumnValueConstraints(ValueConstraints):
 
     @staticmethod
     def from_protobuf(msg: ValueConstraintMsgs) -> "MultiColumnValueConstraints":
-        value_constraints = [MultiColumnValueConstraint.from_protobuf(c) for c in msg.constraints]
+        value_constraints = [MultiColumnValueConstraint.from_protobuf(c) for c in msg.multi_column_constraints]
         if len(value_constraints) > 0:
             return MultiColumnValueConstraints({v.name: v for v in value_constraints})
         return None


### PR DESCRIPTION
## Description

<!-- Description of changes -->
Maps used to map certain operations to easily understandable strings. The display_names are fully generated from the constraint value, field, operation etc. Previously created simple "name" property is still existent.

**This is the second approach, different than the one initially proposed**

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    