### PR TITLE
Revert "Matrix build for Spark and Scala versions (#447)"

### DIFF
--- a/.github/workflows/java-continuous-integration.yml
+++ b/.github/workflows/java-continuous-integration.yml
@@ -10,27 +10,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala-version: [2.11, 2.12]
-        spark-version: [2.4.7, 2.4.8]
-        include:
-          - os: ubuntu-latest
-            scala-version: 2.11
-            spark-version: 2.4.5
-          - os: ubuntu-latest
-            scala-version: 2.12
-            spark-version: 3.0.1
-          - os: ubuntu-latest
-            scala-version: 2.12
-            spark-version: 3.0.3
-          - os: ubuntu-latest
-            scala-version: 2.12
-            spark-version: 3.1.1
-          - os: ubuntu-latest
-            scala-version: 2.12
-            spark-version: 3.1.2
-          - os: ubuntu-latest
-            scala-version: 2.12
-            spark-version: 3.1.3
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -58,9 +37,6 @@ jobs:
         with:
           build-root-directory: java
           arguments: build
-        env:
-          SCALA_VERSION : ${{ matrix.scala-version }}
-          SPARK_VERSION : ${{ matrix.spark-version }}
       - name: Smoke test jar in client environment
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/push_release.yml
+++ b/.github/workflows/push_release.yml
@@ -3,34 +3,13 @@ name: Upload Whylogs Packages
 
 on:
   release:
-    types: [released, prereleased]
+    types: [ released, prereleased]
 
 jobs:
   deploy:
-    strategy:
-      matrix:
-        scala-version: [2.11, 2.12]
-        spark-version: [2.4.7, 2.4.8]
-        include:
-          - os: ubuntu-latest
-            scala-version: 2.11
-            spark-version: 2.4.5
-          - os: ubuntu-latest
-            scala-version: 2.12
-            spark-version: 3.0.1
-          - os: ubuntu-latest
-            scala-version: 2.12
-            spark-version: 3.0.3
-          - os: ubuntu-latest
-            scala-version: 2.12
-            spark-version: 3.1.1
-          - os: ubuntu-latest
-            scala-version: 2.12
-            spark-version: 3.1.2
-          - os: ubuntu-latest
-            scala-version: 2.12
-            spark-version: 3.1.3
+
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -90,8 +69,6 @@ jobs:
       env:
         ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY_ASCII }}
         ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
-        SCALA_VERSION : ${{ matrix.scala-version }}
-        SPARK_VERSION : ${{ matrix.spark-version }}
       run: ./gradlew publish -PossrhUsername=${{ secrets.NEXUS_TOKEN_USERNAME }} -PossrhPassword=${{ secrets.NEXUS_TOKEN_PASSWORD }}
       working-directory: java
 

--- a/.github/workflows/python-continuous-integration.yml
+++ b/.github/workflows/python-continuous-integration.yml
@@ -15,7 +15,8 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [ 3.6, 3.7, 3.8, 3.9]
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/java/spark-bundle/build.gradle.kts
+++ b/java/spark-bundle/build.gradle.kts
@@ -14,8 +14,8 @@ plugins {
     id("com.github.johnrengelman.shadow") version ("5.2.0")
 }
 
-val scalaVersion = System.getenv("SCALA_VERSION") ?: "2.12"
-val sparkVersion = System.getenv("SPARK_VERSION") ?: "3.1.1"
+val scalaVersion = project.properties.getOrDefault("scalaVersion", "2.12")
+val sparkVersion = project.properties.getOrDefault("sparkVersion", "3.1.1") as String
 val artifactBaseName = "whylogs-spark-bundle_${sparkVersion}-scala_$scalaVersion"
 val versionString = rootProject.version
 

--- a/java/spark/build.gradle.kts
+++ b/java/spark/build.gradle.kts
@@ -19,8 +19,8 @@ spotless {
     }
 }
 
-val scalaVersion = System.getenv("SCALA_VERSION") ?: "2.12"
-val sparkVersion = System.getenv("SPARK_VERSION") ?: "3.1.1"
+val scalaVersion = project.properties.getOrDefault("scalaVersion", "2.12")
+val sparkVersion = project.properties.getOrDefault("sparkVersion", "3.1.1") as String
 val artifactBaseName = "${rootProject.name}-spark_$sparkVersion-scala_$scalaVersion"
 
 tasks.jar {
@@ -32,7 +32,7 @@ tasks.withType<Jar> {
 }
 
 fun scalaPackage(groupId: String, name: String, version: String) =
-    "$groupId:${name}_${scalaVersion}:${version}"
+    "$groupId:${name}_$scalaVersion:$version"
 
 sourceSets {
     main {


### PR DESCRIPTION
This reverts commit d6d07c010b858c9d2335f8e86f824d3b34e1030a.

## Description

The matrix build also unintendedly publishes the python package multiple times for each combination of spark/scala. Reverting to unblock the release workflow. 

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    