### PR TITLE
Assert kll exists before getting histograms to be displayed by summary_drift_report

### DIFF
--- a/python/whylogs/viz/utils/profile_viz_calculations.py
+++ b/python/whylogs/viz/utils/profile_viz_calculations.py
@@ -149,8 +149,14 @@ def generate_summaries(
                 col_drift_value = drift_values[target_col_name]
                 if col_drift_value:
                     ref_column_summary["drift_from_ref"] = col_drift_value["p_value"]
-
-            if target_col_view.get_metric("distribution") and ref_col_view.get_metric("distribution"):
+            target_dist = target_col_view.get_metric("distribution")
+            reference_dist = ref_col_view.get_metric("distribution")
+            if (
+                target_dist
+                and reference_dist
+                and not target_dist.kll.value.is_empty()
+                and not reference_dist.kll.value.is_empty()
+            ):
                 target_column_summary["isDiscrete"] = ref_column_summary["isDiscrete"] = False
 
                 target_histogram = histogram_from_view(target_col_view, target_col_name)


### PR DESCRIPTION
- check if kll is empty before generating histogram for summary_drit_report

## Description

This repository needs <!-- Add 1-2 sentences explaining the purpose of this PR. -->

The commits in this pull request will <!-- Summarize PR. -->

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
