### PR TITLE
Make Profile/Profile Views retain the same order of columns as original DataFrame

### DIFF
--- a/python/tests/core/view/test_dataset_profile_view.py
+++ b/python/tests/core/view/test_dataset_profile_view.py
@@ -34,3 +34,12 @@ def test_merge_nan_column(lending_club_df) -> None:
     assert mean == 0
     assert stddev == 0
     assert null_count == n_count
+
+
+def test_order_columns() -> None:
+    d = {"c0": [0], "c1": [1], "c2": [2], "c3": [3], "c4": [4], "c5": [5], "c6": [6], "c7": [7], "c8": [8], "c9": [9]}
+    df = pd.DataFrame(d)
+    profile_view = why.log(df).profile().view()
+    data_keys = d.keys()
+    profile_keys = profile_view.get_columns().keys()
+    assert data_keys == profile_keys

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -108,7 +108,9 @@ class DatasetProfile(object):
         # TODO: do this less frequently when operating at row level
         dirty = self._schema.resolve(pandas=pandas, row=row)
         if dirty:
-            new_cols = self._schema.get_col_names().difference(self._columns.keys())
+            schema_col_keys = self._schema.get_col_names()
+            col_keys = tuple(self._columns.keys())
+            new_cols = (col for col in schema_col_keys if col not in col_keys)
             for col in new_cols:
                 col_schema = self._schema.get(col)
                 if col_schema:

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -109,8 +109,8 @@ class DatasetProfile(object):
         dirty = self._schema.resolve(pandas=pandas, row=row)
         if dirty:
             schema_col_keys = self._schema.get_col_names()
-            col_keys = tuple(self._columns.keys())
-            new_cols = (col for col in schema_col_keys if col not in col_keys)
+            col_keys = self._columns.keys()
+            new_cols = {col: None for col in schema_col_keys if col not in col_keys}
             for col in new_cols:
                 col_schema = self._schema.get(col)
                 if col_schema:

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -109,8 +109,7 @@ class DatasetProfile(object):
         dirty = self._schema.resolve(pandas=pandas, row=row)
         if dirty:
             schema_col_keys = self._schema.get_col_names()
-            col_keys = self._columns.keys()
-            new_cols = {col: None for col in schema_col_keys if col not in col_keys}
+            new_cols = (col for col in schema_col_keys if col not in self._columns)
             for col in new_cols:
                 col_schema = self._schema.get(col)
                 if col_schema:

--- a/python/whylogs/core/schema.py
+++ b/python/whylogs/core/schema.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional, TypeVar
-
+from collections.abc import KeysView
 from whylogs.core.datatypes import StandardTypeMapper, TypeMapper
 from whylogs.core.metrics import Metric, MetricConfig
 from whylogs.core.resolvers import Resolver, StandardResolver
@@ -135,8 +135,8 @@ class DatasetSchema:
 
         return dirty
 
-    def get_col_names(self) -> tuple:
-        return tuple(self._columns.keys())
+    def get_col_names(self) -> KeysView:
+        return self._columns.keys()
 
     def get(self, name: str) -> Optional["ColumnSchema"]:
         return self._columns.get(name)

--- a/python/whylogs/core/schema.py
+++ b/python/whylogs/core/schema.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional, TypeVar
-from collections.abc import KeysView
+
 from whylogs.core.datatypes import StandardTypeMapper, TypeMapper
 from whylogs.core.metrics import Metric, MetricConfig
 from whylogs.core.resolvers import Resolver, StandardResolver
@@ -135,8 +135,8 @@ class DatasetSchema:
 
         return dirty
 
-    def get_col_names(self) -> KeysView:
-        return self._columns.keys()
+    def get_col_names(self) -> tuple:
+        return tuple(self._columns.keys())
 
     def get(self, name: str) -> Optional["ColumnSchema"]:
         return self._columns.get(name)

--- a/python/whylogs/core/schema.py
+++ b/python/whylogs/core/schema.py
@@ -135,8 +135,8 @@ class DatasetSchema:
 
         return dirty
 
-    def get_col_names(self) -> frozenset:
-        return frozenset(self._columns.keys())
+    def get_col_names(self) -> tuple:
+        return tuple(self._columns.keys())
 
     def get(self, name: str) -> Optional["ColumnSchema"]:
         return self._columns.get(name)


### PR DESCRIPTION
When logging a dataframe, order of the columns was not retained in profile/profile_view.

The problem is that `frozenset` doesn't retain order.

- Changed `schema's` `get_col_names` to return a tuple instead of frozenset (to ensure order and immutability)
- Replaced `difference()` (that only works with sets) with logic that works with tuples
- Added test to assert that order is retained

## Description

This repository needs <!-- Add 1-2 sentences explaining the purpose of this PR. -->

The commits in this pull request will <!-- Summarize PR. -->

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
