### PR TITLE
Condition count metric / value constraints

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,39 @@
+FROM python:3.7
+
+RUN mkdir /workspace && \
+    apt update && \
+    apt install git -y && \
+    apt install sudo -y && \
+    adduser --quiet --disabled-password whyuser && \
+    adduser whyuser sudo && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+RUN curl -LJO https://github.com/protocolbuffers/protobuf/releases/download/v3.19.2/protoc-3.19.2-linux-x86_64.zip && \
+    unzip protoc-*-linux-x86_64.zip -d /usr && \
+    chmod -R a+rx /usr/bin/ /usr/include/google && \
+    apt install cmake -y && \
+    pip install pytest && \
+    pip install pytest-cov && \
+    pip install jupyterlab && \
+    pip install numpy && \
+    pip install pandas && \
+    pip install sphinx && \
+    apt install openjdk-11-jre-headless -y && \
+    curl -fsSL https://deb.nodesource.com/setup_17.x | bash - && \
+    apt install nodejs -y && \
+    npm install --global yarn && \
+    curl -LJO "https://gitlab-runner-downloads.s3.amazonaws.com/latest/deb/gitlab-runner_amd64.deb" && \
+    dpkg -i gitlab-runner_amd64.deb
+
+RUN apt install less -y && \
+    apt install emacs -y && \
+    apt install vim -y
+
+USER whyuser
+
+WORKDIR /home/whyuser
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python - && \
+    echo source /home/whyuser/.poetry/env >> .bashrc
+
+WORKDIR /workspace
+CMD [ "bash" ]

--- a/python/examples/advanced/String_Tracking.ipynb
+++ b/python/examples/advanced/String_Tracking.ipynb
@@ -216,9 +216,9 @@
    "source": [
     "Resolvers are passed to whylogs through a `DatasetSchema`, so we'll have to create a custom Schema as well.\n",
     "\n",
-    "We will create a custom Schema that inherits from DatasetSchema. We'll just have to:\n",
+    "We'll just have to:\n",
     "- Pass the UnicodeResolver created previously\n",
-    "- Since we're interested in changing the default character ranges, we'll also pass a default Metric Configuration with the desired ranges"
+    "- Since we're interested in changing the default character ranges, we'll also pass a Metric Configuration with the desired ranges"
    ]
   },
   {
@@ -227,16 +227,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class UnicodeSchema(DatasetSchema):\n",
-    "    resolvers = UnicodeResolver()\n",
-    "    default_configs = MetricConfig(unicode_ranges={\"digits\": (48, 57), \"alpha\": (97, 122)})"
+    "config = MetricConfig(unicode_ranges={\"digits\": (48, 57), \"alpha\": (97, 122)})\n",
+    "schema = DatasetSchema(resolvers=UnicodeResolver(), default_configs=config)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If a default MetricConfig is not passed, it would use the default unicode ranges, would additionaly track for ranges such as: emoticons, control characters and extended latin. "
+    "If a default MetricConfig is not passed, it would use the default unicode ranges, which would track the default ranges such as: emoticons, control characters and extended latin. "
    ]
   },
   {
@@ -254,7 +253,7 @@
    "source": [
     "import whylogs as why\n",
     "\n",
-    "prof_results = why.log(df, schema=UnicodeSchema())\n",
+    "prof_results = why.log(df, schema=DatasetSchema(resolvers=UnicodeResolver(), default_configs=MetricConfig(unicode_ranges={\"digits\": (48, 57), \"alpha\": (97, 122)})))\n",
     "prof = prof_results.profile()"
    ]
   },

--- a/python/tests/api/logger/test_logger.py
+++ b/python/tests/api/logger/test_logger.py
@@ -161,7 +161,7 @@ def test_unicode_range_enabled() -> None:
     digit_counts = [1, 2, 3, 4, 0, 3, 0]
     latin_counts = [1, 2, 3, 5, 3, 6, 10]
     emoticon_counts = [0, 0, 0, 0, 0, 0, 1]
-    configured_schema = DatasetSchema(MetricConfig(track_unicode_ranges=True))
+    configured_schema = DatasetSchema(default_configs=MetricConfig(track_unicode_ranges=True))
     prof_view = why.log(data, schema=configured_schema).view()
     assert "words" in prof_view.get_columns()
     column_profile = prof_view.get_column("words")
