### PR TITLE
Fix README Docs hyperlink

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -6,7 +6,7 @@
 
  </h1>
   <h3 align="center">
-   <a href="https://docs.whylabs.ai/docs/"><b>Documentation</b></a> &bull;
+   <a href="https://whylogs.readthedocs.io/"><b>Documentation</b></a> &bull;
    <a href="https://bit.ly/whylogsslack"><b>Slack Community</b></a> &bull;
    <a href="https://github.com/whylabs/whylogs#python-quickstart"><b>Python Quickstart</b></a>
  </h3>


### PR DESCRIPTION
## Changes

Documentation hyperlink now pointing to [readthedocs](https://whylogs.readthedocs.io/) page

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
