### PR TITLE
Update protoc install action in push_release.yml to match tests

### DIFF
--- a/.github/workflows/push_release.yml
+++ b/.github/workflows/push_release.yml
@@ -23,8 +23,9 @@ jobs:
         poetry-version: 1.1.5
 
     - name: Install Protoc
-      uses: arduino/setup-protoc@master
+      uses: arduino/setup-protoc@v1
       with:
+        version: '3.19.4'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Cache Python dependencies
       uses: actions/cache@v2


### PR DESCRIPTION
## Description

Follow up from yanked release 0.7.3, this should resolve that issue where we pulled latest protoc to build the released wheels which then referenced the new builder type in protobuf which is not backwards compatible with older protobuf.

This now matches our python ci config.

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    