### PR TITLE
Add warning if using both rotation and setting dataset_timestamp

### DIFF
--- a/.github/workflows/python-continuous-integration.yml
+++ b/.github/workflows/python-continuous-integration.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         path: ~/.cache/pypoetry
         key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
-        restore-keys: ${{ runner.os }}-poetry-
+        restore-keys: ${{ runner.os }}-poetry-2
     - name: Install dependencies
       run: make install
     - name: Run build, style, and lint checks

--- a/.github/workflows/python-continuous-integration.yml
+++ b/.github/workflows/python-continuous-integration.yml
@@ -36,8 +36,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/pypoetry
-        key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
-        restore-keys: ${{ runner.os }}-poetry-2
+        key: ${{ runner.os }}-poetry2-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: ${{ runner.os }}-poetry2-
     - name: Install dependencies
       run: make install
     - name: Run build, style, and lint checks

--- a/src/whylogs/app/logger.py
+++ b/src/whylogs/app/logger.py
@@ -99,7 +99,7 @@ class Logger:
         else:
             self.dataset_timestamp = dataset_timestamp
             if with_rotation_time is not None:
-                self._py_logger.warning("dataset_timestamp specified with log rotation! dataset_timestamp will be overwritten on rotation")
+                self._py_logger.warning("dataset_timestamp specified with log rotation! dataset_timestamp ignored")
         self.dataset_name = dataset_name
         self.writers = writers
         self.metadata_writer = metadata_writer

--- a/src/whylogs/app/logger.py
+++ b/src/whylogs/app/logger.py
@@ -98,6 +98,8 @@ class Logger:
             self.dataset_timestamp = datetime.datetime.now(datetime.timezone.utc)
         else:
             self.dataset_timestamp = dataset_timestamp
+            if with_rotation_time is not None:
+                self._py_logger.warning("dataset_timestamp specified with log rotation! dataset_timestamp will be overwritten on rotation")
         self.dataset_name = dataset_name
         self.writers = writers
         self.metadata_writer = metadata_writer


### PR DESCRIPTION
## Description

log rotation doesn't use a passed in dataset_timestamp, add warning to help identify the pitfall. Mitigation fix for #441


### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    