### PR TITLE
pvalue=0 needs to be evaluated as True

### DIFF
--- a/src/whylogs/viewer/templates/index-hbs-cdn-all-in-for-jupyter-notebook.html
+++ b/src/whylogs/viewer/templates/index-hbs-cdn-all-in-for-jupyter-notebook.html
@@ -1091,7 +1091,7 @@
      Handlebars.registerHelper("missingCells", function (properties) {
        const {value, newValue, suffixe} = abbreviate_number(referenceProfile.properties.missing_cells)
        if (typeof value !== 'undefined' && typeof newValue !== 'undefined'  && typeof suffixe !== 'undefined' ) {
-        return numberWithSuffixe(value, valueSuffixe(`(${newValue}%)`), suffixe);
+        return numberWithSuffixe(value, valueSuffixe(`${newValue}`), suffixe);
        }
        return numberWithSuffixe(0, valueNumber(0), valueNumber(''));
      });

--- a/src/whylogs/viz/utils/profile_viz_calculations.py
+++ b/src/whylogs/viz/utils/profile_viz_calculations.py
@@ -143,7 +143,7 @@ def add_drift_val_to_ref_profile_json(target_profile, reference_profile, referen
                     frequent_items=reference_frequent_items_sketch.to_summary(), total_count=ref_total_count
                 )
                 chi_squared_p_value = compute_chi_squared_test_p_value(target_message, reference_message)
-                if chi_squared_p_value.chi_squared_test:
+                if chi_squared_p_value.chi_squared_test is not None:
                     reference_profile_json["columns"][target_col_name]["drift_from_ref"] = chi_squared_p_value.chi_squared_test
                 else:
                     reference_profile_json["columns"][target_col_name]["drift_from_ref"] = None


### PR DESCRIPTION
## Description

When pvalue=0, drift was returned as `None`; As 0 is a legit value, drift needs to be 0, and not None.

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    