@@ -206,7 +206,7 @@ def test_frequent_items_disabled() -> None:
         "words": ["1", "12", "123"],
     }
     data = pd.DataFrame(strings)
-    configured_schema = DatasetSchema(MetricConfig(fi_disabled=True))
+    configured_schema = DatasetSchema(default_configs=MetricConfig(fi_disabled=True))
 
     prof_view = why.log(data, schema=configured_schema).view()
     assert "words" in prof_view.get_columns()

--- a/python/tests/api/pyspark/experimental/test_profiler_function.py
+++ b/python/tests/api/pyspark/experimental/test_profiler_function.py
@@ -3,6 +3,8 @@ from logging import getLogger
 from typing import Dict
 
 import pytest
+
+# from pyspark import SparkConf
 from pyspark.sql import SparkSession
 
 from whylogs.api.pyspark.experimental import (
@@ -17,10 +19,33 @@ from whylogs.core.view.dataset_profile_view import DatasetProfileView
 
 TEST_LOGGER = getLogger(__name__)
 
+from typing import Iterable  # noqa: E402
+
+import whylogs as why  # noqa: E402
+
+COL_NAME_FIELD = "col_name"
+COL_PROFILE_FIELD = "col_profile"
+
+
+def profiler_local(pdf_iterator: Iterable[pd.DataFrame]) -> Iterable[pd.DataFrame]:
+    for input_df in pdf_iterator:
+        res = why.log(input_df)
+        res_df = pd.DataFrame(columns=[COL_NAME_FIELD, COL_PROFILE_FIELD])
+        for col_name, col_profile in res.view().get_columns().items():
+            d = {
+                COL_NAME_FIELD: [col_name],
+                COL_PROFILE_FIELD: [col_profile.to_protobuf().SerializeToString()],
+            }
+            df_temp = pd.DataFrame(data=d)
+            res_df = res_df.append(df_temp)
+        yield res_df
+
 
 class TestPySpark(object):
     @classmethod
     def setup_class(cls):
+        # conf=SparkConf()
+        # conf.set("spark.driver.memory", "8g")
         cls.spark = SparkSession.builder.master("local[1]").getOrCreate()
 
     @classmethod
@@ -42,6 +67,46 @@ class TestPySpark(object):
             schema=test_columns,
         )
         return input_df
+
+    def test_puzzle(self, input_df):
+        # TODO: consider a constant for this, or better encapsulation.
+        cp = "col_name string, col_profile binary"
+
+        input_df.show()
+
+        def profiler_nested(pdf_iterator: Iterable[pd.DataFrame]) -> Iterable[pd.DataFrame]:
+            for input_df in pdf_iterator:
+                res = why.log(input_df)
+                res_df = pd.DataFrame(columns=[COL_NAME_FIELD, COL_PROFILE_FIELD])
+                for col_name, col_profile in res.view().get_columns().items():
+                    d = {
+                        COL_NAME_FIELD: [col_name],
+                        COL_PROFILE_FIELD: [col_profile.to_protobuf().SerializeToString()],
+                    }
+                    df_temp = pd.DataFrame(data=d)
+                    res_df = res_df.append(df_temp)
+                yield res_df
+
+        def profiler_wrapped(pdf_iterator: Iterable[pd.DataFrame]) -> Iterable[pd.DataFrame]:
+            return whylogs_pandas_map_profiler(pdf_iterator)
+
+        # profile_bytes_df = input_df.mapInPandas(whylogs_pandas_map_profiler, schema=cp)  # crashes?
+        # profile_bytes_df = input_df.mapInPandas(profiler_local, schema=cp)  # crashes?
+        # profile_bytes_df = input_df.mapInPandas(profiler_nested, schema=cp)  # works?
+        profile_bytes_df = input_df.mapInPandas(profiler_wrapped, schema=cp)  # works?
+
+        profile_bytes_df.show()
+        column_profiles = profile_bytes_df.groupby("col_name").applyInPandas(column_profile_bytes_aggregator, schema=cp)
+        column_profiles.show()
+        collected_profiles = map(
+            lambda row: (row.col_name, ColumnProfileView.from_bytes(row.col_profile).to_summary_dict()),
+            column_profiles.collect(),
+        )
+        assert profile_bytes_df.rdd.getNumPartitions() > 0
+        assert profile_bytes_df.count() == 4
+        local_column_profiles = list(collected_profiles)
+        TEST_LOGGER.info(local_column_profiles)
+        assert local_column_profiles is not None
 
     def test_profile_mapper_function(self, input_df):
         # TODO: consider a constant for this, or better encapsulation.

