### PR TITLE
Fix DatasetProfile not resolving with a custom schema

### DIFF
--- a/python/tests/core/view/test_dataset_profile.py
+++ b/python/tests/core/view/test_dataset_profile.py
@@ -78,3 +78,14 @@ def test_different_int_types(profile, data_type) -> None:
     for row in df.iterrows():
         profile.track(row=row[1].to_dict())  # type: ignore
     assert profile._columns["col1"]._schema.dtype == int
+
+
+def test_track_with_custom_schema() -> None:
+    class MySchema(DatasetSchema):
+        types = {"col1": str, "col2": np.int32, "col3": str}
+
+    schema = MySchema()
+    prof = DatasetProfile(schema=schema)
+    df = pd.DataFrame({"col1": ["foo"], "col2": np.array([1], dtype=np.int32), "col3": ["bar"]})
+    prof.track(pandas=df)
+    assert prof._columns.keys() == prof._schema._columns.keys()

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -48,6 +48,8 @@ class DatasetProfile(Writable):
         self._columns: Dict[str, ColumnProfile] = dict()
         self._is_active = False
         self._track_count = 0
+        new_cols = schema.get_col_names()
+        self._initialize_new_columns(new_cols)
 
     @property
     def creation_timestamp(self) -> datetime:
@@ -113,12 +115,7 @@ class DatasetProfile(Writable):
         if dirty:
             schema_col_keys = self._schema.get_col_names()
             new_cols = (col for col in schema_col_keys if col not in self._columns)
-            for col in new_cols:
-                col_schema = self._schema.get(col)
-                if col_schema:
-                    self._columns[col] = ColumnProfile(name=col, schema=col_schema, cache_size=self._schema.cache_size)
-                else:
-                    logger.warning("Encountered a column without schema: %s", col)
+            self._initialize_new_columns(tuple(new_cols))
 
         if pandas is not None:
             for k in pandas.keys():
@@ -131,6 +128,14 @@ class DatasetProfile(Writable):
             return
 
         raise NotImplementedError
+
+    def _initialize_new_columns(self, new_cols: tuple) -> None:
+        for col in new_cols:
+            col_schema = self._schema.get(col)
+            if col_schema:
+                self._columns[col] = ColumnProfile(name=col, schema=col_schema, cache_size=self._schema.cache_size)
+            else:
+                logger.warning("Encountered a column without schema: %s", col)
 
     def view(self) -> DatasetProfileView:
         columns = {}


### PR DESCRIPTION
DatasetProfile grab initial columns from the schema
to keep them in synch.


## Changes

- `DatasetProfile` copies the initial columns from the `DatasetSchema`

## Related


Closes whylabs/whylogs#717

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
