### PR TITLE
Bug/np float issue

### DIFF
--- a/src/whylogs/core/types/typeddataconverter.py
+++ b/src/whylogs/core/types/typeddataconverter.py
@@ -13,7 +13,7 @@ TYPES = InferredType.Type
 # Dictionary mapping from type Number to type name
 TYPENUM_TO_NAME = {k: v for v, k in InferredType.Type.items()}
 INTEGRAL_TYPES = (int, np.integer)
-FLOAT_TYPES = (float, np.float, np.float32, np.float64)
+FLOAT_TYPES = (float, np.floating)
 
 
 class TypedDataConverter:

--- a/src/whylogs/core/types/typeddataconverter.py
+++ b/src/whylogs/core/types/typeddataconverter.py
@@ -13,7 +13,7 @@ TYPES = InferredType.Type
 # Dictionary mapping from type Number to type name
 TYPENUM_TO_NAME = {k: v for v, k in InferredType.Type.items()}
 INTEGRAL_TYPES = (int, np.integer)
-FLOAT_TYPES = (float, np.float)
+FLOAT_TYPES = (float, np.float, np.float32, np.float64)
 
 
 class TypedDataConverter:

--- a/tests/unit/core/statistics/datatypes/test_floattracker.py
+++ b/tests/unit/core/statistics/datatypes/test_floattracker.py
@@ -68,6 +68,7 @@ def test_merge_floattrackers_should_addup():
     merge_second = second.merge(first)
     assert merge_second.__dict__ == merge_first.__dict__
 
+
 def test_merge_floattrackers_should_addup():
     float32_tracker = FloatTracker()
     float32_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
@@ -83,12 +84,6 @@ def test_merge_floattrackers_should_addup():
     vals2 = [4.0, 5.0, 6.0]
     for val in vals2:
         simple_tracker.update(val)
-
-    assert simple_tracker.count == len(vals2)
-    assert simple_tracker.max == max(vals2)
-    assert simple_tracker.min == min(vals2)
-    assert simple_tracker.sum == sum(vals2)
-
 
     merge_32_and_simple = float32_array.tolist() + vals2
     merge_first_tracker_32_and_simple = float32_tracker.merge(simple_tracker)

--- a/tests/unit/core/statistics/datatypes/test_floattracker.py
+++ b/tests/unit/core/statistics/datatypes/test_floattracker.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from whylogs.core.statistics.datatypes import FloatTracker
 
 

--- a/tests/unit/core/statistics/datatypes/test_floattracker.py
+++ b/tests/unit/core/statistics/datatypes/test_floattracker.py
@@ -1,3 +1,4 @@
+import numpy as np
 from whylogs.core.statistics.datatypes import FloatTracker
 
 
@@ -11,6 +12,28 @@ def test_values_are_min_max():
     assert first.max == max(vals1)
     assert first.min == min(vals1)
     assert first.sum == sum(vals1)
+
+
+def test_np_float():
+    first = FloatTracker()
+    float32_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    for val in float32_array:
+        first.update(val)
+
+    assert first.count == len(float32_array)
+    assert first.max == max(float32_array)
+    assert first.min == min(float32_array)
+    assert first.sum == sum(float32_array)
+
+    second = FloatTracker()
+    float64_array = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    for val in float64_array:
+        second.update(val)
+
+    assert second.count == len(float64_array)
+    assert second.max == max(float64_array)
+    assert second.min == min(float64_array)
+    assert second.sum == sum(float64_array)
 
 
 def test_merge_floattrackers_should_addup():

--- a/tests/unit/core/statistics/datatypes/test_floattracker.py
+++ b/tests/unit/core/statistics/datatypes/test_floattracker.py
@@ -13,32 +13,30 @@ def _test_tracker_vs_array(tracker_of_array, array):
 
 
 def test_values_are_min_max():
-    first = FloatTracker()
+    tracker = FloatTracker()
     vals1 = [1.0, 2.0, 3.0]
-    _test_tracker_vs_array(first, vals1)
+    _test_tracker_vs_array(tracker, vals1)
 
 
 def test_np_float():
-    first = FloatTracker()
+    float32_tracker = FloatTracker()
     float32_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
-    _test_tracker_vs_array(first, float32_array)
+    _test_tracker_vs_array(float32_tracker, float32_array)
 
-    second = FloatTracker()
+    float64_tracker = FloatTracker()
     float64_array = np.array([1.0, 2.0, 3.0], dtype=np.float64)
-    _test_tracker_vs_array(second, float64_array)
+    _test_tracker_vs_array(float64_tracker, float64_array)
 
 
 def test_merge_floattrackers_should_addup():
-    first = FloatTracker()
+    first_tracker = FloatTracker()
     vals1 = [1.0, 2.0, 3.0]
-    _test_tracker_vs_array(first, vals1)
 
-    second = FloatTracker()
+    second_tracker = FloatTracker()
     vals2 = [4.0, 5.0, 6.0]
-    _test_tracker_vs_array(second, vals2)
 
     all_vals = vals1 + vals2