--- a/python/tests/core/metrics/test_condition_count.py
+++ b/python/tests/core/metrics/test_condition_count.py
@@ -1,0 +1,264 @@
+import re
+from typing import Any, Dict
+
+import pandas as pd
+import pytest
+
+from whylogs.core.dataset_profile import DatasetProfile
+from whylogs.core.datatypes import DataType
+from whylogs.core.metrics import Metric
+from whylogs.core.metrics.condition_count_metric import (
+    Condition,
+    ConditionCountConfig,
+    ConditionCountMetric,
+)
+from whylogs.core.metrics.condition_count_metric import Relation as Rel
+from whylogs.core.metrics.condition_count_metric import and_relations as and_rel
+from whylogs.core.metrics.condition_count_metric import not_relation as not_rel
+from whylogs.core.metrics.condition_count_metric import or_relations as or_rel
+from whylogs.core.metrics.condition_count_metric import relation as rel
+from whylogs.core.metrics.metric_components import IntegralComponent
+from whylogs.core.preprocessing import PreprocessedColumn
+from whylogs.core.resolvers import Resolver
+from whylogs.core.schema import ColumnSchema, DatasetSchema
+
+
+def test_condition_count_metric() -> None:
+    conditions = {
+        "alpha": Condition(rel(Rel.match, "[a-zA-Z]+")),
+        "digit": Condition(rel(Rel.match, "[0-9]+")),
+    }
+    metric = ConditionCountMetric(conditions, IntegralComponent(0))
+    strings = ["abc", "123", "kwatz", "314159", "abc123"]
+    metric.columnar_update(PreprocessedColumn.apply(strings))
+    summary = metric.to_summary_dict(None)
+
+    assert set(summary.keys()) == {"total", "alpha", "digit"}
+    assert summary["total"] == len(strings)
+    assert summary["alpha"] == 3  # "abc123" matches since it's not fullmatch
+    assert summary["digit"] == 2
+
+
+def test_throw_on_failure() -> None:
+    conditions = {
+        "alpha": Condition(rel(Rel.match, "[a-zA-Z]+"), throw_on_failure=True),
+        "beta": Condition(rel(Rel.less, "blah"), throw_on_failure=True),
+    }
+    metric = ConditionCountMetric(conditions, IntegralComponent(0))
+    strings = ["abc", "123", "kwatz", "314159", "abc123"]
+    with pytest.raises(ValueError):
+        metric.columnar_update(PreprocessedColumn.apply(strings))
+
+
+def test_condition_count_merge() -> None:
+    conditions = {
+        "alpha": Condition(rel(Rel.match, "[a-zA-Z]+")),
+        "digit": Condition(rel(Rel.match, "[0-9]+")),
+    }
+    metric1 = ConditionCountMetric(conditions, IntegralComponent(0))
+    metric2 = ConditionCountMetric(conditions, IntegralComponent(0))
+    strings = ["abc", "123", "kwatz", "314159", "abc123"]
+    metric1.columnar_update(PreprocessedColumn.apply(strings))
+    metric2.columnar_update(PreprocessedColumn.apply(strings))
+    metric = metric1.merge(metric2)
+    summary = metric.to_summary_dict(None)
+
+    assert set(summary.keys()) == {"total", "alpha", "digit"}
+    assert summary["total"] == 2 * len(strings)
+    assert summary["alpha"] == 2 * 3  # "abc123" matches since it's not fullmatch
+    assert summary["digit"] == 2 * 2
+
+
+def test_condition_count_bad_merge() -> None:
+    conditions1 = {
+        "alpha": Condition(rel(Rel.match, "[a-zA-Z]+")),
+        "digit": Condition(rel(Rel.match, "[0-9]+")),
+    }
+    metric1 = ConditionCountMetric(conditions1, IntegralComponent(0))
+    conditions2 = {
+        "alpha": Condition(rel(Rel.match, "[a-zA-Z]+")),
+        "digit": Condition(rel(Rel.match, "[0-9]+")),
+        "alnum": Condition(rel(Rel.match, "[a-zA-Z0-9]+")),
+    }
+    metric2 = ConditionCountMetric(conditions2, IntegralComponent(0))
+    strings = ["abc", "123", "kwatz", "314159", "abc123"]
+    metric1.columnar_update(PreprocessedColumn.apply(strings))
+    metric2.columnar_update(PreprocessedColumn.apply(strings))
+    metric = metric1.merge(metric2)
+    summary = metric.to_summary_dict(None)
+
+    assert set(summary.keys()) == {"total", "alpha", "digit"}
+    assert summary["total"] == len(strings)
+    assert summary["alpha"] == 3  # "abc123" matches since it's not fullmatch
+    assert summary["digit"] == 2
+
+
+def test_add_conditions_to_metric() -> None:
+    conditions = {
+        "alpha": Condition(rel(Rel.match, "[a-zA-Z]+")),
+    }
+    metric = ConditionCountMetric(conditions, IntegralComponent(0))
+    strings = ["abc", "123", "kwatz", "314159", "abc123"]
+    metric.columnar_update(PreprocessedColumn.apply(strings))
+    metric.add_conditions({"digit": Condition(rel(Rel.match, "[0-9]+"))})
+    metric.columnar_update(PreprocessedColumn.apply(strings))
+    summary = metric.to_summary_dict(None)
+
+    assert set(summary.keys()) == {"total", "alpha", "digit"}
+    assert summary["total"] == 2 * len(strings)
+    assert summary["alpha"] == 2 * 3  # "abc123" matches since it's not fullmatch
+    assert summary["digit"] == 2
+
+
+def test_condition_predicates() -> None:
+    def even(x: Any) -> bool:
+        return x % 2 == 0
+
+    conditions = {
+        "match": Condition(rel(Rel.match, "[a-zA-Z]+")),
+        "fullmatch": Condition(rel(Rel.fullmatch, "[a-zA-Z]+")),
+        "equal_str": Condition(rel(Rel.equal, "42")),
+        "equal_int": Condition(rel(Rel.equal, 42)),
+        "equal_flt": Condition(rel(Rel.equal, 42.1)),
+        "equal_flt42": Condition(rel(Rel.equal, 42.0)),
+        "less": Condition(rel(Rel.less, 42)),
+        "leq": Condition(rel(Rel.leq, 42)),
+        "greater": Condition(rel(Rel.greater, 42)),
+        "geq": Condition(rel(Rel.geq, 42)),
+        "neq": Condition(rel(Rel.neq, 42)),
+        "udf": Condition(even),
+    }
+    config = ConditionCountConfig(conditions=conditions)
+    metric = ConditionCountMetric.zero(config)
+    data = ["abc", "abc123", "42", 41, 42, 42.0, 42.1, 43]
+    metric.columnar_update(PreprocessedColumn.apply(data))
+    summary = metric.to_summary_dict(None)
+
+    assert summary["total"] == len(data)
+    assert summary["match"] == 2
+    assert summary["fullmatch"] == 1
+    assert summary["equal_str"] == 1
+    assert summary["equal_int"] == 2
+    assert summary["equal_flt"] == 1
+    assert summary["equal_flt42"] == 2
+    assert summary["less"] == 1
+    assert summary["leq"] == 3
+    assert summary["greater"] == 2
+    assert summary["geq"] == 4
+    assert summary["neq"] == 6
+    assert summary["udf"] == 2
+
+
+def test_condition_bool_ops() -> None:
+    conditions = {
+        "between": Condition(and_rel(rel(Rel.greater, 40), rel(Rel.less, 44))),
+        "outside": Condition(or_rel(rel(Rel.less, 40), rel(Rel.greater, 44))),
+        "not_alpha": Condition(not_rel(rel(Rel.match, "[a-zA-Z]+"))),
+    }
+    config = ConditionCountConfig(conditions=conditions)
+    metric = ConditionCountMetric.zero(config)
+    data = ["abc", "123", 10, 42, 50]
+    metric.columnar_update(PreprocessedColumn.apply(data))
+    summary = metric.to_summary_dict(None)
+
+    assert summary["total"] == len(data)
+    assert summary["between"] == 1
+    assert summary["outside"] == 2
+    assert summary["not_alpha"] == 1  # numbers cause type error and don't count
+
+
+def test_bad_condition_name() -> None:
+    conditions = {
+        "total": Condition(rel(Rel.match, "")),
+    }
+    with pytest.raises(ValueError):
+        ConditionCountMetric(conditions, IntegralComponent(0))
+
+    metric = ConditionCountMetric({}, IntegralComponent(0))
+    with pytest.raises(ValueError):
+        metric.add_conditions({"total": re.compile("")})
+
+
+def test_condition_count_in_profile() -> None:
+    class TestResolver(Resolver):
+        def resolve(self, name: str, why_type: DataType, column_schema: ColumnSchema) -> Dict[str, Metric]:
+            return {"condition_count": ConditionCountMetric.zero(column_schema.cfg)}
+
+    conditions = {
+        "alpha": Condition(rel(Rel.match, "[a-zA-Z]+")),
+        "digit": Condition(rel(Rel.match, "[0-9]+")),
+    }
+    config = ConditionCountConfig(conditions=conditions)
+    resolver = TestResolver()
+    schema = DatasetSchema(default_configs=config, resolvers=resolver)
+
+    row = {"col1": ["abc", "123"]}
+    prof = DatasetProfile(schema)
+    prof.track(row=row)
+    prof1_view = prof.view()
+    prof1_view.write("/tmp/test_condition_count_metric_in_profile")
+    prof2_view = DatasetProfile.read("/tmp/test_condition_count_metric_in_profile")
+    prof1_cols = prof1_view.get_columns()
+    prof2_cols = prof2_view.get_columns()
+
+    assert prof1_cols.keys() == prof2_cols.keys()
+    for col_name in prof1_cols.keys():
+        col1_prof = prof1_cols[col_name]
+        col2_prof = prof2_cols[col_name]
+        assert (col1_prof is not None) == (col2_prof is not None)
+        if col1_prof:
+            assert col1_prof._metrics.keys() == col2_prof._metrics.keys()
+            assert col1_prof.to_summary_dict() == col2_prof.to_summary_dict()
+            assert {
+                "condition_count/total",
+                "condition_count/alpha",
+                "condition_count/digit",
+            } <= col1_prof.to_summary_dict().keys()
+
+
+def test_condition_count_in_column_profile() -> None:
+    conditions = {
+        "alpha": Condition(rel(Rel.match, "[a-zA-Z]+")),
+        "digit": Condition(rel(Rel.match, "[0-9]+")),
+    }
+    config = ConditionCountConfig(conditions=conditions)
+    metric = ConditionCountMetric.zero(config)
+
+    row = {"col1": ["abc", "123"]}
+    frame = pd.DataFrame(data=row)
+    prof = DatasetProfile()
+    # Column names must be known in the profile, and that doesn't
+    # happen until some data has been logged
+    prof.track(pandas=frame)
+
+    prof._columns["col1"].add_metric(metric)
+    prof.track(pandas=frame)
+    prof_view = prof.view()
+
+    summary = prof_view.get_column("col1").to_summary_dict()
+    assert summary["condition_count/total"] > 0
+    assert summary["condition_count/alpha"] > 0
+    assert summary["condition_count/digit"] > 0
+
+
+def test_condition_count_in_dataset_profile() -> None:
+    conditions = {
+        "alpha": Condition(rel(Rel.match, "[a-zA-Z]+")),
+        "digit": Condition(rel(Rel.match, "[0-9]+")),
+    }
+    config = ConditionCountConfig(conditions=conditions)
+    metric = ConditionCountMetric.zero(config)
+
+    row = {"col1": ["abc", "123"]}
+    frame = pd.DataFrame(data=row)
+    prof = DatasetProfile()
+    prof.track(pandas=frame)
+
+    prof.add_metric("col1", metric)
+    prof.track(pandas=frame)
+    prof_view = prof.view()
+
+    summary = prof_view.get_column("col1").to_summary_dict()
+    assert summary["condition_count/total"] > 0
+    assert summary["condition_count/alpha"] > 0
+    assert summary["condition_count/digit"] > 0

