### PR TITLE
Decimal handling fixes

### DIFF
--- a/python/tests/api/pyspark/experimental/test_profiler_function.py
+++ b/python/tests/api/pyspark/experimental/test_profiler_function.py
@@ -102,3 +102,12 @@ class TestPySpark(object):
         pandas_type_counts = pandas_decimals_profile_view.get_column("wine").get_metric("types")
         assert pandas_type_counts.integral.value == 0
         assert pandas_type_counts.fractional.value == 2
+
+        wine_column = dataset_profile_view.get_column("wine")
+
+        distribution_metric = wine_column.get_metric("distribution")
+        if distribution_metric is None:
+            TEST_LOGGER.info(
+                f"Could not find distribution metric on decimal series: metrics are {wine_column.get_metric_names()}"
+            )
+        assert distribution_metric is not None

--- a/python/tests/core/constraints/test_metric_constraints.py
+++ b/python/tests/core/constraints/test_metric_constraints.py
@@ -73,7 +73,7 @@ def test_constraints_builder(pandas_constraint_dataframe) -> None:
 
     legs_less_than_12_constraint = MetricConstraint(
         name="legs less than 12",
-        condition=lambda x: x.max < 12,
+        condition=lambda x: not x.max >= 12,
         metric_selector=MetricsSelector(metric_name="distribution", column_name="legs"),
     )
 
@@ -83,7 +83,7 @@ def test_constraints_builder(pandas_constraint_dataframe) -> None:
     )
     no_negative_numbers = MetricConstraint(
         name="no negative numbers",
-        condition=lambda x: x.min >= 0,
+        condition=lambda x: not x.min < 0,
         metric_selector=distribution_selector,
         require_column_existence=False,
     )

--- a/python/tests/core/test_datatypes.py
+++ b/python/tests/core/test_datatypes.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -11,7 +13,7 @@ from whylogs.core.datatypes import (
 )
 
 NUMERICAL_TYPE = [int, bool, np.intc, np.uintc, np.int_, np.uint, np.longlong, np.ulonglong]
-DOUBLE_TYPE = [float, np.double, np.longdouble, np.float16, np.float64]
+DOUBLE_TYPE = [float, np.double, np.longdouble, np.float16, np.float64, Decimal]
 DATETIME_TYPE = [np.datetime64, np.timedelta64, pd.Timestamp, pd.Timedelta]
 STRING_TYPE = [str, pd.CategoricalDtype()]
 

--- a/python/tests/viz/utils/test_quantile_stats.py
+++ b/python/tests/viz/utils/test_quantile_stats.py
@@ -1,7 +1,9 @@
 import math
 
 import numpy as np
+import pandas as pd
 
