### PR TITLE
Add python working directory for python commands in release workflow

### DIFF
--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -1,9 +1,13 @@
-name: Upload Whylogs Packages
+name: Upload whylogs python Packages
 
 on:
   release:
     types: [released, prereleased]
   workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: python
 
 jobs:
   deploy:


### PR DESCRIPTION
## Description

Try to fix the release workflow so that the "make install" executes in the python directory for the python related release steps.