### PR TITLE
Check for empty series before applying masks in preprocessing

### DIFF
--- a/python/tests/api/logger/test_logger.py
+++ b/python/tests/api/logger/test_logger.py
@@ -15,6 +15,7 @@ INTEGER_TYPES = [int, np.intc, np.uintc, np.int_, np.uint, np.longlong, np.ulong
 DATETIME_TYPES = [np.datetime64, pd.Timestamp]
 TIMEDELTA_TYPES = ["timedelta64[s]", "timedelta64[ms]"]
 
+
 def test_basic_log() -> None:
     d = {"col1": [1, 2], "col2": [3.0, 4.0], "col3": ["a", "b"]}
     df = pd.DataFrame(data=d)
@@ -215,8 +216,8 @@ def test_frequent_items_disabled() -> None:
 
 def test_key_error() -> None:
     data = {
-        "emptyDates": ["NaT","NaT"],
+        "emptyDates": ["NaT", "NaT"],
     }
-    df = pd.DataFrame(data, dtype='datetime64[ns]')
+    df = pd.DataFrame(data, dtype="datetime64[ns]")
     results = why.log(df)
     assert results is not None

--- a/python/tests/api/logger/test_logger.py
+++ b/python/tests/api/logger/test_logger.py
@@ -15,7 +15,6 @@ INTEGER_TYPES = [int, np.intc, np.uintc, np.int_, np.uint, np.longlong, np.ulong
 DATETIME_TYPES = [np.datetime64, pd.Timestamp]
 TIMEDELTA_TYPES = ["timedelta64[s]", "timedelta64[ms]"]
 
-
 def test_basic_log() -> None:
     d = {"col1": [1, 2], "col2": [3.0, 4.0], "col3": ["a", "b"]}
     df = pd.DataFrame(data=d)
@@ -212,3 +211,12 @@ def test_frequent_items_disabled() -> None:
     assert "words" in prof_view.get_columns()
     column_profile = prof_view.get_column("words")
     assert "frequent_items" not in column_profile.get_metric_names()
+
+
+def test_key_error() -> None:
+    data = {
+        "emptyDates": ["NaT","NaT"],
+    }
+    df = pd.DataFrame(data, dtype='datetime64[ns]')
+    results = why.log(df)
+    assert results is not None

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -122,6 +122,12 @@ class PreprocessedColumn:
                 self.numpy.ints = ints
                 return
 
+        # if non_null_series is empty, then early exit.
+        # this fixes a bug where empty columns produce masks of types other than bool
+        # and DatetimeArrays do not support | operator for example.
+        if non_null_series.count() == 0:
+            return
+
         if issubclass(series.dtype.type, str):
             self.pandas.strings = non_null_series
             return

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -125,7 +125,7 @@ class PreprocessedColumn:
         # if non_null_series is empty, then early exit.
         # this fixes a bug where empty columns produce masks of types other than bool
         # and DatetimeArrays do not support | operator for example.
-        if non_null_series.count() == 0:
+        if non_null_series.empty:
             return
 
         if issubclass(series.dtype.type, str):


### PR DESCRIPTION
## Description

Fixes #654  by skipping applying masks to empty pandas series.

The problem occurs because when a mask is applied to an empty series the return type is not a series of bool, but retains the original series dtype, then later there are expressions that try to combine masks with logical or, and this doesn't work on non-boolean types which causes this code path to throw.