### PR TITLE
fixing mean and stddev calculation for single-value updates

### DIFF
--- a/python/tests/core/constraints/test_metric_constraints.py
+++ b/python/tests/core/constraints/test_metric_constraints.py
@@ -50,7 +50,7 @@ def test_metric_constraint_callable() -> None:
     )
     TEST_LOGGER.info(f"distribution is {distribution_metric.to_summary_dict()}")
     TEST_LOGGER.info(f"empy distribution is {empty_distribution.to_summary_dict()}")
-    assert distribution_stddev_gt_avg.condition(distribution_metric)
+    assert not distribution_stddev_gt_avg.condition(distribution_metric)
     assert distribution_stddev_gt_avg.condition(empty_distribution)
 
 

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -250,10 +250,10 @@ class DistributionMetric(Metric):
 
                         second = VarianceM2Result(n=n_b, mean=mean_b, m2=m2_b)
                         first = parallel_variance_m2(first=first, second=second)
-                    else:
+                    elif n_b == 1:
                         # fall back to https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
                         # #Weighted_incremental_algorithm
-                        first = welford_online_variance_m2(existing=first, new_value=first[0])
+                        first = welford_online_variance_m2(existing=first, new_value=arr[0])
 
         for lst in [view.list.ints, view.list.floats]:
             if lst is not None and len(lst) > 0:


### PR DESCRIPTION
## Description

When updating distribution metrics with a single new value, welford algorithm is used. The algorithm expects a `new_value`, but    it was being passed instead a variance result from the already tracked data, and not the incoming value.

It was also attempting to use the algorithm when there is no value to be tracked, so changed the `else` to check for `len`==1

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
