### PR TITLE
dont crash on timedelta64 values

### DIFF
--- a/src/whylogs/core/columnprofile.py
+++ b/src/whylogs/core/columnprofile.py
@@ -2,8 +2,6 @@
 Defines the ColumnProfile class for tracking per-column statistics
 """
 
-from pandas.api.types import is_timedelta64_dtype
-
 from whylogs.core.statistics import (
     CountersTracker,
     NumberTracker,
@@ -130,8 +128,8 @@ class ColumnProfile:
             # for bool type first
             self.counters.increment_bool()
 
-        # prevent errors in number tracker on timedelta64
-        if TypedDataConverter._is_array_like(typed_data) or is_timedelta64_dtype(typed_data):
+        # prevent errors in number tracker on unknown types
+        if TypedDataConverter._is_array_like(typed_data) or dtype == _TYPES.UNKNOWN:
             return
 
         self.number_tracker.track(typed_data)

--- a/src/whylogs/core/columnprofile.py
+++ b/src/whylogs/core/columnprofile.py
@@ -2,6 +2,8 @@
 Defines the ColumnProfile class for tracking per-column statistics
 """
 
+from pandas.api.types import is_timedelta64_dtype
+
 from whylogs.core.statistics import (
     CountersTracker,
     NumberTracker,
@@ -128,7 +130,8 @@ class ColumnProfile:
             # for bool type first
             self.counters.increment_bool()
 
-        if TypedDataConverter._is_array_like(typed_data):
+        # prevent errors in number tracker on timedelta64
+        if TypedDataConverter._is_array_like(typed_data) or is_timedelta64_dtype(typed_data):
             return
 
         self.number_tracker.track(typed_data)

--- a/src/whylogs/core/types/typeddataconverter.py
+++ b/src/whylogs/core/types/typeddataconverter.py
@@ -4,6 +4,7 @@ TODO: implement this using something other than yaml
 """
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_timedelta64_dtype
 import yaml
 
 from whylogs.proto import InferredType
@@ -82,7 +83,8 @@ class TypedDataConverter:
         elif isinstance(typed_data, FLOAT_TYPES):
             dtype = TYPES.FRACTIONAL
         elif isinstance(typed_data, INTEGRAL_TYPES):
-            dtype = TYPES.INTEGRAL
+            if not is_timedelta64_dtype(typed_data):
+                dtype = TYPES.INTEGRAL
         elif isinstance(typed_data, str):
             dtype = TYPES.STRING
         elif TypedDataConverter._are_nulls(typed_data):

--- a/src/whylogs/core/types/typeddataconverter.py
+++ b/src/whylogs/core/types/typeddataconverter.py
@@ -4,8 +4,8 @@ TODO: implement this using something other than yaml
 """
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_timedelta64_dtype
 import yaml
+from pandas.api.types import is_timedelta64_dtype
 
 from whylogs.proto import InferredType
 

--- a/tests/component/app/test_logger.py
+++ b/tests/component/app/test_logger.py
@@ -3,9 +3,12 @@
 import datetime
 import os
 
+import numpy as np
 import pandas as pd
+import pytest
 
 from whylogs import DatasetProfile
+from whylogs.app import Session
 from whylogs.app.config import SessionConfig, WriterConfig
 from whylogs.app.session import get_or_create_session, session_from_config
 from whylogs.app.writers import writer_from_config
@@ -13,6 +16,9 @@ from whylogs.util import time
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 
+_TEST_DATA_TYPES = [
+    (pd.DataFrame([[np.timedelta64(0, 'ns')], [np.timedelta64(1, 'ns')]], columns=['duration'])),
+]
 
 def test_write_template_path():
     data_time = time.from_utc_ms(9999)
@@ -40,6 +46,14 @@ def test_config_api(tmpdir):
         logger.log_dataframe(pd.DataFrame())
     session.close()
 
+@pytest.mark.parametrize("data", _TEST_DATA_TYPES)
+def test_numpy_types_do_not_throw(data):
+    # create a session with no writers
+    session = Session(writers=[])
+
+    with session.logger("test_name") as logger:
+        logger.log_dataframe(data)
+    session.close()
 
 def test_load_config(tmpdir):
     original_dir = os.curdir

--- a/tests/component/app/test_logger.py
+++ b/tests/component/app/test_logger.py
@@ -17,8 +17,9 @@ from whylogs.util import time
 script_dir = os.path.dirname(os.path.realpath(__file__))
 
 _TEST_DATA_TYPES = [
-    (pd.DataFrame([[np.timedelta64(0, 'ns')], [np.timedelta64(1, 'ns')]], columns=['duration'])),
+    (pd.DataFrame([[np.timedelta64(0, "ns")], [np.timedelta64(1, "ns")]], columns=["duration"])),
 ]
+
 
 def test_write_template_path():
     data_time = time.from_utc_ms(9999)
@@ -46,6 +47,7 @@ def test_config_api(tmpdir):
         logger.log_dataframe(pd.DataFrame())
     session.close()
 
+
 @pytest.mark.parametrize("data", _TEST_DATA_TYPES)
 def test_numpy_types_do_not_throw(data):
     # create a session with no writers
@@ -54,6 +56,7 @@ def test_numpy_types_do_not_throw(data):
     with session.logger("test_name") as logger:
         logger.log_dataframe(data)
     session.close()
+
 
 def test_load_config(tmpdir):
     original_dir = os.curdir

--- a/tests/unit/core/types/test_typeddataconverter.py
+++ b/tests/unit/core/types/test_typeddataconverter.py
@@ -27,8 +27,9 @@ def test_invalid_yaml_returns_string():
     except yaml.scanner.ScannerError:
         pass
 
+
 def test_timedelta64_type():
-    typed_data = np.timedelta64(0, 'ns')
+    typed_data = np.timedelta64(0, "ns")
 
     dtype = TypedDataConverter.get_type(typed_data)
     assert dtype == InferredType.Type.UNKNOWN

--- a/tests/unit/core/types/test_typeddataconverter.py
+++ b/tests/unit/core/types/test_typeddataconverter.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from whylogs.core.types import TypedDataConverter
+from whylogs.proto import InferredType
 
 _TEST_NULL_DATA = [
     ([None, np.nan, None] * 3, 9),
@@ -25,6 +26,12 @@ def test_invalid_yaml_returns_string():
         raise RuntimeError("Should raise exception")
     except yaml.scanner.ScannerError:
         pass
+
+def test_timedelta64_type():
+    typed_data = np.timedelta64(0, 'ns')
+
+    dtype = TypedDataConverter.get_type(typed_data)
+    assert dtype == InferredType.Type.UNKNOWN
 
 
 @pytest.mark.parametrize("data,nulls_expected", _TEST_NULL_DATA)


### PR DESCRIPTION
## Description
Fixes #500 

We pass timedelta64 values to number tracker where it throws an error:
```
E       numpy.core._exceptions._UFuncBinaryResolutionError: ufunc 'subtract' cannot use operands with types dtype('<m8[ns]') and dtype('float64')

src/whylogs/core/statistics/datatypes/variancetracker.py:39: UFuncTypeError
```

We skip other time values and unknown types from tracking, so adding a check for this type and also skipping processing with number tracker.

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    