### PR TITLE
Treat decimals as fractional

### DIFF
--- a/python/tests/api/pyspark/experimental/test_profiler_function.py
+++ b/python/tests/api/pyspark/experimental/test_profiler_function.py
@@ -84,17 +84,21 @@ class TestPySpark(object):
         assert profile_view.get_column("0").get_metric("distribution").min == 0.0
 
     def test_decimals_are_fractional(self):
-        decimal_data=[[Decimal(8.4), Decimal(13.8)],[Decimal(2.9), Decimal(7.2)],]
-        pandas_decimals = pd.DataFrame({'wine': [Decimal(8.4), Decimal(13.8)], 'beer': [Decimal(2.9), Decimal(7.2)]})
-        decimals_df = self.spark.createDataFrame(decimal_data, schema=['wine', 'beer'])
+        decimal_data = [
+            [Decimal(8.4), Decimal(13.8)],
+            [Decimal(2.9), Decimal(7.2)],
+        ]
+        pandas_decimals = pd.DataFrame({"wine": [Decimal(8.4), Decimal(13.8)], "beer": [Decimal(2.9), Decimal(7.2)]})
+        decimals_df = self.spark.createDataFrame(decimal_data, schema=["wine", "beer"])
         dataset_profile_view = collect_dataset_profile_view(decimals_df)
-        type_counts = dataset_profile_view.get_column('wine').get_metric("types")
+        type_counts = dataset_profile_view.get_column("wine").get_metric("types")
         assert type_counts.integral.value == 0
-        assert  type_counts.fractional.value == 2
+        assert type_counts.fractional.value == 2
 
         # check that pandas dataframes without spark also behave similarly
         import whylogs as why
+
         pandas_decimals_profile_view = why.log(pandas_decimals).view()
-        pandas_type_counts = pandas_decimals_profile_view.get_column('wine').get_metric("types")
+        pandas_type_counts = pandas_decimals_profile_view.get_column("wine").get_metric("types")
         assert pandas_type_counts.integral.value == 0
-        assert  pandas_type_counts.fractional.value == 2
+        assert pandas_type_counts.fractional.value == 2

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -129,10 +129,10 @@ class PreprocessedColumn:
         if parse_numeric_string:
             non_null_series = pd.to_numeric(non_null_series, errors="ignore")
 
-        float_mask = non_null_series.apply(lambda x: pdc.is_float(x))
+        float_mask = non_null_series.apply(lambda x: pdc.is_float(x) or pdc.is_decimal(x))
         bool_mask = non_null_series.apply(lambda x: pdc.is_bool(x))
         bool_mask_where_true = non_null_series.apply(lambda x: pdc.is_bool(x) and x)
-        int_mask = non_null_series.apply(lambda x: pdc.is_number(x) and not pdc.is_float(x) and not pdc.is_bool(x))
+        int_mask = non_null_series.apply(lambda x: pdc.is_number(x) and pdc.is_integer(x) and not pdc.is_bool(x))
         str_mask = non_null_series.apply(lambda x: isinstance(x, str))
 
         floats = non_null_series[float_mask]

--- a/python/whylogs/core/view/column_profile_view.py
+++ b/python/whylogs/core/view/column_profile_view.py
@@ -142,5 +142,7 @@ class ColumnProfileView(object):
     @classmethod
     def from_bytes(cls, data: bytes) -> "ColumnProfileView":
         msg = ColumnMessage()
+        if isinstance(data, bytearray):
+            data = bytes(data)
         msg.ParseFromString(data)
         return ColumnProfileView.from_protobuf(msg)


### PR DESCRIPTION
## Description

Fixes #620 - whylogs needs to detect Decimals as fractional numbers so we can correctly count them as non-integer numeric types. Previously we relied on detection of non-float numbers as integer type.

## Changes

- Added some tests that reproduce the reported bug.
- Updated the preprocessing of inputs to correctly categorize Decimals as fractional (over defaulting to integral type when non-float and numeric).

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
