### PR TITLE
Stabilizing IPython init

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -12,7 +12,7 @@ from python.whylogs.core.constraints.metric_constraints import (
 import whylogs as why
 from whylogs import ResultSet
 from whylogs.core.view.dataset_profile_view import DatasetProfileView
-from whylogs.viz.extensions.reports.summary_drift import SummaryDriftReport
+from whylogs.viz import SummaryDriftReport
 
 _MY_DIR = os.path.realpath(os.path.dirname(__file__))
 _DATA_DIR = os.path.join(_MY_DIR, "testdata")

--- a/python/whylogs/viz/__init__.py
+++ b/python/whylogs/viz/__init__.py
@@ -1,8 +1,10 @@
 import IPython  # type: ignore  # noqa  # import ipython to make
 
+from whylogs.viz.extensions.reports.summary_drift import SummaryDriftReport
 from whylogs.viz.notebook_profile_viz import NotebookProfileVisualizer
 
 __ALL__ = [
     # column
     NotebookProfileVisualizer,
+    SummaryDriftReport,
 ]


### PR DESCRIPTION
Details: tests are intermittently passing, due to a circular import in IPython. moved SummaryDriftReport to whylogs.viz init to try to avoid this

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
