### PR TITLE
restrict bin count based on numeric precision on kll floats sketch

### DIFF
--- a/src/whylogs/core/summaryconverters.py
+++ b/src/whylogs/core/summaryconverters.py
@@ -124,6 +124,9 @@ def single_quantile_from_sketch(sketch: kll_floats_sketch, quantile: float):
 def _calculate_bins(end: float, start: float, n: int, avg_per_bucket: float, max_buckets: int):
     # Include the max value in the right-most bin
     end += abs(end) * 1e-7
+    abs_end = abs(end)
+    abs_start = abs(start)
+    max_magnitude = max(abs_end, abs_start)
 
     # the kll_floats_sketch use 32bit floats, so we check precision against np.float32
     float_mantissa_bits = np.finfo(np.float32).nmant
@@ -133,7 +136,7 @@ def _calculate_bins(end: float, start: float, n: int, avg_per_bucket: float, max
     width = (end - start) / n_buckets
 
     # check for precision of width with respect to float_mantissa_bits and bin width:
-    bits_in_max = math.floor(math.log2(end))
+    bits_in_max = math.floor(math.log2(max_magnitude))
     width_bits = math.floor(math.log2((end - start) / n_buckets))
     logger.debug(f"bits_in_max is: {bits_in_max}")
     logger.debug(f"width_bits is: {width_bits}")
@@ -143,7 +146,7 @@ def _calculate_bins(end: float, start: float, n: int, avg_per_bucket: float, max
         logger.info(f"Width must be larger than {bits_in_width} bits.")
         new_buckets = math.floor((end - start) / math.pow(2, bits_in_width))
         logger.warn(f"Avoiding bin edge collisions by resizing to {new_buckets} buckets")
-        n_buckets = new_buckets
+        n_buckets = max(new_buckets, 1)
         width = (end - start) / n_buckets
 
     # Calculate histograms from the Probability Mass Function

--- a/src/whylogs/core/summaryconverters.py
+++ b/src/whylogs/core/summaryconverters.py
@@ -145,7 +145,7 @@ def _calculate_bins(end: float, start: float, n: int, avg_per_bucket: float, max
         new_buckets = math.floor((end - start) / min_interval)
         logger.warning(
             f"A bin width of {width} won't work with values in range of [{start}, {end}] "
-            f"because numbers closer to eachother than {int(min_interval)} might not be distinct "
+            f"because numbers closer to each other than {int(min_interval)} might not be distinct "
             "when passed as float32: avoiding bin edge collisions by resizing from: "
             f"{n_buckets} to: {new_buckets} histogram buckets in summary."
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,16 @@ def df():
 
 
 @pytest.fixture(scope="session")
+def df_single():
+    return pd.DataFrame((np.random.randint(low=6092996828, high=6093000284, size=(100, 1))), columns=["id"], dtype=np.int64)
+
+
+@pytest.fixture(scope="session")
+def df_two_int_col():
+    return pd.DataFrame((np.random.randint(low=6092996828, high=6093000284, size=(100, 2))), columns=["id", "A"])
+
+
+@pytest.fixture(scope="session")
 def test_data_path():
 
     imag_path = os.path.join(_MY_DIR, os.pardir, "testdata")

--- a/tests/unit/app/test_session.py
+++ b/tests/unit/app/test_session.py
@@ -1,5 +1,6 @@
 from logging import getLogger
 
+import pandas as pd
 import pytest
 
 from whylogs.app.config import SessionConfig
@@ -76,6 +77,19 @@ def test_session_profile_small(df_single):
         flat_summary = summary["summary"]
         TEST_LOGGER.info(f"logged {i} rows and summary is {flat_summary}")
         assert len(flat_summary) == 1
+
+
+def test_session_profile_negative_ints():
+    df = pd.DataFrame(range(-22335544310, -22335542310), columns=["negative"])
+    session = session_from_config(SessionConfig("default-project", "default-pipeline", [], False))
+    profile = session.log_dataframe(df)
+    TEST_LOGGER.debug(f"logged df: {df.shape} ")
+    TEST_LOGGER.debug(f"logged profile: {profile} ")
+    summary = profile.flat_summary()
+    TEST_LOGGER.debug(f"logged summary: {summary} ")
+    flat_summary = summary["summary"]
+    TEST_LOGGER.debug(f"logged flat_summary: {flat_summary} ")
+    assert len(flat_summary) == 1
 
 
 def test_session_profile_two_column(df_two_int_col):

--- a/tests/unit/app/test_session.py
+++ b/tests/unit/app/test_session.py
@@ -1,5 +1,6 @@
 from logging import getLogger
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -55,8 +56,10 @@ def test_session_profile(df):
 
 def test_session_profile_single_column(df_single):
     TEST_LOGGER.debug(f"About to log {df_single.describe()} with columns {df_single.columns}")
-    session = session_from_config(SessionConfig("default-project", "default-pipeline", [], False))
-    profile = session.log_dataframe(df_single)
+    # session = session_from_config(SessionConfig("default-project", "default-pipeline", [], False))
+    session = get_or_create_session()
+    df = pd.DataFrame(range(22335544310, 22335545310), columns=["A"])
+    profile = session.log_dataframe(df)  # df_single)
     assert profile is not None
 
     summary = profile.flat_summary()
@@ -84,7 +87,30 @@ def test_session_profile_negative_ints():
     session = session_from_config(SessionConfig("default-project", "default-pipeline", [], False))
     profile = session.log_dataframe(df)
     TEST_LOGGER.debug(f"logged df: {df.shape} ")
-    TEST_LOGGER.debug(f"logged profile: {profile} ")
+    summary = profile.flat_summary()
+    TEST_LOGGER.debug(f"logged summary: {summary} ")
+    flat_summary = summary["summary"]
+    TEST_LOGGER.debug(f"logged flat_summary: {flat_summary} ")
+    assert len(flat_summary) == 1
+
+
+def test_session_profile_negative_to_zero():
+    df = pd.DataFrame(range(-1000, 1), columns=["negative_to_zero"])
+    session = session_from_config(SessionConfig("default-project", "default-pipeline", [], False))
+    profile = session.log_dataframe(df)
+    TEST_LOGGER.debug(f"logged df: {df.shape} ")
+    summary = profile.flat_summary()
+    TEST_LOGGER.debug(f"logged summary: {summary} ")
+    flat_summary = summary["summary"]
+    TEST_LOGGER.debug(f"logged flat_summary: {flat_summary} ")
+    assert len(flat_summary) == 1
+
+
+def test_session_profile_all_close_to_zero():
+    df = pd.DataFrame(np.arange(-1.00000001e-20, -1e-20, 1e-30), columns=["close_to_zero"])
+    session = session_from_config(SessionConfig("default-project", "default-pipeline", [], False))
+    profile = session.log_dataframe(df)
+    TEST_LOGGER.debug(f"logged df: {df.shape} ")
     summary = profile.flat_summary()
     TEST_LOGGER.debug(f"logged summary: {summary} ")
     flat_summary = summary["summary"]

--- a/tests/unit/app/test_session.py
+++ b/tests/unit/app/test_session.py
@@ -1,3 +1,5 @@
+from logging import getLogger
+
 import pytest
 
 from whylogs.app.config import SessionConfig
@@ -8,6 +10,8 @@ from whylogs.app.session import (
     reset_default_session,
     session_from_config,
 )
+
+TEST_LOGGER = getLogger(__name__)
 
 
 def test_get_global_session():
@@ -27,7 +31,6 @@ def test_reset():
 
 
 def test_session_log_dataframe(df):
-    pass
 
     session = session_from_config(SessionConfig("default-project", "default-pipeline", [], False))
     session.log_dataframe(df)
@@ -47,6 +50,44 @@ def test_session_profile(df):
 
     flat_summary = summary["summary"]
     assert len(flat_summary) == 4
+
+
+def test_session_profile_single_column(df_single):
+    TEST_LOGGER.debug(f"About to log {df_single.describe()} with columns {df_single.columns}")
+    session = session_from_config(SessionConfig("default-project", "default-pipeline", [], False))
+    profile = session.log_dataframe(df_single)
+    assert profile is not None
+
+    summary = profile.flat_summary()
+
+    flat_summary = summary["summary"]
+    assert len(flat_summary) == 1
+
+
+def test_session_profile_small(df_single):
+    TEST_LOGGER.debug(f"About to log {df_single.describe()} with columns {df_single.columns}")
+    session = session_from_config(SessionConfig("default-project", "default-pipeline", [], False))
+    for i in range(1, 5):
+        profile = session.log_dataframe(df_single.head(i))
+        assert profile is not None
+
+        summary = profile.flat_summary()
+
+        flat_summary = summary["summary"]
+        TEST_LOGGER.info(f"logged {i} rows and summary is {flat_summary}")
+        assert len(flat_summary) == 1
+
+
+def test_session_profile_two_column(df_two_int_col):
+    TEST_LOGGER.debug(f"About to log {df_two_int_col.describe()} with columns {df_two_int_col.columns}")
+    session = session_from_config(SessionConfig("default-project", "default-pipeline", [], False))
+    profile = session.log_dataframe(df_two_int_col)
+    assert profile is not None
+
+    summary = profile.flat_summary()
+
+    flat_summary = summary["summary"]
+    assert len(flat_summary) == 2
 
 
 def test_profile_df(df):


### PR DESCRIPTION
## Description

Addresses #518 by reducing the bin count if the width of the bins is lower than rounding of the values.

This is a mitigation for the conversion of profile to summary which uses a default bin count that doesn't work in some cases. We still could use some follow up to better track larger integers not well captured by the floats sketch.

### General Checklist

* [x] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    