--- a/python/tests/core/metrics/test_custom_deserialization.py
+++ b/python/tests/core/metrics/test_custom_deserialization.py
@@ -51,16 +51,14 @@ class TestResolver(Resolver):
         return {"testmetric": TestMetric(max=MaxIntegralComponent(0))}
 
 
-class TestSchema(DatasetSchema):
-    types = {
-        "col1": int,
-    }
-    resolvers = TestResolver()
-
-
 def test_custom_metric_in_profile() -> None:
     row = {"col1": 12}
-    schema = TestSchema()
+    schema = DatasetSchema(
+        types={
+            "col1": int,
+        },
+        resolvers=TestResolver(),
+    )
     prof = DatasetProfile(schema)
     prof.track(row=row)
     prof1_view = prof.view()

--- a/python/tests/core/metrics/test_unicode_range.py
+++ b/python/tests/core/metrics/test_unicode_range.py
@@ -1,4 +1,5 @@
-from typing import Dict
+import math
+from typing import Any, Dict
 
 import numpy as np
 import pytest
@@ -132,6 +133,15 @@ class UnicodeSchema(DatasetSchema):
     resolvers = UnicodeResolver()
 
 
+def _NaNfully_equal(left: Dict[Any, Any], right: Dict[Any, Any]) -> bool:
+    if set(left.keys()) != set(right.keys()):
+        return False
+    for key in left.keys():
+        if (left[key] != right[key]) and not (math.isnan(left[key]) and math.isnan(right[key])):
+            return False
+    return True
+
+
 def test_unicode_range_metric_in_profile() -> None:
     row = {"col1": "abc123"}
     schema = UnicodeSchema()
