### PR TITLE
KeyError fix for single value Series DistributionMetric columnar updates

### DIFF
--- a/python/tests/core/metrics/test_metrics.py
+++ b/python/tests/core/metrics/test_metrics.py
@@ -25,6 +25,27 @@ def test_distribution_metrics_numpy() -> None:
     assert distribution_summary["q_99"] == 99.0
 
 
+def test_distribution_metrics_series() -> None:
+    dist = DistributionMetric.zero(MetricConfig())
+    data = pd.Series(list(range(100)))
+    col = PreprocessedColumn.apply(data)
+    dist.columnar_update(col)
+
+    assert dist.kll.value.get_n() == 100
+    assert dist.mean.value == data.mean()
+    assert dist.variance == data.var()
+
+
+def test_distribution_metrics_indexed_series_single_row() -> None:
+    dist = DistributionMetric.zero(MetricConfig())
+    data = pd.Series(list(range(1)), index=[284])
+    col = PreprocessedColumn.apply(data)
+    dist.columnar_update(col)
+
+    assert dist.kll.value.get_n() == 1
+    assert dist.mean.value == data.mean()
+
+
 def test_distribution_metrics_list() -> None:
     dist = DistributionMetric.zero(MetricConfig())
     col = PreprocessedColumn()

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -26,6 +26,7 @@ from whylogs.core.metrics.metric_components import (
 )
 from whylogs.core.preprocessing import PreprocessedColumn
 from whylogs.core.proto import MetricComponentMessage, MetricMessage
+from whylogs.core.stubs import pd as pd
 
 T = TypeVar("T")
 M = TypeVar("M", bound=MetricComponent)
@@ -254,7 +255,10 @@ class DistributionMetric(Metric):
                     elif n_b == 1:
                         # fall back to https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
                         # #Weighted_incremental_algorithm
-                        first = welford_online_variance_m2(existing=first, new_value=arr[0])
+                        if isinstance(arr, pd.Series):
+                            first = welford_online_variance_m2(existing=first, new_value=arr.iloc[0])
+                        else:
+                            first = welford_online_variance_m2(existing=first, new_value=arr[0])
 
         for lst in [view.list.ints, view.list.floats]:
             if lst is not None and len(lst) > 0:


### PR DESCRIPTION
## Description

This PR fixes https://github.com/whylabs/whylogs/issues/655.

When updating DistributionMetrics for a Pandas Series with a single row and Random Integer indexes (not sequentially and starting with 0), a KeyError was reached.

- Added checking for pandas series and accessing with `.iloc[0]` instead of `[0]`
- Added tests to cover this case.

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
