### PR TITLE
Cache poetry dependencies from lock file

### DIFF
--- a/.github/workflows/python-continuous-integration.yml
+++ b/.github/workflows/python-continuous-integration.yml
@@ -33,11 +33,11 @@ jobs:
         version: '3.19.4'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set up Poetry cache for Python dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: ${{ runner.os }}-poetry-
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pypoetry
+        key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: ${{ runner.os }}-poetry-
     - name: Install dependencies
       run: make install
     - name: Run build, style, and lint checks

--- a/.github/workflows/python-continuous-integration.yml
+++ b/.github/workflows/python-continuous-integration.yml
@@ -32,13 +32,12 @@ jobs:
       with:
         version: '3.19.4'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Cache Python dependencies
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-dev.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+    - name: Set up Poetry cache for Python dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: ${{ runner.os }}-poetry-
     - name: Install dependencies
       run: make install
     - name: Run build, style, and lint checks

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ test-notebooks: ## Run tests for the notebooks
 
 install: ## Install all dependencies with poetry.
 	@$(call i, Installing dependencies)
+	$(source HOME/.poetry/env)
 	poetry install
 
 coverage: ## Generate test coverage reports.


### PR DESCRIPTION
## Description

The old cache was referencing pip and non existing file requirements-dev.txt

Fix by replacing with poetry cache and the poetry.lock file.

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    