### PR TITLE
Fixes bumpversion to search and replace

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -14,9 +14,17 @@ values =
 	prod
 
 [bumpversion:file:src/whylogs/_version.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
 
 [bumpversion:file:docs/conf.py]
+search = version = "{current_version}"
+replace = version = "{new_version}"
 
 [bumpversion:file:Makefile]
+search = version := {current_version}
+replace = version := {new_version}
 
 [bumpversion:file:pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"


### PR DESCRIPTION
## Description

### Problem: 
Bump version workflow is broken #489 caused both the version number and a dependency version to be implement. This was due to the search and replace doing a simple search for just the numbers. 

This caused one of the dependencies also on 0.7.0 to be matched and replaced. 

### Fix 
bumpversion has a search and replace keywords that default to:
```
search={current_version}
replace={new_version}
```

Since we have several different file formats each of those needed to be specified 

### Future Maintenance needed
None

### Testing
Manually tested it with the cause that failed (version 0.7.0). Please comment what tests you believe would be helpful on this. 

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [X] Conform by the style guides, by using formatter
* [na] Documentation updated
* [X ] (optional) Please add a label to your PR

## Helpful References
https://pypi.org/project/bumpversion/

    