### PR TITLE
Set HEAP_APPID_DEV during GitHub ci

### DIFF
--- a/.github/workflows/whylogs-ci.yml
+++ b/.github/workflows/whylogs-ci.yml
@@ -16,6 +16,7 @@ env:
   POETRY_VERSION: "1.1.11"
   PROTOC_VERSION: "3.19.4"
   PYPI_PUBLISH: false
+  HEAP_APPID_DEV: "3422045963"
 
 jobs:
   python-ci:


### PR DESCRIPTION
## Description

Set the environment variable so we don't publish to prod during CI

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
