### PR TITLE
Emit LoggingError when no inputs are passed to whylogs.log()

### DIFF
--- a/python/tests/api/logger/test_logger.py
+++ b/python/tests/api/logger/test_logger.py
@@ -7,6 +7,7 @@ import pytest
 
 import whylogs as why
 from whylogs.core import ColumnProfileView, MetricConfig
+from whylogs.core.errors import LoggingError
 from whylogs.core.schema import DatasetSchema
 
 FLOAT_TYPES = [float, np.float16, np.float32, np.float64, np.floating, np.float_, np.longdouble]
@@ -26,6 +27,11 @@ def test_basic_log() -> None:
     assert profile._columns["col1"]._schema.dtype == np.int64
     assert profile._columns["col2"]._schema.dtype == np.float64
     assert profile._columns["col3"]._schema.dtype.name == "object"
+
+
+def test_log_nothing_raises_error() -> None:
+    with pytest.raises(LoggingError):
+        why.log()
 
 
 def test_basic_log_row() -> None:

--- a/python/whylogs/api/logger/logger.py
+++ b/python/whylogs/api/logger/logger.py
@@ -61,6 +61,9 @@ class Logger(ABC):
     ) -> ResultSet:
         if self._is_closed:
             raise LoggingError("Cannot log to a closed logger")
+        if obj is None and pandas is None and row is None:
+            # TODO: check for shell environment and emit more verbose error string to let user know how to correct.
+            raise LoggingError("log() was called without passing in any input!")
 
         profiles = self._get_matching_profiles(obj, pandas=pandas, row=row)
 


### PR DESCRIPTION
## Description

Fixes #639 be raising an error that has a better chance of hinting the user towards how to correct the problem than raising NotImplementedError.
