### PR TITLE
Add options to WhylabsWriter to unblock use with rolling logger

### DIFF
--- a/python/tests/api/writer/test_whylabs.py
+++ b/python/tests/api/writer/test_whylabs.py
@@ -76,3 +76,10 @@ class TestWhylabsWriter(object):
         os.environ["WHYLABS_API_KEY"] = "0123456789.any"
         with pytest.raises(ValueError):
             results.writer("whylabs").option(org_id="org_id", api_key="api_key_123.foo").write(dataset_id="dataset_id")
+
+    def test_writer_accepts_dest_param(self, results, caplog):
+        self.responses = responses.RequestsMock()
+        self.responses.start()
+        self.responses.add(PUT, url="https://api.whylabsapp.com", body=results.view().to_pandas().to_json())
+        with pytest.raises(ValueError):
+            results.writer("whylabs").option(api_key="bad_key_format").write(dataset_id="dataset_id", dest="tmp")

--- a/python/tests/api/writer/test_whylabs.py
+++ b/python/tests/api/writer/test_whylabs.py
@@ -78,8 +78,6 @@ class TestWhylabsWriter(object):
             results.writer("whylabs").option(org_id="org_id", api_key="api_key_123.foo").write(dataset_id="dataset_id")
 
     def test_writer_accepts_dest_param(self, results, caplog):
-        self.responses = responses.RequestsMock()
-        self.responses.start()
-        self.responses.add(PUT, url="https://api.whylabsapp.com", body=results.view().to_pandas().to_json())
+        # TODO: inspect error or mock better to avoid network call and keep test focused.
         with pytest.raises(ValueError):
             results.writer("whylabs").option(api_key="bad_key_format").write(dataset_id="dataset_id", dest="tmp")

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -83,7 +83,7 @@ class WhyLabsWriter(Writer):
         self,
         profile: Union[DatasetProfileView, DatasetProfile],
         dataset_id: Optional[str] = None,
-        **options,
+        **kwargs,
     ) -> Any:
         if dataset_id is not None:
             self._dataset_id = dataset_id

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -79,7 +79,12 @@ class WhyLabsWriter(Writer):
         if api_key is not None:
             self._api_key = api_key
 
-    def write(self, profile: Union[DatasetProfileView, DatasetProfile], dataset_id: Optional[str] = None) -> Any:
+    def write(
+        self,
+        profile: Union[DatasetProfileView, DatasetProfile],
+        dataset_id: Optional[str] = None,
+        dest: Optional[str] = None,
+    ) -> Any:
         if dataset_id is not None:
             self._dataset_id = dataset_id
 

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -83,7 +83,7 @@ class WhyLabsWriter(Writer):
         self,
         profile: Union[DatasetProfileView, DatasetProfile],
         dataset_id: Optional[str] = None,
-        dest: Optional[str] = None,
+        **options,
     ) -> Any:
         if dataset_id is not None:
             self._dataset_id = dataset_id


### PR DESCRIPTION
## Description

Add options to WhylabsWriter to unblock use with rolling logger, which passes a dest parameter and breaks WhylabsWriter's write call.

