### PR TITLE
[Docs] Fix integrations examples.rst + structure Readme

### DIFF
--- a/python/docs/examples.rst
+++ b/python/docs/examples.rst
@@ -33,5 +33,5 @@ Integrations
 .. toctree::
     :maxdepth: 1
 
-    examples/integrations/Writing_Profiles
-    examples/integrations/Pyspark_Profiling
+    examples/integrations/writing_profiles
+    examples/integrations/pyspark_profiling

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -2,6 +2,8 @@ This folder contains example scripts demonstrating whylogs usage.
 
 If you're new to whylogs and want to get your hands dirty, check out the [Getting Started](./basic/Getting_Started.ipynb) Notebook under the `basics` folder!
 
-If you are already a bit familiar, but wanted to check out our integrations and see where else `whylogs` can take you, feel free to check out our [integrations](./integrations/) folder!
+If you're willing to learn more how to use and get going with whylogs, take a look at our sections:
+- [Basic usage](./basic)
+- [Whylogs Integrations](./integrations/)
 
 The examples in this folder can also be viewed in whylogs' documentation in https://whylogs-v1-doc-dev.netlify.app/examples

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -3,6 +3,7 @@ This folder contains example scripts demonstrating whylogs usage.
 If you're new to whylogs and want to get your hands dirty, check out the [Getting Started](./basic/Getting_Started.ipynb) Notebook under the `basics` folder!
 
 If you're willing to learn more how to use and get going with whylogs, take a look at our sections:
+
 - [Basic usage](./basic)
 - [Whylogs Integrations](./integrations/)
 

--- a/python/examples/integrations/README.md
+++ b/python/examples/integrations/README.md
@@ -1,0 +1,9 @@
+## Whylogs Integrations
+
+In here you will find examples on `whylogs`' main integration modules. Feel free to check out:
+
+- How to create profiles with Pyspark (`pyspark_profiling`)
+- How to write your profiles to different locations, such as local, s3, etc. (`writing_profiles`)
+- More to come!
+
+Feel free to hit the `Open in Colab` button on the top of any of the examples to explore and interact with it!


### PR DESCRIPTION
## Description

Small iteration on our examples README.md and also setting our `examples.rst` to lowercase, as are the `.ipynb` files under `integrations`

### General Checklist

* [ ] Tests added for this feature/bug
      if it was a bug, test must cover it.
* [ ] Conform by the style guides, by using formatter
* [x] Documentation updated
* [ ] (optional) Please add a label to your PR

    