@@ -150,4 +160,4 @@ def test_unicode_range_metric_in_profile() -> None:
         assert (col1_prof is not None) == (col2_prof is not None)
         if col1_prof:
             assert col1_prof._metrics.keys() == col2_prof._metrics.keys()
-            assert col1_prof.to_summary_dict() == col2_prof.to_summary_dict()
+            assert _NaNfully_equal(col1_prof.to_summary_dict(), col2_prof.to_summary_dict())

--- a/python/tests/core/view/test_dataset_profile.py
+++ b/python/tests/core/view/test_dataset_profile.py
@@ -28,12 +28,7 @@ def test_override_schema_col2_as_string() -> None:
     d = {"col1": [1, 2, 3], "col2": [3.0, 4.0, "c"], "col3": ["a", "b", "c"]}
     df = pd.DataFrame(data=d)
 
-    class MyCustomSchema(DatasetSchema):
-        types = {
-            "col2": str,
-        }
-
-    profile = DatasetProfile(MyCustomSchema())
+    profile = DatasetProfile(DatasetSchema(types={"col2": str}))
     profile.track(pandas=df)
     view = profile.view()
     assert view.get_column("col1") is not None

--- a/python/whylogs/core/column_profile.py
+++ b/python/whylogs/core/column_profile.py
@@ -25,6 +25,9 @@ class ColumnProfile(object):
         self._cache: List[Any] = []
 
     def add_metric(self, metric: Metric) -> None:
