### PR TITLE
Remove Netlify publishing

### DIFF
--- a/.github/workflows/whylogs-ci.yml
+++ b/.github/workflows/whylogs-ci.yml
@@ -150,30 +150,6 @@ jobs:
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
         if: ${{ github.ref != 'refs/heads/mainline' }}
 
-      - name: "Deploy to Netlify: Pull Requests"
-        uses: nwtgck/actions-netlify@v1.2
-        with:
-          publish-dir: python/docs/_build/html
-          enable-pull-request-comment: true
-          overwrites-pull-request-comment: false
-          alias: git-${{ steps.vars.outputs.sha_short }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
-          NETLIFY_SITE_ID: "6c942dd9-863c-4ce5-8c26-eb4ee546ed60"
-        if: ${{ github.ref != 'refs/heads/mainline' }}
-
-      - name: "Deploy to Netlify - Mainline"
-        uses: nwtgck/actions-netlify@v1.2
-        with:
-          production-deploy: true
-          publish-dir: python/docs/_build/html
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
-          NETLIFY_SITE_ID: "6c942dd9-863c-4ce5-8c26-eb4ee546ed60"
-        if: ${{ github.ref == 'refs/heads/mainline' }}
-
       - name: Publish docs
         uses: JamesIves/github-pages-deploy-action@4.0.0
         with:


### PR DESCRIPTION
## Description

Remove Netlify publishing. We use ReadTheDocs instead

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
