### PR TITLE
fix contribution.md hyperlink on readme

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -250,7 +250,7 @@ If you have any questions, comments, or just want to hang out with us, please jo
 
 ### How to Contribute
 
-We welcome contributions to whylogs. Please see our [contribution guide](https://github.com/whylabs/whylogs/blob/mainline/CONTRIBUTING.md) and our [development guide](https://github.com/whylabs/whylogs/blob/mainline/DEVELOPMENT.md) for details.
+We welcome contributions to whylogs. Please see our [contribution guide](https://github.com/whylabs/whylogs/blob/mainline/.github/CONTRIBUTING.md) for details.
 
 ### Contributors
 


### PR DESCRIPTION
## Description

Fixing CONTRIBUTING.md hyperlink on README.
**PS.:** Removed DEVELOPMENT.md because we don't have it anymore on the repo. Should we?

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
