### PR TITLE
Don't slice using negative indexes to filter  bar charts

### DIFF
--- a/src/whylogs/viewer/templates/index-hbs-cdn-all-in-jupyter-bar-chart.html
+++ b/src/whylogs/viewer/templates/index-hbs-cdn-all-in-jupyter-bar-chart.html
@@ -203,7 +203,12 @@
      
     const findAndDeleteUndefined = (axisData) => {
       const undefinedAxisIndex = axisData.findIndex((axis) => axis === undefined)
-      return [...axisData.slice(0, undefinedAxisIndex), ...axisData.slice(undefinedAxisIndex + 1)]
+      if (undefinedAxisIndex == -1) {
+        return axisData;
+      }
+
+      const result = [...axisData.slice(0, undefinedAxisIndex), ...axisData.slice(undefinedAxisIndex + 1)]
+      return result
     }
 
     const filterAndSortChartData = (overlappedHistogramData, histogramData) => {
@@ -330,6 +335,7 @@
     
         svgEl.append("g")
           .attr("transform", `translate(${MARGIN.LEFT}, 0)`)
+          .attr("id", "g1")
           .call(yAxis)
           .call(g => g.select(".domain").remove())
           .call(g => g.selectAll(".tick line")
@@ -362,6 +368,7 @@
     
         svgEl.append("g")
             .attr("transform", `translate(0,${SVG_HEIGHT - MARGIN.BOTTOM})`)
+            .attr("id", "g2")
             .call(xAxis)
             .call(g => g.select(".domain").remove())
             .call(g => g.selectAll(".tick line").remove())
@@ -380,11 +387,13 @@
           .range(rectColors)
     
         svgEl.append("g")
+           .attr("id", "g3")
            .selectAll("g")
            .data(data)
            .enter()
            .append("g")
              .attr("transform", function(d) { return "translate(" + xScale(d?.group) + ",0)"; })
+             .attr("id", "g4")
            .selectAll("rect")
            .data(function(d) { return subgroups.map(function(key) { return {key: key, value: d && d[key]}; }); })
            .enter().append("rect")
@@ -398,6 +407,7 @@
     
          return svgEl._groups[0][0].outerHTML;
       }    
+
 
       const profileFromCSVfile = {{{reference_profile_from_whylogs}}}
 


### PR DESCRIPTION
## Description

We search for undefined values to filter them, but then also use the -1 to slice the arrays, resulting in wrapping around to the first element and double rendering some bins on our NotebookProfilerViewer charts. The double rendering appears darker with the use of opacity.

The fix is to not try to change the data if there are no undefined values in the findAndDeleteUndefined  function.

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    