### PR TITLE
Change KLL accuracy according to numerical/submetrics type

### DIFF
--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -38,7 +38,7 @@ METRIC = TypeVar("METRIC", bound="Metric")
 @dataclass(frozen=True)
 class MetricConfig:
     hll_lg_k: int = 12
-    kll_k: int = 256
+    kll_k: int = 1024
     fi_lg_max_k: int = 10  # 128 entries
     fi_disabled: bool = False
     track_unicode_ranges: bool = False

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -336,7 +336,7 @@ class DistributionMetric(Metric):
 
     @classmethod
     def zero(cls, config: MetricConfig) -> "DistributionMetric":
-        if config.track_unicode_ranges or config.customize_kll:
+        if config.customize_kll:
             sk = ds.kll_doubles_sketch(k=config.kll_k_custom)
         else:
             sk = ds.kll_doubles_sketch(k=config.kll_k)

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -42,6 +42,8 @@ class MetricConfig:
     fi_lg_max_k: int = 10  # 128 entries
     fi_disabled: bool = False
     track_unicode_ranges: bool = False
+    customize_kll: bool = False
+    kll_k_custom = 256
     unicode_ranges: Dict[str, Tuple[int, int]] = field(
         default_factory=lambda: {
             "emoticon": (0x1F600, 0x1F64F),
@@ -334,7 +336,10 @@ class DistributionMetric(Metric):
 
     @classmethod
     def zero(cls, config: MetricConfig) -> "DistributionMetric":
-        sk = ds.kll_doubles_sketch(k=config.kll_k)
+        if config.track_unicode_ranges or config.customize_kll:
+            sk = ds.kll_doubles_sketch(k=config.kll_k_custom)
+        else:
+            sk = ds.kll_doubles_sketch(k=config.kll_k)
         return DistributionMetric(
             kll=KllComponent(sk),
             mean=FractionalComponent(0.0),

--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -50,8 +50,10 @@ class UnicodeRangeMetric(CompoundMetric):
         if _STRING_LENGTH in self.range_definitions:
             raise ValueError("STRING_LENGTH cannot be used as a range name")
 
-        submetrics = {key: DistributionMetric.zero(MetricConfig()) for key in self.range_definitions.keys()}
-        submetrics[_STRING_LENGTH] = DistributionMetric.zero(MetricConfig())
+        submetrics = {
+            key: DistributionMetric.zero(MetricConfig(customize_kll=True)) for key in self.range_definitions.keys()
+        }
+        submetrics[_STRING_LENGTH] = DistributionMetric.zero(MetricConfig(customize_kll=True))
         super(type(self), self).__init__(submetrics)  # type: ignore
 
     @property

--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -51,9 +51,9 @@ class UnicodeRangeMetric(CompoundMetric):
             raise ValueError("STRING_LENGTH cannot be used as a range name")
 
         submetrics = {
-            key: DistributionMetric.zero(MetricConfig(kll_k_large=False)) for key in self.range_definitions.keys()
+            key: DistributionMetric.zero(MetricConfig(large_kll_k=False)) for key in self.range_definitions.keys()
         }
-        submetrics[_STRING_LENGTH] = DistributionMetric.zero(MetricConfig(kll_k_large=False))
+        submetrics[_STRING_LENGTH] = DistributionMetric.zero(MetricConfig(large_kll_k=False))
         super(type(self), self).__init__(submetrics)  # type: ignore
 
     @property

--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -51,9 +51,9 @@ class UnicodeRangeMetric(CompoundMetric):
             raise ValueError("STRING_LENGTH cannot be used as a range name")
 
         submetrics = {
-            key: DistributionMetric.zero(MetricConfig(customize_kll=True)) for key in self.range_definitions.keys()
+            key: DistributionMetric.zero(MetricConfig(kll_large=False)) for key in self.range_definitions.keys()
         }
-        submetrics[_STRING_LENGTH] = DistributionMetric.zero(MetricConfig(customize_kll=True))
+        submetrics[_STRING_LENGTH] = DistributionMetric.zero(MetricConfig(kll_large=False))
         super(type(self), self).__init__(submetrics)  # type: ignore
 
     @property

--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -51,9 +51,9 @@ class UnicodeRangeMetric(CompoundMetric):
             raise ValueError("STRING_LENGTH cannot be used as a range name")
 
         submetrics = {
-            key: DistributionMetric.zero(MetricConfig(kll_large=False)) for key in self.range_definitions.keys()
+            key: DistributionMetric.zero(MetricConfig(kll_k_large=False)) for key in self.range_definitions.keys()
         }
-        submetrics[_STRING_LENGTH] = DistributionMetric.zero(MetricConfig(kll_large=False))
+        submetrics[_STRING_LENGTH] = DistributionMetric.zero(MetricConfig(kll_k_large=False))
         super(type(self), self).__init__(submetrics)  # type: ignore
 
     @property


### PR DESCRIPTION
## Description

This PR aims to solve https://github.com/whylabs/whylogs/issues/684.

- changed kll_k from 256 to 1024, to avoid erratic behavior of ks-test drift calculation for large-sized samples
- adding customize_kll and kll_k_custom to distinguish kll accuracy between main numerical DistributionMetrics and submetrics (unicode, string_length, custom metrics)
- adding `customize_kll` flag when initializing DistributionMetrics for submetrics in the UnicodeRange Metric
## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
