### PR TITLE
add sort by drift p-values

### DIFF
--- a/python/whylogs/viz/html/templates/index-hbs-cdn-all-in-for-jupyter-notebook.html
+++ b/python/whylogs/viz/html/templates/index-hbs-cdn-all-in-for-jupyter-notebook.html
@@ -776,8 +776,11 @@
                         <div class="wl-table-head table-border-none graph-table-head">Target</div>
                         <div class="wl-table-head table-border-none reference-table-head">Reference</div>
                       </div>
-                      <div class="wl-table-head wl-sub-table-head text-align-center" id="diff-from-ref">
-                        p-value
+                      <div class="wl-table-head wl-sub-table-head text-align-center" style="cursor: pointer;" id="diff-from-ref">
+                        <p id="pvalue" > p-value </p>
+                        <p id="pvalue-asc" style="display: none;"> p-value &#9650 </p>
+                        <p id="pvalue-desc" style="display: none;"> p-value &#9660 </p>
+
                         <div class="tooltip-full-number">
                             <span class="question-mark">?</span>
                           <span class="tooltiptext">
@@ -796,6 +799,7 @@
                     data-feature-name={{@key}}
                     data-inferred-type={{inferredType this}}
                     data-scroll-to-feature-name={{@key}}
+                    data-p-value={{getpvalue this}}
                   >
                       <div class="wl-table-cell wl-table-cell__graph-wrap">
                         <div class="wl-table-cell__title-wrap">
@@ -1117,6 +1121,18 @@
          }
        }
 
+
+       Handlebars.registerHelper("getpvalue", function (column, key) {
+        const columnKey = key.data.key
+        const {drift_from_ref} = referenceProfile.columns[columnKey]
+
+        if (cheqValueTypeNumber(referenceProfile, drift_from_ref)) {
+          const driftFromRefNumber = drift_from_ref.toPrecision(2)
+          return Number(driftFromRefNumber)
+
+        }
+      });
+
       Handlebars.registerHelper("getDiffFromRef", function (column, key) {
         const columnKey = key.data.key
         const {drift_from_ref} = referenceProfile.columns[columnKey]
@@ -1244,12 +1260,20 @@
       const $discrete = document.getElementById("inferredDiscrete");
       const $nonDiscrete = document.getElementById("inferredNonDiscrete");
       const $unknown = document.getElementById("inferredUnknown");
+      const $diffFromRef = document.getElementById("diff-from-ref");
 
       const activeTypes = {
         discrete: true,
         "non-discrete": true,
         unknown: true,
       };
+
+      var driftOrder = {
+        original: true,
+        descending: false,
+        ascending: false,
+      };
+      var originalColumnOrder;
 
       let searchString = "";
 
@@ -1282,13 +1306,49 @@
         }
       }
 
+
+      function orderByDrift(direction) {
+        var tableBodyChildren = $tableBody.children;
+        if (driftOrder['original']) {
+          driftOrder['original'] = false
+          driftOrder['descending'] = true
+
+          originalColumnOrder = [...tableBodyChildren];
+          tableBodyChildren = [...tableBodyChildren].sort((a,b) => (b.dataset.pValue - a.dataset.pValue))
+          document.getElementById("pvalue").style.display = "none";
+          document.getElementById("pvalue-desc").style.display = "";
+          
+        } else if (driftOrder['descending']) {
+          driftOrder['descending'] = false
+          driftOrder['ascending'] = true
+          tableBodyChildren = [...tableBodyChildren].sort((a,b) => (a.dataset.pValue - b.dataset.pValue))
+          document.getElementById("pvalue-desc").style.display = "none";
+          document.getElementById("pvalue-asc").style.display = "";
+
+
+        } else if (driftOrder['ascending']) {
+          driftOrder['ascending'] = false
+          driftOrder['original'] = true
+
+          tableBodyChildren = originalColumnOrder;
+          document.getElementById("pvalue-asc").style.display = "none";
+          document.getElementById("pvalue").style.display = "";
+
+        }
+
+        for (let i = 0; i < tableBodyChildren.length; i++) {
+          console.log(tableBodyChildren[i].dataset.pValue)
+        }
+        for (var i = 0; i < tableBodyChildren.length; i++){$tableBody.append(tableBodyChildren[i])}
+      }
+
+
       function handleSearch() {
         const tableBodyChildren = $tableBody.children;
 
         for (let i = 0; i < tableBodyChildren.length; i++) {
           const type = tableBodyChildren[i].dataset.inferredType.toLowerCase();
           const name = tableBodyChildren[i].dataset.featureName.toLowerCase();
-
           if (activeTypes[type] && name.startsWith(searchString)) {
             tableBodyChildren[i].style.display = "";
           } else {
@@ -1302,6 +1362,13 @@
         debounce((event) => {
           searchString = event.target.value.toLowerCase();
           handleSearch();
+        }, 100),
+      );
+
+      $diffFromRef.addEventListener(
+        "click",
+        debounce((event) => {
+          orderByDrift();
         }, 100),
       );
 

--- a/python/whylogs/viz/html/templates/index-hbs-cdn-all-in-for-jupyter-notebook.html
+++ b/python/whylogs/viz/html/templates/index-hbs-cdn-all-in-for-jupyter-notebook.html
@@ -1317,7 +1317,7 @@
           tableBodyChildren = [...tableBodyChildren].sort((a,b) => (b.dataset.pValue - a.dataset.pValue))
           document.getElementById("pvalue").style.display = "none";
           document.getElementById("pvalue-desc").style.display = "";
-          
+
         } else if (driftOrder['descending']) {
           driftOrder['descending'] = false
           driftOrder['ascending'] = true


### PR DESCRIPTION
## Description
This adds functionality of sorting features by drift p-values.
Clicking on column header `p-value` will rearrange features in ascending, descending or original order. It will rotate in this sequence: original -> descending -> ascending -> (repeats)

## Changes
- Added event and function for sorting by pvalue
- Added clickable style for p-value column
- Added up/down arrows next to p-value column to show the current order
## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
