### PR TITLE
Minor UnicodeRangeMetric fixes

### DIFF
--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -24,7 +24,7 @@ class UnicodeRangeMetric(CompoundMetric):
     """
     For string values, maintains a DistributionMetric for the counts of
     characters that fall within user-defined codepoint ranges.
- 
+
     Parameters
      ----------
      range_definitions : Dict[str, Tuple[int, int]]


### PR DESCRIPTION
## Description
* remove unneeded `_DEFAULT_RANGES`
* make `UnicodeRangeMetric` a `@dataclass`
<!-- Description of changes -->

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [ ] Documentation updated
* [ ] (optional) Please add a label to your PR

    