### PR TITLE
Restrict max python version to less than 3.10 aligned with test matrix

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,7 +11,7 @@ include = ["whylogs/core/proto/v0/*.py*", "whylogs/core/proto/*.py*"]
 
 [tool.poetry.dependencies]
 # core dependencies. Be REALLY mindful when touching this list
-python = ">=3.7.1, <4.0"
+python = ">=3.7.1, <3.10"
 whylogs-sketching = "3.4.0.dev9"
 protobuf = ">=3.15.5"
 importlib-metadata = { version = ">=0.23", python = "<3.8" }


### PR DESCRIPTION
## Description

This repository needs to describe the max python version in a way consistent with our tests which support 3.9.

3.10 has some dependencies missing, and we can allow that after we build whylogs-datasketching for those and turn on python 3.10 in our test matrix.

mitigates #627 