### PR TITLE
Orders all views columns before sending to pandas

### DIFF
--- a/python/tests/core/view/test_dataset_profile_view.py
+++ b/python/tests/core/view/test_dataset_profile_view.py
@@ -43,3 +43,43 @@ def test_order_columns() -> None:
     data_keys = d.keys()
     profile_keys = profile_view.get_columns().keys()
     assert data_keys == profile_keys
+
+
+def test_sort_columns_sending_to_pandas() -> None:
+    data = {
+        "animal": ["cat", "hawk", "snake", "cat"],
+        "legs": [4, 2, 0, 4],
+        "weight": [4.3, 1.8, 1.3, 4.1],
+    }
+
+    df = pd.DataFrame(data)
+    profile_view = why.log(df).profile().view()
+    view1 = profile_view.to_pandas().columns
+
+    merged_view = profile_view.merge(profile_view)
+    view2 = merged_view.to_pandas().columns
+    assert (view1 == view2).all()
+
+
+def test_different_ordered() -> None:
+    data1 = {
+        "animal": ["cat", "hawk", "snake", "cat"],
+        "legs": [4, 2, 0, 4],
+        "weight": [4.3, 1.8, 1.3, 4.1],
+    }
+    data2 = {
+        "legs": [4, 2, 0, 4],
+        "animal": ["cat", "hawk", "snake", "cat"],
+        "weight": [4.3, 1.8, 1.3, 4.1],
+    }
+
+    df1 = pd.DataFrame(data1)
+    profile_view1 = why.log(df1).profile().view()
+    view1 = profile_view1.to_pandas().columns
+
+    df2 = pd.DataFrame(data2)
+    profile_view2 = why.log(df2).profile().view()
+
+    merged_view = profile_view1.merge(profile_view2)
+    view2 = merged_view.to_pandas().columns
+    assert (view1 == view2).all()

--- a/python/whylogs/core/view/dataset_profile_view.py
+++ b/python/whylogs/core/view/dataset_profile_view.py
@@ -225,6 +225,6 @@ class DatasetProfileView(object):
             sum_dict = col.to_summary_dict(column_metric=column_metric, cfg=cfg)
             sum_dict["column"] = col_name
             sum_dict["type"] = SummaryType.COLUMN
-            all_dicts.append(sum_dict)
+            all_dicts.append(dict(sorted(sum_dict.items())))
         df = pd.DataFrame(all_dicts)
         return df.set_index("column")

--- a/python/whylogs/core/view/dataset_profile_view.py
+++ b/python/whylogs/core/view/dataset_profile_view.py
@@ -226,7 +226,7 @@ class DatasetProfileView(Writable):
 
     def to_pandas(self, column_metric: Optional[str] = None, cfg: Optional[SummaryConfig] = None) -> pd.DataFrame:
         all_dicts = []
-        for col_name, col in self._columns.items():
+        for col_name, col in sorted(self._columns.items()):
             sum_dict = col.to_summary_dict(column_metric=column_metric, cfg=cfg)
             sum_dict["column"] = col_name
             sum_dict["type"] = SummaryType.COLUMN

--- a/python/whylogs/viz/notebook_profile_viz.py
+++ b/python/whylogs/viz/notebook_profile_viz.py
@@ -4,8 +4,6 @@ import logging
 import os
 from typing import Any, Dict, Optional
 
-from IPython.core.display import HTML  # type: ignore
-
 from whylogs.api.usage_stats import emit_usage
 from whylogs.core.configs import SummaryConfig
 from whylogs.core.constraints import Constraints
@@ -19,6 +17,8 @@ from whylogs.viz.utils.profile_viz_calculations import (
     generate_summaries,
     histogram_from_view,
 )
+
+from IPython.core.display import HTML  # type: ignore
 
 logger = logging.getLogger(__name__)
 emit_usage("visualizer")

--- a/python/whylogs/viz/notebook_profile_viz.py
+++ b/python/whylogs/viz/notebook_profile_viz.py
@@ -4,6 +4,8 @@ import logging
 import os
 from typing import Any, Dict, Optional
 
+from IPython.core.display import HTML  # type: ignore
+
 from whylogs.api.usage_stats import emit_usage
 from whylogs.core.configs import SummaryConfig
 from whylogs.core.constraints import Constraints
@@ -17,8 +19,6 @@ from whylogs.viz.utils.profile_viz_calculations import (
     generate_summaries,
     histogram_from_view,
 )
-
-from IPython.core.display import HTML  # type: ignore
 
 logger = logging.getLogger(__name__)
 emit_usage("visualizer")


### PR DESCRIPTION
## Description

To keep things easy to use every profile should have the same order for metrics and columns. There is no bug for how they merge, just to make it easy to use and less confusing. 

## Changes

- sorts the dictionary by column name before sending to pandas

## Related

Closes #648

- [ X] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
