### PR TITLE
Fix for webbrowser filepaths in WSL

### DIFF
--- a/examples/Dataset_Profiler_Viewer.ipynb
+++ b/examples/Dataset_Profiler_Viewer.ipynb
@@ -49,10 +49,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "1232b2a8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: faker in /home/jamie/.cache/pypoetry/virtualenvs/whylogs-dFpe3D9Y-py3.8/lib/python3.8/site-packages (13.3.4)\n",
+      "Requirement already satisfied: python-dateutil>=2.4 in /home/jamie/.cache/pypoetry/virtualenvs/whylogs-dFpe3D9Y-py3.8/lib/python3.8/site-packages (from faker) (2.8.2)\n",
+      "Requirement already satisfied: six>=1.5 in /home/jamie/.cache/pypoetry/virtualenvs/whylogs-dFpe3D9Y-py3.8/lib/python3.8/site-packages (from python-dateutil>=2.4->faker) (1.16.0)\n"
+     ]
+    }
+   ],
    "source": [
     "!pip install faker"
    ]
@@ -86,10 +96,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "2e018520",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARN: Missing config\n"
+     ]
+    }
+   ],
    "source": [
     "session = get_or_create_session()\n",
     "def profile_generator():\n",
@@ -125,10 +143,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "e293634d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/tmp/tmpdq9b4myt.html'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "profile_viewer(profiles=[profile], output_path=None)"
    ]
@@ -143,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "d36563e9",
    "metadata": {},
    "outputs": [],
@@ -161,21 +190,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "6a4eb38c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "profile_viewer(profiles=[profile], reference_profiles=[reference_profile], output_path=None,)"
+    "from whylogs.logs import display_logging\n",
+    "display_logging(level=\"INFO\")\n",
+    "output_path = profile_viewer(profiles=[profile], reference_profiles=[reference_profile])\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1b1d89e2",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -194,7 +217,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/src/whylogs/viz/browser_viz.py
+++ b/src/whylogs/viz/browser_viz.py
@@ -1,8 +1,8 @@
 import logging
 import os
-from platform import uname
 import tempfile
 import webbrowser
+from platform import uname
 from typing import List
 
 from whylogs.core import DatasetProfile

--- a/src/whylogs/viz/browser_viz.py
+++ b/src/whylogs/viz/browser_viz.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from platform import uname
 import tempfile
 import webbrowser
 from typing import List
@@ -10,6 +11,10 @@ from whylogs.util.protobuf import message_to_json
 _MY_DIR = os.path.realpath(os.path.dirname(__file__))
 
 logger = logging.getLogger(__name__)
+
+
+def is_wsl():
+    return "microsoft-standard-WSL" in uname().release
 
 
 def profile_viewer(profiles: List[DatasetProfile] = None, reference_profiles: List[DatasetProfile] = None, output_path=None) -> str:
@@ -60,5 +65,8 @@ def profile_viewer(profiles: List[DatasetProfile] = None, reference_profiles: Li
     with open(output_path, "w") as f:
         f.write(output_index)
 
-    webbrowser.open_new_tab(f"file:{output_path}#")
+    # fix relative filepath for browser if executing within WSL
+    browser_file = f"file://wsl%24/Ubuntu{output_path}#" if is_wsl() else f"file:{output_path}#"
+
+    webbrowser.open_new_tab(browser_file)
     return output_path


### PR DESCRIPTION
## Description
Fixes #531 by detecting if in WSL and prefixing the output path accordingly before opening with webbrowser
+ minor updates to notebook while testing.

* verified on WSL2 running https://github.com/whylabs/whylogs/blob/mainline/examples/Dataset_Profiler_Viewer.ipynb in VSCode python 3.8

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    