### PR TITLE
Fix single-key segmentation bug

### DIFF
--- a/src/whylogs/app/logger.py
+++ b/src/whylogs/app/logger.py
@@ -591,8 +591,12 @@ class Logger:
 
         for each_segment in segments:
             try:
-                segment_df = grouped_data.get_group(each_segment)
-                segment_tags = [{"key": self.segments[i], "value": each_segment[i]} for i in range(len(self.segments))]
+                if len(self.segments) == 1:
+                    segment_df = grouped_data.get_group(each_segment)
+                    segment_tags = [{"key": self.segments[0], "value": each_segment}]
+                else:
+                    segment_df = grouped_data.get_group(each_segment)
+                    segment_tags = [{"key": self.segments[i], "value": each_segment[i]} for i in range(len(self.segments))]
 
                 self.log_df_segment(segment_df, segment_tags)
             except KeyError:

--- a/tests/unit/app/test_segments.py
+++ b/tests/unit/app/test_segments.py
@@ -161,4 +161,3 @@ def test_log_multiple_segments(tmpdir):
     with session.logger("image_test", segments=["x", "y"]) as logger:
         logger.log_segments(df)
         assert len(logger.segmented_profiles) == 9
-        

--- a/tests/unit/app/test_segments.py
+++ b/tests/unit/app/test_segments.py
@@ -1,16 +1,18 @@
 import datetime
 import os
+import shutil
+from logging import getLogger
+
 import pandas as pd
 import pytest
-import shutil
 from freezegun import freeze_time
-from logging import getLogger
 
 from whylogs.app.config import SessionConfig, WriterConfig
 from whylogs.app.logger import _TAG_PREFIX, _TAG_VALUE
 from whylogs.app.session import session_from_config
 
 TEST_LOGGER = getLogger(__name__)
+
 
 def test_segments(df_lending_club, tmpdir):
     output_path = tmpdir.mkdir("whylogs")
@@ -81,12 +83,12 @@ def test_segments_single_key(df_lending_club, tmpdir):
     TEST_LOGGER.info(f"Unique home_ownership values are: {home_ownership_values}")
     with session.logger("test", segments=["home_ownership"], cache_size=1) as logger:
         logger.log_dataframe(df_lending_club)
-        
+
         profiles1 = logger.segmented_profiles
         assert len(profiles1) == len(home_ownership_values)
         for _, prof in profiles1.items():
-            assert prof.tags['whylogs.tag.home_ownership'] in home_ownership_values
-            
+            assert prof.tags["whylogs.tag.home_ownership"] in home_ownership_values
+
     with session.logger("test2") as logger:
         logger.log_dataframe(df_lending_club, segments=["home_ownership"])
         profiles2 = logger.segmented_profiles

--- a/tests/unit/app/test_segments.py
+++ b/tests/unit/app/test_segments.py
@@ -161,3 +161,4 @@ def test_log_multiple_segments(tmpdir):
     with session.logger("image_test", segments=["x", "y"]) as logger:
         logger.log_segments(df)
         assert len(logger.segmented_profiles) == 9
+        


### PR DESCRIPTION
## Description

When segmenting on a single column, segmentation was made, and tagged, based on the first character of said column.
Adding a check on the length of segments, in order to get the proper df subgroup and tags

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    