### PR TITLE
Optionally skip lower-casing the strings

### DIFF
--- a/python/tests/core/metrics/test_unicode_range.py
+++ b/python/tests/core/metrics/test_unicode_range.py
@@ -27,7 +27,8 @@ def test_unicode_range_metric() -> None:
 
 
 def test_unicode_range_metric_upper_case() -> None:
-    metric = UnicodeRangeMetric({"lower": (97, 122), "upper": (65, 90)}, lower_case=False)
+    config = MetricConfig(unicode_ranges={"lower": (97, 122), "upper": (65, 90)}, lower_case=False)
+    metric = UnicodeRangeMetric.zero(config)
     strings = ["abc", "ABC", "123", "abcdABCD", "...", "wxYZ"]
     col = PreprocessedColumn.apply(strings)
     upper_counts = [0, 3, 0, 4, 0, 2]

--- a/python/tests/core/metrics/test_unicode_range.py
+++ b/python/tests/core/metrics/test_unicode_range.py
@@ -26,6 +26,18 @@ def test_unicode_range_metric() -> None:
     assert metric.submetrics[_STRING_LENGTH].mean.value == np.array([len(s) for s in strings]).mean()
 
 
+def test_unicode_range_metric_upper_case() -> None:
+    metric = UnicodeRangeMetric({"lower": (97, 122), "upper": (65, 90)}, lower_case=False)
+    strings = ["abc", "ABC", "123", "abcdABCD", "...", "wxYZ"]
+    col = PreprocessedColumn.apply(strings)
+    upper_counts = [0, 3, 0, 4, 0, 2]
+    lower_counts = [3, 0, 0, 4, 0, 2]
+    metric.columnar_update(col)
+
+    assert metric.submetrics["lower"].mean.value == np.array(lower_counts).mean()
+    assert metric.submetrics["upper"].mean.value == np.array(upper_counts).mean()
+
+
 def test_unicode_range_metric_unknown() -> None:
     metric = UnicodeRangeMetric({"digits": (48, 57), "alpha": (97, 122)})
     strings = ["1", "12", "123", "1234a", "abc", "abc123", "@@@", "%%%", "^^^"]

--- a/python/tests/core/metrics/test_unicode_range.py
+++ b/python/tests/core/metrics/test_unicode_range.py
@@ -27,7 +27,13 @@ def test_unicode_range_metric() -> None:
 
 
 def test_unicode_range_metric_upper_case() -> None:
-    config = MetricConfig(unicode_ranges={"lower": (97, 122), "upper": (65, 90)}, lower_case=False)
+    # fmt: off
+    ranges = {
+        "lower": (97, 122),  # a -- z
+        "upper": (65, 90)    # A -- Z
+    }
+    config = MetricConfig(unicode_ranges=ranges, lower_case=False)  # Distinguish between upper/lower case
+    # fmt: on
     metric = UnicodeRangeMetric.zero(config)
     strings = ["abc", "ABC", "123", "abcdABCD", "...", "wxYZ"]
     col = PreprocessedColumn.apply(strings)

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -53,8 +53,8 @@ class MetricConfig:
             "extended-latin": (0x0080, 0x02AF),
         }
     )
-    lower_case: bool = True
-    normalize: bool = True
+    lower_case: bool = True  # Convert Unicode characters to lower-case before counting Unicode ranges
+    normalize: bool = True  # Unicode normalize strings before counting Unicode ranges
 
 
 _METRIC_DESERIALIZER_REGISTRY: Dict[str, Type[METRIC]] = {}  # type: ignore

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -53,6 +53,8 @@ class MetricConfig:
             "extended-latin": (0x0080, 0x02AF),
         }
     )
+    lower_case: bool = True
+    normalize: bool = True
 
 
 _METRIC_DESERIALIZER_REGISTRY: Dict[str, Type[METRIC]] = {}  # type: ignore

--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -88,7 +88,6 @@ class UnicodeRangeMetric(CompoundMetric):
                 if not found:
                     range_counter["UNKNOWN"] += 1
 
-            print(range_counter)
             for range_name, range_count in range_counter.items():
                 range_data[range_name].append(range_count)
 

--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -36,6 +36,8 @@ class UnicodeRangeMetric(CompoundMetric):
     """
 
     range_definitions: Dict[str, Tuple[int, int]]
+    lower_case: bool = True
+    normalize: bool = True
 
     def __post_init__(self):
         super(type(self), self).__post_init__()
@@ -75,7 +77,9 @@ class UnicodeRangeMetric(CompoundMetric):
             lengths.append(len(value))
             range_counter: Dict[str, int] = {range_name: 0 for range_name in self.range_definitions.keys()}
             # TODO: need to transform to utf-32 or handle surrogates
-            for char in unicodedata.normalize("NFD", value).lower():
+            s = unicodedata.normalize("NFD", value) if self.normalize else value
+            s = s.lower() if self.lower_case else s
+            for char in s:
                 found = False
                 for range_name, range_limits in self.range_definitions.items():
                     if range_limits[0] <= ord(char) <= range_limits[1]:
@@ -84,6 +88,7 @@ class UnicodeRangeMetric(CompoundMetric):
                 if not found:
                     range_counter["UNKNOWN"] += 1
 
+            print(range_counter)
             for range_name, range_count in range_counter.items():
                 range_data[range_name].append(range_count)
 

--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -101,7 +101,7 @@ class UnicodeRangeMetric(CompoundMetric):
 
     @classmethod
     def zero(cls, config: MetricConfig) -> "UnicodeRangeMetric":
-        return cls(config.unicode_ranges)
+        return cls(config.unicode_ranges, lower_case=config.lower_case, normalize=config.normalize)
 
     @classmethod
     def from_protobuf(cls, msg: MetricMessage) -> "UnicodeRangeMetric":


### PR DESCRIPTION
## Description
Adds `lower_case` and `normalize` Boolean members to `MetricConfig` to optionally turn off lower-casing and normalization in the `UnicodeRangeMetric`.

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
