### PR TITLE
convert bytearray to bytes for column profile parsing

### DIFF
--- a/python/whylogs/core/view/column_profile_view.py
+++ b/python/whylogs/core/view/column_profile_view.py
@@ -142,5 +142,7 @@ class ColumnProfileView(object):
     @classmethod
     def from_bytes(cls, data: bytes) -> "ColumnProfileView":
         msg = ColumnMessage()
+        if isinstance(data, bytearray):
+            data = bytes(data)
         msg.ParseFromString(data)
         return ColumnProfileView.from_protobuf(msg)


### PR DESCRIPTION
 in pyspark notebook example I see this error:
```
column_views_dict = collect_column_profile_views(spark_dataframe)
```
->
```
TypeError                                 Traceback (most recent call last)
...

whylogs/core/view/column_profile_view.py:145, in ColumnProfileView.from_bytes(cls, data)
    142 @classmethod
    143 def from_bytes(cls, data: bytes) -> "ColumnProfileView":
    144     msg = ColumnMessage()
--> 145     msg.ParseFromString(data)
    146     return ColumnProfileView.from_protobuf(msg)

TypeError: expected bytes, bytearray found
```

## Description

detect and convert bytearray when parsing column bytes.

