### PR TITLE
Adds the BumpVersion for our CICD workflow

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -2,14 +2,14 @@
 current_version = 1.0.5
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = dev
-values = 
+values =
 	dev
 	prod
 

--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,0 +1,30 @@
+[bumpversion]
+current_version = 1.0.5
+tag = False
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
+serialize = 
+	{major}.{minor}.{patch}-{release}{build}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = prod
+first_value = dev
+values = 
+	dev
+	prod
+
+[bumpversion:file:src/whylogs/_version.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:docs/conf.py]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:Makefile]
+search = version := {current_version}
+replace = version := {new_version}
+
+[bumpversion:file:pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"

--- a/python/Makefile
+++ b/python/Makefile
@@ -39,6 +39,31 @@ install-poetry:
 help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
+bump-patch: ## Bump the patch version (_._.X) everywhere it appears in the project
+	@$(call i, Bumping the patch number)
+	poetry run bumpversion patch --allow-dirty
+
+bump-minor: ## Bump the minor version (_.X._) everywhere it appears in the project
+	@$(call i, Bumping the minor number)
+	poetry run bumpversion minor --allow-dirty
+
+bump-major: ## Bump the major version (X._._) everywhere it appears in the project
+	@$(call i, Bumping the major number)
+	poetry run bumpversion major --allow-dirty
+
+bump-release: ## Convert the version into a release variant (_._._) everywhere it appears in the project
+	@$(call i, Bumping the major number)
+	poetry run bumpversion release --allow-dirty
+
+bump-dev: ## Convert the version into a dev variant (_._._-dev__) everywhere it appears in the project
+	@$(call i, Bumping the major number)
+	poetry run bumpversion dev --allow-dirty
+
+bump-build: ## Bump the build number (_._._-____XX) everywhere it appears in the project
+	@$(call i, Bumping the major number)
+	poetry run bumpversion build --allow-dirty
+
+
 publish: clean dist ## Clean the project, generate new distribution files and publish them to pypi
 	@$(call i, Publishing the currently built dist to pypi)
 	poetry publish

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -175,6 +175,14 @@ urllib3 = ">=1.25.4,<1.27"
 crt = ["awscrt (==0.13.8)"]
 
 [[package]]
+name = "bump2version"
+version = "1.0.1"
+description = "Version-bump your software with a single command!"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "certifi"
 version = "2022.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -1685,6 +1693,22 @@ python-versions = ">=3.6"
 sphinx = ">=2.0"
 
 [[package]]
+name = "sphinx-rtd-theme"
+version = "0.5.2"
+description = "Read the Docs theme for Sphinx"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+docutils = "<0.17"
+sphinx = "*"
+
+[package.extras]
+dev = ["transifex-client", "sphinxcontrib-httpdomain", "bump2version"]
+
+
+[[package]]
 name = "tabulate"
 version = "0.8.10"
 description = "Pretty-print tabular data"
@@ -1981,6 +2005,10 @@ boto3 = [
 botocore = [
     {file = "botocore-1.27.19-py3-none-any.whl", hash = "sha256:e52c77fb349ae5d2a36ba0c2d1dc1416d963f987139dc2e036d2d8d697e4b4c7"},
     {file = "botocore-1.27.19.tar.gz", hash = "sha256:850bec9363e10c56b2678c3742a48150f6201d7184695326a380fe7341075484"},
+]
+bump2version = [
+    {file = "bump2version-1.0.1-py2.py3-none-any.whl", hash = "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410"},
+    {file = "bump2version-1.0.1.tar.gz", hash = "sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6"},
 ]
 certifi = [
     {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -1692,13 +1692,6 @@ python-versions = ">=3.6"
 [package.dependencies]
 sphinx = ">=2.0"
 
-[[package]]
-name = "sphinx-rtd-theme"
-version = "0.5.2"
-description = "Read the Docs theme for Sphinx"
-category = "dev"
-optional = false
-python-versions = "*"
 
 [package.dependencies]
 docutils = "<0.17"

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -1692,15 +1692,6 @@ python-versions = ">=3.6"
 [package.dependencies]
 sphinx = ">=2.0"
 
-
-[package.dependencies]
-docutils = "<0.17"
-sphinx = "*"
-
-[package.extras]
-dev = ["transifex-client", "sphinxcontrib-httpdomain", "bump2version"]
-
-
 [[package]]
 name = "tabulate"
 version = "0.8.10"


### PR DESCRIPTION
## Description
Get's the bumpversion ability we had in v0 ported over to v1. This allows our github actions bump the appropriate number while keeping everything in sync

## Changes

- Changes the makefile
- Adds a config file
- Hooks it together in poetry

## Related
#688  #689 

- [ X] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