-    _test_merged_tracker_vs_arrays(all_vals, first, second)
+    _test_merged_tracker_vs_arrays(all_vals, first_tracker, second_tracker)
 
 
 def _test_merged_tracker_vs_arrays(combined_arrays, first_tracker, second_tracker):

--- a/tests/unit/core/statistics/datatypes/test_floattracker.py
+++ b/tests/unit/core/statistics/datatypes/test_floattracker.py
@@ -3,69 +3,51 @@ import numpy as np
 from whylogs.core.statistics.datatypes import FloatTracker
 
 
+def _test_tracker_vs_array(tracker_of_array, array):
+    for val in array:
+        tracker_of_array.update(val)
+    assert tracker_of_array.count == len(array)
+    assert tracker_of_array.max == max(array)
+    assert tracker_of_array.min == min(array)
+    assert tracker_of_array.sum == sum(array)
+
+
 def test_values_are_min_max():
     first = FloatTracker()
     vals1 = [1.0, 2.0, 3.0]
-    for val in vals1:
-        first.update(val)
-
-    assert first.count == len(vals1)
-    assert first.max == max(vals1)
-    assert first.min == min(vals1)
-    assert first.sum == sum(vals1)
+    _test_tracker_vs_array(first, vals1)
 
 
 def test_np_float():
     first = FloatTracker()
     float32_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
-    for val in float32_array:
-        first.update(val)
-
-    assert first.count == len(float32_array)
-    assert first.max == max(float32_array)
-    assert first.min == min(float32_array)
-    assert first.sum == sum(float32_array)
+    _test_tracker_vs_array(first, float32_array)
 
     second = FloatTracker()
     float64_array = np.array([1.0, 2.0, 3.0], dtype=np.float64)
-    for val in float64_array:
-        second.update(val)
-
-    assert second.count == len(float64_array)
-    assert second.max == max(float64_array)
-    assert second.min == min(float64_array)
-    assert second.sum == sum(float64_array)
+    _test_tracker_vs_array(second, float64_array)
 
 
 def test_merge_floattrackers_should_addup():
     first = FloatTracker()
     vals1 = [1.0, 2.0, 3.0]
-    for val in vals1:
-        first.update(val)
-
-    assert first.count == len(vals1)
-    assert first.max == max(vals1)
-    assert first.min == min(vals1)
-    assert first.sum == sum(vals1)
+    _test_tracker_vs_array(first, vals1)
 
     second = FloatTracker()
     vals2 = [4.0, 5.0, 6.0]
-    for val in vals2:
-        second.update(val)
-
-    assert second.count == len(vals2)
-    assert second.max == max(vals2)
-    assert second.min == min(vals2)
-    assert second.sum == sum(vals2)
+    _test_tracker_vs_array(second, vals2)
 
     all_vals = vals1 + vals2
-    merge_first = first.merge(second)
-    assert merge_first.count == len(all_vals)
-    assert merge_first.max == max(all_vals)
-    assert merge_first.min == min(all_vals)
-    assert merge_first.sum == sum(all_vals)
+    _test_merged_tracker_vs_arrays(all_vals, first, second)
 
-    merge_second = second.merge(first)
+
+def _test_merged_tracker_vs_arrays(combined_arrays, first_tracker, second_tracker):
+    merge_first = first_tracker.merge(second_tracker)
+    assert merge_first.count == len(combined_arrays)
+    assert merge_first.max == max(combined_arrays)
+    assert merge_first.min == min(combined_arrays)
+    assert merge_first.sum == sum(combined_arrays)
+    merge_second = second_tracker.merge(first_tracker)
     assert merge_second.__dict__ == merge_first.__dict__
 
 
@@ -86,31 +68,10 @@ def test_merge_floattrackers_should_addup():
         simple_tracker.update(val)
 
     merge_32_and_simple = float32_array.tolist() + vals2
-    merge_first_tracker_32_and_simple = float32_tracker.merge(simple_tracker)
-    assert merge_first_tracker_32_and_simple.count == len(merge_32_and_simple)
-    assert merge_first_tracker_32_and_simple.max == max(merge_32_and_simple)
-    assert merge_first_tracker_32_and_simple.min == min(merge_32_and_simple)
-    assert merge_first_tracker_32_and_simple.sum == sum(merge_32_and_simple)
-
-    merge_second_tracker_32_and_simple = simple_tracker.merge(float32_tracker)
-    assert merge_first_tracker_32_and_simple.__dict__ == merge_second_tracker_32_and_simple.__dict__
+    _test_merged_tracker_vs_arrays(merge_32_and_simple, float32_tracker, simple_tracker)
 
     merge_64_and_simple = float64_array.tolist() + vals2