+        if metric.namespace in self._metrics:
+            logger.warning(f"Replacing metric {metric.namespace} in column {self._name}")
+
         self._metrics[metric.namespace] = metric
 
     def track(self, row: Dict[str, Any]) -> None:

--- a/python/whylogs/core/column_profile.py
+++ b/python/whylogs/core/column_profile.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Dict, List
 
+from whylogs.core.metrics import Metric
 from whylogs.core.preprocessing import PreprocessedColumn
 from whylogs.core.projectors import SingleFieldProjector
 from whylogs.core.proto import ColumnMessage
@@ -22,6 +23,9 @@ class ColumnProfile(object):
         logger.debug("Setting cache size for column: %s with size: %s", self._name, cache_size)
         self._cache_size = cache_size
         self._cache: List[Any] = []
+
+    def add_metric(self, metric: Metric) -> None:
+        self._metrics[metric.namespace] = metric
 
     def track(self, row: Dict[str, Any]) -> None:
         value = self._projector.apply(row)

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Mapping, Optional
 
 from whylogs.api.writer.writer import Writable
+from whylogs.core.metrics import Metric
 from whylogs.core.utils.utils import deprecated_alias
 
 from .column_profile import ColumnProfile
@@ -72,6 +73,11 @@ class DatasetProfile(Writable):
             logger.warning("No timezone set in the datetime_timestamp object. Default to local timezone")
 
         self._dataset_timestamp = dataset_timestamp.astimezone(tz=timezone.utc)
