### PR TITLE
remove % symbol for total count of missing values

### DIFF
--- a/src/whylogs/viewer/templates/index-hbs-cdn-all-in-for-jupyter-notebook.html
+++ b/src/whylogs/viewer/templates/index-hbs-cdn-all-in-for-jupyter-notebook.html
@@ -1091,7 +1091,7 @@
      Handlebars.registerHelper("missingCells", function (properties) {
        const {value, newValue, suffixe} = abbreviate_number(referenceProfile.properties.missing_cells)
        if (typeof value !== 'undefined' && typeof newValue !== 'undefined'  && typeof suffixe !== 'undefined' ) {
-        return numberWithSuffixe(value, valueSuffixe(`(${newValue}%)`), suffixe);
+        return numberWithSuffixe(value, valueSuffixe(`${newValue}`), suffixe);
        }
        return numberWithSuffixe(0, valueNumber(0), valueNumber(''));
      });


### PR DESCRIPTION
## Description

Missing value count was displayed between parenthesis and with a % sign at the end. Removed both.

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    