+import whylogs as why
 from whylogs.viz.utils import _calculate_quantile_statistics  # type: ignore
 from whylogs.viz.utils.quantile_stats import (
     _calculate_bins,
@@ -27,6 +29,17 @@ def test_calculate_quantile_stats_should_return_dict(profile_view):
     actual_iqr = actual_stats["iqr"]
 
     assert expected_iqr == actual_iqr
+
+
+def test_calculate_quantile_stats_should_not_throw_on_empty_distribution():
+    df = pd.DataFrame(columns=["numbers_column"], dtype=float)
+    profile = why.log(df).view()
+    column_view = profile.get_column("numbers_column")
+    assert column_view is not None
+    # pass a column view with an empty distribution
+    _calculate_quantile_statistics(column_view=column_view)
+    distribution_metric = column_view.get_metric("distribution")
+    assert distribution_metric is not None
 
 
 def test_resize_bins():

--- a/python/whylogs/core/datatypes.py
+++ b/python/whylogs/core/datatypes.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from decimal import Decimal
 from typing import Any, Generic, List, Optional, Type, TypeVar, Union
 
 from whylogs.core.stubs import np
@@ -36,7 +37,7 @@ class DataType(ABC, Generic[NT]):
         raise NotImplementedError
 
 
-NumericalType = Union[int, float, np.number]
+NumericalType = Union[int, float, np.number, Decimal]
 
 NUMBER = TypeVar("NUMBER")
 
@@ -75,7 +76,7 @@ class Fractional(DataType[float]):
         if not isinstance(dtype_or_type, type):
             return False
 
-        return issubclass(dtype_or_type, (float, np.floating))
+        return issubclass(dtype_or_type, (float, np.floating, Decimal))
 
 
 class String(DataType[str]):

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -142,6 +142,10 @@ class PreprocessedColumn:
         strings = non_null_series[str_mask]
         objs = non_null_series[~(float_mask | str_mask | int_mask | bool_mask)]
 
+        # convert numeric types to float if they are considered
+        # Fractional types e.g. decimal.Decimal only if there are values
+        if not floats.empty:
+            floats = floats.astype(float)
         self.numpy = NumpyView(floats=floats, ints=ints)
         self.pandas.strings = strings
         self.pandas.objs = objs

--- a/python/whylogs/core/resolvers.py
+++ b/python/whylogs/core/resolvers.py
@@ -25,6 +25,7 @@ class StandardResolver(Resolver):
     """Standard metric resolution with builtin types."""
 
     def resolve(self, name: str, why_type: DataType, column_schema: ColumnSchema) -> Dict[str, Metric]:
+
         metrics: List[StandardMetric] = [StandardMetric.counts, StandardMetric.types]
         if isinstance(why_type, Integral):
             metrics.append(StandardMetric.distribution)
@@ -34,8 +35,9 @@ class StandardResolver(Resolver):
         elif isinstance(why_type, Fractional):
             metrics.append(StandardMetric.cardinality)
             metrics.append(StandardMetric.distribution)
-        elif isinstance(why_type, String):
+        elif isinstance(why_type, String):  # Catch all category as we map 'object' here
             metrics.append(StandardMetric.cardinality)
+            metrics.append(StandardMetric.distribution)  # 'object' columns can contain Decimal
             metrics.append(StandardMetric.frequent_items)
 
         if column_schema.cfg.fi_disabled:

--- a/python/whylogs/viz/utils/drift_calculations.py
+++ b/python/whylogs/viz/utils/drift_calculations.py
@@ -45,6 +45,9 @@ def _compute_ks_test_p_value(
         kll_floats_sketch summaries
 
     """
+    if reference_distribution.is_empty() or target_distribution.is_empty():
+        return None
+
     D_max = 0
     target_quantile_values = target_distribution.get_quantiles(QUANTILES)
     ref_quantile_values = reference_distribution.get_quantiles(QUANTILES)

--- a/python/whylogs/viz/utils/quantile_stats.py
+++ b/python/whylogs/viz/utils/quantile_stats.py
@@ -30,7 +30,7 @@ def _calculate_quantile_statistics(column_view: Union[ColumnProfileView, None]) 
     distribution_metric: Optional[DistributionMetric] = column_view.get_metric("distribution")
     desired_quantiles = [0.05, 0.25, 0.5, 0.75, 0.95]
 
-    if distribution_metric is None:
+    if distribution_metric is None or distribution_metric.kll.value.is_empty():
         return None
 
     quantiles = distribution_metric.kll.value.get_quantiles(desired_quantiles)


### PR DESCRIPTION
## Description

Until pandas has a dtype value for Decimal to inform that the values are numeric, whylogs will allow distribution metrics on object columns (which will be empty if the column contains no numeric values). Handling of empty distribution metrics was not correct in a few places (e.g. we needed to detect when we have an empty distribution before reading quantiles from it), also constraint conditions can surface surprising results when nan is compared to a threshold, so updated some of the tests.

Fix Decimal handling:
* Allow distribution metric on object column types to cover Decimal in pandas scenario.
* Add some better test validation of output metrics
* Update constraints to work against nan values
* Add tests for empty distribution metrics