### PR TITLE
make plots not sticky when scrolling horizontally

### DIFF
--- a/python/whylogs/viz/html/templates/index-hbs-cdn-all-in-for-jupyter-notebook.html
+++ b/python/whylogs/viz/html/templates/index-hbs-cdn-all-in-for-jupyter-notebook.html
@@ -168,7 +168,7 @@
       }
 
       .wl-table-head {
-        position: sticky;
+        position: relative;
         left: 0;
         min-width: 100px;
         border-bottom: 2px solid var(--brandSecondary100);
@@ -186,7 +186,7 @@
       }
 
       .wl-table-row .wl-table-cell:first-child{
-        position: sticky;
+        position: relative;
         left: 0;
         background-color: var(--white);
         border-right-width: 2px;


### PR DESCRIPTION
## Description

When scrolling horizontally, target and reference plots were fixed. That makes it hard to visualize other metrics.

With the changes, plots scroll together with the rest of the columns

The commits in this pull request will <!-- Summarize PR. -->

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
