### PR TITLE
Skip running python tests on README.md updates

### DIFF
--- a/.github/workflows/java-continuous-integration.yml
+++ b/.github/workflows/java-continuous-integration.yml
@@ -2,8 +2,12 @@ name: whylogs Java CI
 on:
   push:
     branches: [ mainline, release]
+    paths-ignore:
+      - '**/README.md'
   pull_request:
     branches: [ mainline, release]
+    paths-ignore:
+      - '**/README.md'
 
 jobs:
   build:

--- a/.github/workflows/python-continuous-integration.yml
+++ b/.github/workflows/python-continuous-integration.yml
@@ -3,8 +3,12 @@ name: whylogs Python CI
 on:
   push:
     branches: [ mainline, release]
+    paths-ignore:
+      - '**/README.md'
   pull_request:
     branches: [ mainline, release]
+    paths-ignore:
+      - '**/README.md'
 
 jobs:
   test:

--- a/.github/workflows/test-notebook.yml
+++ b/.github/workflows/test-notebook.yml
@@ -3,8 +3,12 @@ name: notebook test
 on:
   push:
     branches: [ mainline, release]
+    paths-ignore:
+      - '**/README.md'
   pull_request:
     branches: [ mainline, release]
+    paths-ignore:
+      - '**/README.md'
 
 jobs:
   notebook-test:


### PR DESCRIPTION
## Description

We have small README.md updates piling up after hitting poetry cache issues in the python-ci, let's not run those tests on README.md updates

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    