-    merge_first_tracker_64_and_simple = float64_tracker.merge(simple_tracker)
-    assert merge_first_tracker_64_and_simple.count == len(merge_64_and_simple)
-    assert merge_first_tracker_64_and_simple.max == max(merge_64_and_simple)
-    assert merge_first_tracker_64_and_simple.min == min(merge_64_and_simple)
-    assert merge_first_tracker_64_and_simple.sum == sum(merge_64_and_simple)
-
-    merge_second_tracker_64_and_simple = simple_tracker.merge(float64_tracker)
-    assert merge_first_tracker_64_and_simple.__dict__ == merge_second_tracker_64_and_simple.__dict__
+    _test_merged_tracker_vs_arrays(merge_64_and_simple, float64_tracker, simple_tracker)
 
     merge_64_and_32 = np.concatenate((float64_array, float32_array))
-    merge_first_tracker_64_and_32 = float64_tracker.merge(float32_tracker)
-    assert merge_first_tracker_64_and_32.count == len(merge_64_and_32)
-    assert merge_first_tracker_64_and_32.max == max(merge_64_and_32)
-    assert merge_first_tracker_64_and_32.min == min(merge_64_and_32)
-    assert merge_first_tracker_64_and_32.sum == sum(merge_64_and_32)
-
-    merge_second_tracker_64_and_32 = float32_tracker.merge(float64_tracker)
-    assert merge_first_tracker_64_and_32.__dict__ == merge_second_tracker_64_and_32.__dict__
+    _test_merged_tracker_vs_arrays(merge_64_and_32, float32_tracker, float64_tracker)

--- a/tests/unit/core/statistics/datatypes/test_floattracker.py
+++ b/tests/unit/core/statistics/datatypes/test_floattracker.py
@@ -66,3 +66,55 @@ def test_merge_floattrackers_should_addup():
 
     merge_second = second.merge(first)
     assert merge_second.__dict__ == merge_first.__dict__
+
+def test_merge_floattrackers_should_addup():
+    float32_tracker = FloatTracker()
+    float32_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    for val in float32_array:
+        float32_tracker.update(val)
+
+    float64_tracker = FloatTracker()
+    float64_array = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    for val in float64_array:
+        float64_tracker.update(val)
+
+    simple_tracker = FloatTracker()
+    vals2 = [4.0, 5.0, 6.0]
+    for val in vals2:
+        simple_tracker.update(val)
+
+    assert simple_tracker.count == len(vals2)
+    assert simple_tracker.max == max(vals2)
+    assert simple_tracker.min == min(vals2)
+    assert simple_tracker.sum == sum(vals2)
+
+
+    merge_32_and_simple = float32_array.tolist() + vals2
+    merge_first_tracker_32_and_simple = float32_tracker.merge(simple_tracker)
+    assert merge_first_tracker_32_and_simple.count == len(merge_32_and_simple)
+    assert merge_first_tracker_32_and_simple.max == max(merge_32_and_simple)
+    assert merge_first_tracker_32_and_simple.min == min(merge_32_and_simple)
+    assert merge_first_tracker_32_and_simple.sum == sum(merge_32_and_simple)
+
+    merge_second_tracker_32_and_simple = simple_tracker.merge(float32_tracker)
+    assert merge_first_tracker_32_and_simple.__dict__ == merge_second_tracker_32_and_simple.__dict__
+
+    merge_64_and_simple = float64_array.tolist() + vals2
+    merge_first_tracker_64_and_simple = float64_tracker.merge(simple_tracker)
+    assert merge_first_tracker_64_and_simple.count == len(merge_64_and_simple)
+    assert merge_first_tracker_64_and_simple.max == max(merge_64_and_simple)
+    assert merge_first_tracker_64_and_simple.min == min(merge_64_and_simple)
+    assert merge_first_tracker_64_and_simple.sum == sum(merge_64_and_simple)
+
+    merge_second_tracker_64_and_simple = simple_tracker.merge(float64_tracker)
+    assert merge_first_tracker_64_and_simple.__dict__ == merge_second_tracker_64_and_simple.__dict__
+
+    merge_64_and_32 = np.concatenate((float64_array, float32_array))
+    merge_first_tracker_64_and_32 = float64_tracker.merge(float32_tracker)
+    assert merge_first_tracker_64_and_32.count == len(merge_64_and_32)
+    assert merge_first_tracker_64_and_32.max == max(merge_64_and_32)
+    assert merge_first_tracker_64_and_32.min == min(merge_64_and_32)
+    assert merge_first_tracker_64_and_32.sum == sum(merge_64_and_32)
+
+    merge_second_tracker_64_and_32 = float32_tracker.merge(float64_tracker)
+    assert merge_first_tracker_64_and_32.__dict__ == merge_second_tracker_64_and_32.__dict__


### PR DESCRIPTION
## Description

This fixes #546 allowing for use of np.float32 by changing the np.float we were accepting to np.floating. Note that the np.floating is the np API for handing floating points of all scalars and the previous were deprecated. 

https://numpy.org/devdocs/reference/arrays.scalars.html#numpy.floating

Adds testing for this use case and to make sure merge is still working, but tests are not in place around downcasting. Further work needs to be done on ensuring we can work with float64 depending on the datasketches fork https://github.com/whylabs/whylogs-sketching. 

### General Checklist

* [X] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [X] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [X] (optional) Please add a label to your PR

    