### PR TITLE
Fixed what's next urls to point to documentation site

### DIFF
--- a/python/examples/basic/Getting_Started.ipynb
+++ b/python/examples/basic/Getting_Started.ipynb
@@ -476,17 +476,18 @@
    "metadata": {},
    "source": [
     "- Basic\n",
-    "    - [Visualizing Profiles](dummy) - Compare profiles to detect distribution shifts, visualize histograms and bar charts and explore your data\n",
-    "    - More to come!"
+    "    - [Visualizing Profiles](https://whylogs-v1-doc-dev.netlify.app/examples/basic/notebook_profile_visualizer) - Compare profiles to detect distribution shifts, visualize histograms and bar charts and explore your data\n",
+    "    - [Schema Configuration for Tracking Metrics](https://whylogs-v1-doc-dev.netlify.app/examples/basic/schema_configuration) - Configure tracking metrics according to data type or column features\n",
+    "    - More to Come!"
    ]
   }
  ],
  "metadata": {
   "interpreter": {
-   "hash": "3814c9af6e2d3206196f39a29888f65a61eac00efe8af085b91e4c3d5c6071b3"
+   "hash": "f76ec28949fecf16b926a3fc5a03c1aa6468ee82fa5da4ce6fd607df021af5b5"
   },
   "kernelspec": {
-   "display_name": "Python 3.8.13 ('v1')",
+   "display_name": "Python 3.8.13 ('v1.x')",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
## Description

URL pointing to Visualizer notebook was a placeholder. Replaced to doc URL and added one more example in the list (schema configuration)

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    