### PR TITLE
Rounding error for scientific notation on Chi2 test

### DIFF
--- a/src/whylogs/viewer/templates/index-hbs-cdn-all-in-for-jupyter-notebook.html
+++ b/src/whylogs/viewer/templates/index-hbs-cdn-all-in-for-jupyter-notebook.html
@@ -1134,7 +1134,7 @@
 
         if (cheqValueTypeNumber(referenceProfile, drift_from_ref)) {
           driftCount++
-          const driftFromRefNumber = drift_from_ref % 1 ? fixNumberTo(drift_from_ref, 2) : drift_from_ref
+          const driftFromRefNumber = drift_from_ref.toPrecision(2)
           const circleColor = Object.values(drifts)[countOfDrifts(driftFromRefNumber, 3)].colorClass
 
           $(document).ready(() => {


### PR DESCRIPTION
## Description

Previous rounding method was yielding wrong results for scientific notation values.

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    