### PR TITLE
Zero padding the differences between two sets of frequent items

### DIFF
--- a/python/whylogs/viz/jupyter_notebook_viz.py
+++ b/python/whylogs/viz/jupyter_notebook_viz.py
@@ -12,6 +12,7 @@ from whylogs.api.usage_stats import emit_usage
 from whylogs.core.configs import SummaryConfig
 from whylogs.core.constraints import Constraints
 from whylogs.core.view.dataset_profile_view import DatasetProfileView
+from whylogs.viz.utils.frequent_items_calculations import zero_padding_frequent_items
 from whylogs.viz.utils.profile_viz_calculations import (
     add_feature_statistics,
     frequent_items_from_view,
@@ -165,6 +166,14 @@ class NotebookProfileVisualizer:
 
                 reference_profile_features[feature_name]["frequentItems"] = frequent_items_from_view(
                     ref_col_view, feature_name, config
+                )
+
+                (
+                    target_profile_features[feature_name]["frequentItems"],
+                    reference_profile_features[feature_name]["frequentItems"],
+                ) = zero_padding_frequent_items(
+                    target_feature_items=target_profile_features[feature_name]["frequentItems"],
+                    reference_feature_items=reference_profile_features[feature_name]["frequentItems"],
                 )
             else:
                 logger.warning("Reference profile not detected. Plotting only for target feature.")

--- a/python/whylogs/viz/utils/drift_calculations.py
+++ b/python/whylogs/viz/utils/drift_calculations.py
@@ -9,6 +9,7 @@ from whylogs.core.view.dataset_profile_view import DatasetProfileView  # type: i
 from whylogs.viz.utils.frequent_items_calculations import (
     FrequentStats,
     get_frequent_stats,
+    zero_padding_frequent_items,
 )
 
 QUANTILES = [0.0, 0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99, 1.0]
@@ -132,6 +133,7 @@ def _compute_chi_squared_test_p_value(
         frequent and unique items summaries
     """
     target_freq_items = target_distribution["frequent_items"]
+    ref_freq_items = reference_distribution["frequent_items"]
     target_total_count = target_distribution["total_count"]
     target_unique_count = target_distribution["unique_count"]
     ref_total_count = reference_distribution["total_count"]
@@ -139,10 +141,11 @@ def _compute_chi_squared_test_p_value(
     if ref_total_count <= 0 or target_total_count <= 0:
         return None
 
+    target_freq_items, ref_freq_items = zero_padding_frequent_items(target_freq_items, ref_freq_items)
+
     ref_dist_items = dict()
     for item in reference_distribution["frequent_items"]:
         ref_dist_items[item["value"]] = item["estimate"]
-
     proportion_ref_dist_items = {k: v / ref_total_count for k, v in ref_dist_items.items()}
 
     chi_sq = 0.0

--- a/python/whylogs/viz/utils/frequent_items_calculations.py
+++ b/python/whylogs/viz/utils/frequent_items_calculations.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from typing_extensions import TypedDict
 
@@ -56,3 +56,33 @@ def frequent_items_from_view(
     target_frequent_items = column_frequent_items_metric.to_summary_dict(config)["frequent_strings"]
     frequent_items = get_frequent_items_estimate(target_frequent_items)
     return frequent_items
+
+
+def zero_padding_frequent_items(
+    target_feature_items: List[FrequentItemEstimate], reference_feature_items: List[FrequentItemEstimate]
+) -> Tuple[List[FrequentItemEstimate], List[FrequentItemEstimate]]:
+    """Fills estimate value of item with 0 when such item is present in the other profile but absent in the current profile.
+    This is done for both profiles passed.
+
+    Parameters
+    ----------
+    target_feature_items : List[FrequentItemEstimate]
+        A list of frequent items of a given column for target profile
+    reference_feature_items : List[FrequentItemEstimate]
+        A list of frequent items of a given column for reference profile
+
+    Returns
+    -------
+    Tuple[List[FrequentItemEstimate], List[FrequentItemEstimate]]
+        The same list of items given in the input, but with zero padding for absent items.
+    """
+    for reference_item in reference_feature_items:
+        item_value = reference_item["value"]
+        if item_value not in [x["value"] for x in target_feature_items]:
+            target_feature_items.append({"value": item_value, "estimate": 0})
+    for target_item in target_feature_items:
+        item_value = target_item["value"]
+        if item_value not in [x["value"] for x in reference_feature_items]:
+            reference_feature_items.append({"value": item_value, "estimate": 0})
+
+    return target_feature_items, reference_feature_items


### PR DESCRIPTION
In some cases, items (or categories) are present in one profile (target or reference) but absent in the other.

This currently causes a problem in two areas:
- `viz`'s `distribution_chart` plots: Items that are present on the reference profile but absent in the target profile are not shown in the plot
- drift calculations: `chi-squared`'s implementation ignores items that appear exclusively on the reference profile.

To address these issues, an additional padding step is included, where items that don't appear in the current profile but are present in the other one are created with an estimate of 0. This is done for both profiles.

## Description

This repository needs <!-- Add 1-2 sentences explaining the purpose of this PR. -->

The commits in this pull request will <!-- Summarize PR. -->

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