+
+    def add_metric(self, col_name: str, metric: Metric) -> None:
+        if col_name not in self._columns:
+            raise ValueError(f"{col_name} is not a column in the dataset profile")
+        self._columns[col_name].add_metric(metric)
 
     def track(
         self,

--- a/python/whylogs/core/metrics/__init__.py
+++ b/python/whylogs/core/metrics/__init__.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 from whylogs.core.metrics.column_metrics import ColumnCountsMetric, TypeCountersMetric
+from whylogs.core.metrics.condition_count_metric import ConditionCountMetric
 from whylogs.core.metrics.metrics import (
     CardinalityMetric,
     DistributionMetric,
@@ -20,6 +21,7 @@ class StandardMetric(Enum):
     cardinality = CardinalityMetric
     frequent_items = FrequentItemsMetric
     unicode_range = UnicodeRangeMetric
+    condition_count = ConditionCountMetric
 
     def __init__(self, clz: Metric):
         self._clz = clz

--- a/python/whylogs/core/metrics/condition_count_metric.py
+++ b/python/whylogs/core/metrics/condition_count_metric.py
@@ -1,0 +1,182 @@
+import logging
+import re
+from copy import copy
+from dataclasses import dataclass, field
+from enum import Enum
+from itertools import chain
+from typing import Any, Callable, Dict, List, Set, Union
+
+from whylogs.core.configs import SummaryConfig
+from whylogs.core.metrics.metric_components import IntegralComponent, MetricComponent
+from whylogs.core.metrics.metrics import Metric, MetricConfig, OperationResult
+from whylogs.core.preprocessing import PreprocessedColumn
+from whylogs.core.proto import MetricMessage
+
+logger = logging.getLogger(__name__)
+
+
+class Relation(Enum):
+    match = 1
+    fullmatch = 2
+    equal = 3
+    less = 4
+    leq = 5
+    greater = 6
+    geq = 7
+    neq = 8
+
+
+def relation(op: Relation, value: Union[str, int, float]) -> Callable[[Any], bool]:
+    if op == Relation.match:
+        return lambda x: re.compile(value).match(x)  # type: ignore
+    if op == Relation.fullmatch:
+        return lambda x: re.compile(value).fullmatch(x)  # type: ignore
+    if op == Relation.equal:
+        return lambda x: x == value  # type: ignore
+    if op == Relation.less:
+        return lambda x: x < value  # type: ignore
+    if op == Relation.leq:
+        return lambda x: x <= value  # type: ignore
+    if op == Relation.greater:
+        return lambda x: x > value  # type: ignore
+    if op == Relation.geq:
+        return lambda x: x >= value  # type: ignore
+    if op == Relation.neq:
+        return lambda x: x != value  # type: ignore
+    raise ValueError("Unknown ConditionCountMetric predicate")
+
+
+def and_relations(left: Callable[[Any], bool], right: Callable[[Any], bool]) -> Callable[[Any], bool]:
+    return lambda x: left(x) and right(x)
+
+
+def or_relations(left: Callable[[Any], bool], right: Callable[[Any], bool]) -> Callable[[Any], bool]:
+    return lambda x: left(x) or right(x)
+
+
+def not_relation(relation: Callable[[Any], bool]) -> Callable[[Any], bool]:
+    return lambda x: not relation(x)
+
+
+@dataclass(frozen=True)
+class Condition:
+    relation: Callable[[Any], bool]
+    throw_on_failure: bool = False
+    log_on_failure: bool = False
+
+
+@dataclass(frozen=True)
+class ConditionCountConfig(MetricConfig):
+    conditions: Dict[str, Condition] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ConditionCountMetric(Metric):
+    conditions: Dict[str, Condition]
+    total: IntegralComponent
+    matches: Dict[str, IntegralComponent] = field(default_factory=dict)
+
+    @property
+    def namespace(self) -> str:
+        return "condition_count"
+
+    def __post_init__(self) -> None:
+        super(type(self), self).__post_init__()
+        if "total" in self.conditions.keys():
+            raise ValueError("Condition cannot be named 'total'")
+
+        for cond_name in self.conditions.keys():
+            if cond_name not in self.matches:
+                self.matches[cond_name] = IntegralComponent(0)
+
+    def merge(self, other: "ConditionCountMetric") -> "ConditionCountMetric":
+        if set(self.matches.keys()) != set(other.matches.keys()):
+            # log warning?
+            matches = {cond_name: IntegralComponent(comp.value) for cond_name, comp in self.matches.items()}
+            total = self.total.value
+        else:
+            matches = {
+                cond_name: IntegralComponent(self.matches[cond_name].value + other.matches[cond_name].value)
+                for cond_name in self.matches.keys()
+            }
+            total = self.total.value + other.total.value
+
+        return ConditionCountMetric(copy(self.conditions), IntegralComponent(total), matches)
+
+    def add_conditions(self, conditions: Dict[str, Condition]) -> None:
+        if "total" in conditions.keys():
+            raise ValueError("Condition cannot be named 'total'")
+        for cond_name, cond in conditions.items():
+            self.conditions[cond_name] = cond
+            self.matches[cond_name] = IntegralComponent(0)
+
+    def get_component_paths(self) -> List[str]:
+        paths: List[str] = [
+            "total",
+        ] + list(self.conditions.keys())
+        return paths
+
+    def columnar_update(self, data: PreprocessedColumn) -> OperationResult:
+        if data.len <= 0:
+            return OperationResult.ok(0)
+
+        count = 0
+        failed_conditions: Set[str] = set()
+        for x in list(chain.from_iterable(data.raw_iterator())):
+            count += 1
+            for cond_name, condition in self.conditions.items():
+                try:
+                    if condition.relation(x):
+                        self.matches[cond_name].set(self.matches[cond_name].value + 1)
+                    else:
+                        failed_conditions.add(cond_name)
+
+                except:  # noqa
+                    pass
+
+        self.total.set(self.total.value + count)
+        if condition.log_on_failure:
+            logger.warning(f"Condition(s) {', '.join(failed_conditions)} failed")
+        if condition.throw_on_failure:
+            raise ValueError(f"Condition(s) {', '.join(failed_conditions)} failed")
+        return OperationResult.ok(count)
+
+    @classmethod
+    def zero(cls, config: MetricConfig) -> "ConditionCountMetric":
+        if config is None or not isinstance(config, ConditionCountConfig):
+            raise ValueError("ConditionCountMetric.zero() requires ConditionCountConfig argument")
+
+        return ConditionCountMetric(
+            conditions=copy(config.conditions),
+            total=IntegralComponent(0),
+        )
+
+    def to_protobuf(self) -> MetricMessage:
+        msg = {"total": self.total.to_protobuf()}
+        for cond_name in self.conditions.keys():
+            msg[cond_name] = self.matches[cond_name].to_protobuf()
+
+        return MetricMessage(metric_components=msg)
+
+    def to_summary_dict(self, cfg: SummaryConfig) -> Dict[str, Any]:
+        summary = {"total": self.total.value}
+        for cond_name in self.matches.keys():
+            summary[cond_name] = self.matches[cond_name].value
+
+        return summary
+
+    @classmethod
+    def from_protobuf(cls, msg: MetricMessage) -> "ConditionCountMetric":
+        cond_names: Set[str] = set(msg.metric_components.keys())
+        cond_names.remove("total")
+
+        conditions = {cond_name: lambda x: False for cond_name in cond_names}
+        total = MetricComponent.from_protobuf(msg.metric_components["total"])
+        matches = {
+            cond_name: MetricComponent.from_protobuf(msg.metric_components[cond_name]) for cond_name in cond_names
+        }
+        return ConditionCountMetric(
+            conditions,
+            total,
+            matches,
+        )

--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -2,8 +2,6 @@ import unicodedata
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
-from typing_extensions import TypeAlias
-
 from whylogs.core.metrics.compound_metric import CompoundMetric
 from whylogs.core.metrics.metrics import (
     DistributionMetric,
@@ -12,9 +10,6 @@ from whylogs.core.metrics.metrics import (
 )
 from whylogs.core.preprocessing import PreprocessedColumn
 from whylogs.core.proto import MetricMessage
-
-ColumnSchema: TypeAlias = "ColumnSchema"  # type: ignore
-
 
 _STRING_LENGTH = "string_length"
 


### PR DESCRIPTION
## Description

Proposed API for condition count metric. A `ConditionCountMetric` on a column hosts multiple predicates and counts how many times each is satisfied  by logged values as well as the total count of values logged. These replace v0 value constraints. To get more constraint-like behavior, you can optionally have failed predicates log a warning or throw a `ValueException`. You can also set WhyLabs alerts on the condition counts in the profile.

To facilitate EDA use cases, you can add additional conditions to a configured metric using `ConditionCountMetric::add_conditions()`.  You can add a `ConditionCountMetric` to an existing profile using `DatasetProfile::add_metric()` or `ColumnProfile::add_metric()`.

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
