### PR TITLE
Fix using None as type when pandas is not present

### DIFF
--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -100,7 +100,7 @@ class DatasetProfile(Writable):
             if row is not None:
                 raise ValueError("Cannot pass both obj and row params")
 
-            if isinstance(obj, pd.DataFrame):
+            if pd.DataFrame is not None and isinstance(obj, pd.DataFrame):
                 pandas = obj
             elif isinstance(obj, (dict, Dict, Mapping)):
                 row = obj

--- a/python/whylogs/core/datatypes.py
+++ b/python/whylogs/core/datatypes.py
@@ -86,7 +86,7 @@ class String(DataType[str]):
     @classmethod
     def _do_match(cls, dtype_or_type: Any, maybe_type: Optional[Any]) -> bool:
         # Pandas Categorical is Strings
-        if isinstance(dtype_or_type, CategoricalDtype):
+        if CategoricalDtype is not None and isinstance(dtype_or_type, CategoricalDtype):
             return True
 
         # handle pandas series. Anything 'object' is treated as a Series of strings

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -170,7 +170,7 @@ class PreprocessedColumn:
     def apply(data: Any) -> "PreprocessedColumn":
         result = PreprocessedColumn()
         result.original = data
-        if isinstance(data, pd.Series):
+        if pd.Series is not None and isinstance(data, pd.Series):
             result._pandas_split(data)
             result.len = len(data)
             return result


### PR DESCRIPTION
## Description

If pandas is not installed we hit errors when doing isinstance checks against None, so we need to check if the pandas stubs are None before instance checks.

Tested on docker image without pandas
```
In [1]: import whylogs as why

In [2]: d = { "animal": ["cat"] }

In [4]: r =why.log(d)

In [5]: profile_view = r.view()
In [10]: profile_view.get_columns()
Out[10]: {'animal': <whylogs.core.view.column_profile_view.ColumnProfileView at 0x55158f0940>}

In [11]: profile_view.get_column("animal")
Out[11]: <whylogs.core.view.column_profile_view.ColumnProfileView at 0x55158f0940>

In [12]: c = profile_view.get_column("animal")

In [14]: c.to_summary_dict()
Out[14]:
{'counts/n': 1,
 'counts/null': 0,
 'types/integral': 0,
 'types/fractional': 0,
 'types/boolean': 0,
 'types/string': 0,
 'types/object': 1}

```

without these changes you get an error something like:

```
File /usr/local/lib/python3.8/dist-packages/whylogs/core/dataset_profile.py:103, in DatasetProfile._do_track(self, obj, pandas, row)
    100 if row is not None:
    101     raise ValueError("Cannot pass both obj and row params")
--> 103 if isinstance(obj, pd.DataFrame):
    104     pandas = obj


TypeError: isinstance() arg 2 must be a type or tuple of types
```