### PR TITLE
Aggregator for Metric Components

### DIFF
--- a/java/core/src/main/java/com/whylogs/core/metrics/aggregators/AggregatorRegistry.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/aggregators/AggregatorRegistry.java
@@ -1,0 +1,33 @@
+package com.whylogs.core.metrics.aggregators;
+
+import com.whylogs.core.metrics.components.MetricComponent;
+import lombok.Data;
+
+import java.util.HashMap;
+
+@Data
+public class AggregatorRegistry {
+    private HashMap<String, IAggregator> namedAggregators;
+    private HashMap<Integer, IAggregator> idAggregators;
+
+    public <T extends MetricComponent> void register(T component, IAggregator aggregator) {
+        idAggregators.put(component.getTypeId(), aggregator);
+        namedAggregators.put(component.getTypeName(), aggregator);
+    }
+
+    public void register(int typeId, IAggregator aggregator) {
+        idAggregators.put(typeId, aggregator);
+    }
+
+    public IAggregator get(MetricComponent component) {
+        return idAggregators.get(component.getTypeId());
+    }
+
+    public IAggregator get(int typeId) {
+        return idAggregators.get(typeId);
+    }
+
+    public IAggregator get(String typeName) {
+        return namedAggregators.get(typeName);
+    }
+}

--- a/java/core/src/main/java/com/whylogs/core/metrics/aggregators/AggregatorRegistry.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/aggregators/AggregatorRegistry.java
@@ -1,52 +1,49 @@
 package com.whylogs.core.metrics.aggregators;
 
 import com.whylogs.core.metrics.components.MetricComponent;
-import lombok.Data;
-import lombok.Synchronized;
-
 import java.util.HashMap;
 import java.util.function.BiFunction;
-
 
 // Registry for aggregators. You can register a component or a type-id to an aggregator.
 // The aggregators are of IAggregator which is just a wrapper on BiFunction.
 // This allows the use of lambdas to create aggregators.
 public class AggregatorRegistry {
-    private final HashMap<String, BiFunction> namedAggregators;
-    private final HashMap<Integer, BiFunction> idAggregators;
+  private final HashMap<String, BiFunction> namedAggregators;
+  private final HashMap<Integer, BiFunction> idAggregators;
 
-    private AggregatorRegistry() {
-        this.namedAggregators = new HashMap<>();
-        this.idAggregators = new HashMap<>();
-    }
+  private AggregatorRegistry() {
+    this.namedAggregators = new HashMap<>();
+    this.idAggregators = new HashMap<>();
+  }
 
-    // Instance holder to avoid double checking anti-pattern for singlton
-    private static final class InstanceHolder {
-        static final AggregatorRegistry instance = new AggregatorRegistry();
-    }
+  // Instance holder to avoid double checking anti-pattern for singlton
+  private static final class InstanceHolder {
+    static final AggregatorRegistry instance = new AggregatorRegistry();
+  }
 
-    public static AggregatorRegistry getInstance() {
-        return InstanceHolder.instance;
-    }
+  public static AggregatorRegistry getInstance() {
+    return InstanceHolder.instance;
+  }
 
-    public <T extends MetricComponent, A extends BiFunction> void register(T component,  A aggregator) {
-        idAggregators.put(component.getTypeId(), aggregator);
-        namedAggregators.put(component.getTypeName(), aggregator);
-    }
+  public <T extends MetricComponent, A extends BiFunction> void register(
+      T component, A aggregator) {
+    idAggregators.put(component.getTypeId(), aggregator);
+    namedAggregators.put(component.getTypeName(), aggregator);
+  }
 
-    public <A extends BiFunction> void register(int typeId, A aggregator) {
-        idAggregators.put(typeId, aggregator);
-    }
+  public <A extends BiFunction> void register(int typeId, A aggregator) {
+    idAggregators.put(typeId, aggregator);
+  }
 
-    public BiFunction get(MetricComponent component) {
-        return idAggregators.get(component.getTypeId());
-    }
+  public BiFunction get(MetricComponent component) {
+    return idAggregators.get(component.getTypeId());
+  }
 
-    public BiFunction get(int typeId) {
-        return idAggregators.get(typeId);
-    }
+  public BiFunction get(int typeId) {
+    return idAggregators.get(typeId);
+  }
 
-    public BiFunction get(String typeName) {
-        return namedAggregators.get(typeName);
-    }
+  public BiFunction get(String typeName) {
+    return namedAggregators.get(typeName);
+  }
 }

--- a/java/core/src/main/java/com/whylogs/core/metrics/aggregators/AggregatorRegistry.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/aggregators/AggregatorRegistry.java
@@ -6,6 +6,9 @@ import lombok.Data;
 import java.util.HashMap;
 
 @Data
+// Registry for aggregators. You can register a component or a type-id to an aggregator.
+// The aggregators are of IAggregator which is just a wrapper on BiFunction.
+// This allows the use of lambdas to create aggregators.
 public class AggregatorRegistry {
     private HashMap<String, IAggregator> namedAggregators;
     private HashMap<Integer, IAggregator> idAggregators;

--- a/java/core/src/main/java/com/whylogs/core/metrics/aggregators/IAggregator.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/aggregators/IAggregator.java
@@ -3,6 +3,6 @@ package com.whylogs.core.metrics.aggregators;
 import com.whylogs.core.errors.UnsupportedError;
 import java.util.function.BiFunction;
 
-public interface IAggregator<T, U, R> extends BiFunction<T, U, R> {
-  R merge(T lhs, U rhs) throws UnsupportedError;
+public interface IAggregator<T> extends BiFunction<T, T, T> {
+  T merge(T lhs, T rhs) throws UnsupportedError;
 }

--- a/java/core/src/main/java/com/whylogs/core/metrics/aggregators/IAggregator.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/aggregators/IAggregator.java
@@ -1,0 +1,9 @@
+package com.whylogs.core.metrics.aggregators;
+
+import com.whylogs.core.errors.UnsupportedError;
+
+import java.util.function.BiFunction;
+
+public interface IAggregator<T, U, R> extends BiFunction<T, U, R> {
+    R merge(T lhs, U rhs) throws UnsupportedError;
+}

--- a/java/core/src/main/java/com/whylogs/core/metrics/aggregators/IAggregator.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/aggregators/IAggregator.java
@@ -1,9 +1,8 @@
 package com.whylogs.core.metrics.aggregators;
 
 import com.whylogs.core.errors.UnsupportedError;
-
 import java.util.function.BiFunction;
 
 public interface IAggregator<T, U, R> extends BiFunction<T, U, R> {
-    R merge(T lhs, U rhs) throws UnsupportedError;
+  R merge(T lhs, U rhs) throws UnsupportedError;
 }

--- a/java/core/src/main/java/com/whylogs/core/metrics/aggregators/NumberSumAggregator.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/aggregators/NumberSumAggregator.java
@@ -4,7 +4,7 @@ import com.whylogs.core.errors.UnsupportedError;
 import lombok.SneakyThrows;
 
 // This sum forces lhs, rhs, and result to be the same type
-public class NumberSumAggregator<T extends Number> implements IAggregator<T, T, T> {
+public class NumberSumAggregator<T extends Number> implements IAggregator<T> {
 
   @Override
   public T merge(T lhs, T rhs) throws UnsupportedError {

--- a/java/core/src/main/java/com/whylogs/core/metrics/aggregators/NumberSumAggregator.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/aggregators/NumberSumAggregator.java
@@ -4,7 +4,7 @@ import com.whylogs.core.errors.UnsupportedError;
 import lombok.SneakyThrows;
 
 // This sum forces lhs, rhs, and result to be the same type
-public class SumAggregator<T extends Number> implements IAggregator<T, T, T> {
+public class NumberSumAggregator<T extends Number> implements IAggregator<T, T, T> {
 
     @Override
     public T merge(T lhs, T rhs) throws UnsupportedError {

--- a/java/core/src/main/java/com/whylogs/core/metrics/aggregators/NumberSumAggregator.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/aggregators/NumberSumAggregator.java
@@ -6,44 +6,44 @@ import lombok.SneakyThrows;
 // This sum forces lhs, rhs, and result to be the same type
 public class NumberSumAggregator<T extends Number> implements IAggregator<T, T, T> {
 
-    @Override
-    public T merge(T lhs, T rhs) throws UnsupportedError {
-        if (lhs instanceof Double){
-            Double result = lhs.doubleValue() + rhs.doubleValue();
-            return (T) result;
-        }
-
-        if (lhs instanceof Float){
-            Float result = lhs.floatValue() + rhs.floatValue();
-            return (T) result;
-        }
-
-        if (lhs instanceof Long) {
-            Long result = lhs.longValue() + rhs.longValue();
-            return (T) result;
-        }
-
-        if(lhs instanceof Integer) {
-            Integer result = lhs.intValue() + rhs.intValue();
-            return (T) result;
-        }
-
-        if(lhs instanceof Short) {
-            Short result = (short) (lhs.shortValue() + rhs.shortValue());
-            return (T) result;
-        }
-
-        if(lhs instanceof Byte) {
-            Byte result = (byte) (lhs.byteValue() + rhs.byteValue());
-            return (T) result;
-        }
-
-        throw new UnsupportedError("Unsupported type for sum: " + lhs.getClass().getName());
+  @Override
+  public T merge(T lhs, T rhs) throws UnsupportedError {
+    if (lhs instanceof Double) {
+      Double result = lhs.doubleValue() + rhs.doubleValue();
+      return (T) result;
     }
 
-    @SneakyThrows
-    @Override
-    public T apply(T lhs, T rhs){
-        return merge(lhs, rhs);
+    if (lhs instanceof Float) {
+      Float result = lhs.floatValue() + rhs.floatValue();
+      return (T) result;
     }
+
+    if (lhs instanceof Long) {
+      Long result = lhs.longValue() + rhs.longValue();
+      return (T) result;
+    }
+
+    if (lhs instanceof Integer) {
+      Integer result = lhs.intValue() + rhs.intValue();
+      return (T) result;
+    }
+
+    if (lhs instanceof Short) {
+      Short result = (short) (lhs.shortValue() + rhs.shortValue());
+      return (T) result;
+    }
+
+    if (lhs instanceof Byte) {
+      Byte result = (byte) (lhs.byteValue() + rhs.byteValue());
+      return (T) result;
+    }
+
+    throw new UnsupportedError("Unsupported type for sum: " + lhs.getClass().getName());
+  }
+
+  @SneakyThrows
+  @Override
+  public T apply(T lhs, T rhs) {
+    return merge(lhs, rhs);
+  }
 }

--- a/java/core/src/main/java/com/whylogs/core/metrics/aggregators/SumAggregator.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/aggregators/SumAggregator.java
@@ -1,0 +1,49 @@
+package com.whylogs.core.metrics.aggregators;
+
+import com.whylogs.core.errors.UnsupportedError;
+import lombok.SneakyThrows;
+
+// This sum forces lhs, rhs, and result to be the same type
+public class SumAggregator<T extends Number> implements IAggregator<T, T, T> {
+
+    @Override
+    public T merge(T lhs, T rhs) throws UnsupportedError {
+        if (lhs instanceof Double){
+            Double result = lhs.doubleValue() + rhs.doubleValue();
+            return (T) result;
+        }
+
+        if (lhs instanceof Float){
+            Float result = lhs.floatValue() + rhs.floatValue();
+            return (T) result;
+        }
+
+        if (lhs instanceof Long) {
+            Long result = lhs.longValue() + rhs.longValue();
+            return (T) result;
+        }
+
+        if(lhs instanceof Integer) {
+            Integer result = lhs.intValue() + rhs.intValue();
+            return (T) result;
+        }
+
+        if(lhs instanceof Short) {
+            Short result = (short) (lhs.shortValue() + rhs.shortValue());
+            return (T) result;
+        }
+
+        if(lhs instanceof Byte) {
+            Byte result = (byte) (lhs.byteValue() + rhs.byteValue());
+            return (T) result;
+        }
+
+        throw new UnsupportedError("Unsupported type for sum: " + lhs.getClass().getName());
+    }
+
+    @SneakyThrows
+    @Override
+    public T apply(T lhs, T rhs){
+        return merge(lhs, rhs);
+    }
+}

--- a/java/core/src/main/java/com/whylogs/core/metrics/components/IntegralComponent.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/components/IntegralComponent.java
@@ -10,4 +10,9 @@ public class IntegralComponent extends MetricComponent<Integer> {
     public IntegralComponent(Integer value) {
         super(value);
     }
+
+    @Override
+    public String getTypeName() {
+        return this.getClass().getSimpleName();
+    }
 }

--- a/java/core/src/main/java/com/whylogs/core/metrics/components/IntegralComponent.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/components/IntegralComponent.java
@@ -13,7 +13,7 @@ public class IntegralComponent extends MetricComponent<Integer> {
   public IntegralComponent(Integer value) {
     super(value);
   }
-  
+
   @Override
   public String getTypeName() {
     return this.getClass().getSimpleName();

--- a/java/core/src/main/java/com/whylogs/core/metrics/components/MaxIntegralComponent.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/components/MaxIntegralComponent.java
@@ -23,6 +23,11 @@ public class MaxIntegralComponent extends IntegralComponent {
         return TYPE_ID;
     }
 
+    @Override
+    public String getTypeName() {
+        return this.getClass().getSimpleName();
+    }
+
     public static MaxIntegralComponent max(Collection<? extends Integer> list){
         int max = Integer.MIN_VALUE;
         for(Integer i : list){

--- a/java/core/src/main/java/com/whylogs/core/metrics/components/MetricComponent.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/components/MetricComponent.java
@@ -45,6 +45,9 @@ public class MetricComponent<T> {
         throw new NotImplementedException();
     }
 
+    public String getTypeName() {
+        return this.getClass().getSimpleName();
+    }
 
 
     // TODO to_protobuf

--- a/java/core/src/main/java/com/whylogs/core/metrics/components/MetricComponent.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/components/MetricComponent.java
@@ -39,7 +39,7 @@ public class MetricComponent<T> {
   public int getTypeId() {
     return TYPE_ID;
   }
-  
+
   public String getTypeName() {
     return this.getClass().getSimpleName();
   }

--- a/java/core/src/main/java/com/whylogs/core/metrics/components/MinIntegralComponent.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/components/MinIntegralComponent.java
@@ -16,7 +16,7 @@ public class MinIntegralComponent extends IntegralComponent {
   public MinIntegralComponent(Integer value) {
     super(value);
   }
-  
+
   @Override
   public String getTypeName() {
     return this.getClass().getSimpleName();
@@ -26,7 +26,7 @@ public class MinIntegralComponent extends IntegralComponent {
   public int getTypeId() {
     return TYPE_ID;
   }
-  
+
   public static MinIntegralComponent min(Collection<? extends Integer> list) {
     int min = Integer.MAX_VALUE;
     for (Integer i : list) {

--- a/java/core/src/main/java/com/whylogs/core/metrics/components/MinIntegralComponent.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/components/MinIntegralComponent.java
@@ -22,6 +22,11 @@ public class MinIntegralComponent extends IntegralComponent {
         return TYPE_ID;
     }
 
+    @Override
+    public String getTypeName() {
+        return this.getClass().getSimpleName();
+    }
+
     public static MinIntegralComponent min(Collection<? extends Integer> list){
         int min = Integer.MAX_VALUE;
         for(Integer i : list){

--- a/java/core/src/test/java/com/whylogs/core/metrics/aggregators/TestAggregatorRegistry.java
+++ b/java/core/src/test/java/com/whylogs/core/metrics/aggregators/TestAggregatorRegistry.java
@@ -1,4 +1,31 @@
 package com.whylogs.core.metrics.aggregators;
 
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.function.BinaryOperator;
+
+@Test
 public class TestAggregatorRegistry {
+
+    @Test
+    public void test_registry_singleton(){
+        AggregatorRegistry registry = AggregatorRegistry.getInstance();
+        AggregatorRegistry registry2 = AggregatorRegistry.getInstance();
+        Assert.assertEquals(registry, registry2);
+    }
+
+    @Test
+    public void test_registry_add(){
+        // try with a binary operator, we need the typing so you can't seem to do an
+        // inline lambda
+        AggregatorRegistry registry = AggregatorRegistry.getInstance();
+        BinaryOperator<Integer> aggregator = (lhs, rhs) -> lhs + rhs;
+        registry.register(1,  aggregator);
+        Assert.assertEquals(registry.get(1), aggregator);
+
+        registry.register(2,  new NumberSumAggregator<Integer>());
+        int sum = (int) registry.get(2).apply(1, 2);
+        Assert.assertEquals(sum, 3);
+    }
 }

--- a/java/core/src/test/java/com/whylogs/core/metrics/aggregators/TestAggregatorRegistry.java
+++ b/java/core/src/test/java/com/whylogs/core/metrics/aggregators/TestAggregatorRegistry.java
@@ -1,0 +1,4 @@
+package com.whylogs.core.metrics.aggregators;
+
+public class TestAggregatorRegistry {
+}

--- a/java/core/src/test/java/com/whylogs/core/metrics/aggregators/TestAggregatorRegistry.java
+++ b/java/core/src/test/java/com/whylogs/core/metrics/aggregators/TestAggregatorRegistry.java
@@ -1,31 +1,30 @@
 package com.whylogs.core.metrics.aggregators;
 
+import java.util.function.BinaryOperator;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.function.BinaryOperator;
 
 @Test
 public class TestAggregatorRegistry {
 
-    @Test
-    public void test_registry_singleton(){
-        AggregatorRegistry registry = AggregatorRegistry.getInstance();
-        AggregatorRegistry registry2 = AggregatorRegistry.getInstance();
-        Assert.assertEquals(registry, registry2);
-    }
+  @Test
+  public void test_registry_singleton() {
+    AggregatorRegistry registry = AggregatorRegistry.getInstance();
+    AggregatorRegistry registry2 = AggregatorRegistry.getInstance();
+    Assert.assertEquals(registry, registry2);
+  }
 
-    @Test
-    public void test_registry_add(){
-        // try with a binary operator, we need the typing so you can't seem to do an
-        // inline lambda
-        AggregatorRegistry registry = AggregatorRegistry.getInstance();
-        BinaryOperator<Integer> aggregator = (lhs, rhs) -> lhs + rhs;
-        registry.register(1,  aggregator);
-        Assert.assertEquals(registry.get(1), aggregator);
+  @Test
+  public void test_registry_add() {
+    // try with a binary operator, we need the typing so you can't seem to do an
+    // inline lambda
+    AggregatorRegistry registry = AggregatorRegistry.getInstance();
+    BinaryOperator<Integer> aggregator = (lhs, rhs) -> lhs + rhs;
+    registry.register(1, aggregator);
+    Assert.assertEquals(registry.get(1), aggregator);
 
-        registry.register(2,  new NumberSumAggregator<Integer>());
-        int sum = (int) registry.get(2).apply(1, 2);
-        Assert.assertEquals(sum, 3);
-    }
+    registry.register(2, new NumberSumAggregator<Integer>());
+    int sum = (int) registry.get(2).apply(1, 2);
+    Assert.assertEquals(sum, 3);
+  }
 }

--- a/java/core/src/test/java/com/whylogs/core/metrics/aggregators/TestSumAggregators.java
+++ b/java/core/src/test/java/com/whylogs/core/metrics/aggregators/TestSumAggregators.java
@@ -1,0 +1,83 @@
+package com.whylogs.core.metrics.aggregators;
+
+import com.whylogs.core.errors.UnsupportedError;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test
+public class TestSumAggregators {
+
+    @DataProvider(name = "intData")
+    public Object[][] intData(){
+        return new Object[][]{
+                {1, 2, 3},
+                {-1, -2, -3},
+                {Integer.MIN_VALUE, Integer.MAX_VALUE, -1},
+                {-3, 2, -1}
+        };
+    }
+
+    @Test(dataProvider = "intData")
+    public void testIntegerSum(int lhs, int rhs, int expected) throws UnsupportedError {
+        NumberSumAggregator<Integer> aggregator = new NumberSumAggregator<>();
+        int result = 0;
+
+        try{
+            result = aggregator.merge(lhs, rhs);
+        } catch (UnsupportedError e) {
+            Assert.fail();
+        }
+
+        Assert.assertEquals(result, expected);
+    }
+
+    @DataProvider(name = "doubleData")
+    public Object[][] doubleData(){
+        return new Object[][]{
+                {1.0, 2.5, 3.5},
+                {-1.0, -2.0, -3.0},
+                {-3.0, 2.0, -1.0}
+        };
+    }
+
+    @Test(dataProvider = "doubleData")
+    public void testDoubleSum(Double lhs, Double rhs, Double expected) throws UnsupportedError {
+        NumberSumAggregator<Double> aggregator = new NumberSumAggregator<>();
+        double result = 0;
+
+        try{
+            result = aggregator.merge(lhs, rhs);
+        } catch (UnsupportedError e) {
+            Assert.fail();
+        }
+
+        Assert.assertEquals(result, expected);
+    }
+
+    @DataProvider(name = "floatData")
+    public Object[][] floatData(){
+        float a = 1;
+        float b = 2;
+        float c = 3;
+        float d = -1;
+        return new Object[][]{
+                {a, b, c},
+                {d,  c, b},
+        };
+    }
+
+    @Test(dataProvider = "floatData")
+    public void testFloatSum(Float lhs, Float rhs, Float expected) throws UnsupportedError {
+        NumberSumAggregator<Float> aggregator = new NumberSumAggregator<>();
+        float result = 0;
+
+        try{
+            result = aggregator.merge(lhs, rhs);
+        } catch (UnsupportedError e) {
+            Assert.fail();
+        }
+
+        Assert.assertEquals(result, expected);
+    }
+}

--- a/java/core/src/test/java/com/whylogs/core/metrics/aggregators/TestSumAggregators.java
+++ b/java/core/src/test/java/com/whylogs/core/metrics/aggregators/TestSumAggregators.java
@@ -8,76 +8,76 @@ import org.testng.annotations.Test;
 @Test
 public class TestSumAggregators {
 
-    @DataProvider(name = "intData")
-    public Object[][] intData(){
-        return new Object[][]{
-                {1, 2, 3},
-                {-1, -2, -3},
-                {Integer.MIN_VALUE, Integer.MAX_VALUE, -1},
-                {-3, 2, -1}
-        };
+  @DataProvider(name = "intData")
+  public Object[][] intData() {
+    return new Object[][] {
+      {1, 2, 3},
+      {-1, -2, -3},
+      {Integer.MIN_VALUE, Integer.MAX_VALUE, -1},
+      {-3, 2, -1}
+    };
+  }
+
+  @Test(dataProvider = "intData")
+  public void testIntegerSum(int lhs, int rhs, int expected) throws UnsupportedError {
+    NumberSumAggregator<Integer> aggregator = new NumberSumAggregator<>();
+    int result = 0;
+
+    try {
+      result = aggregator.merge(lhs, rhs);
+    } catch (UnsupportedError e) {
+      Assert.fail();
     }
 
-    @Test(dataProvider = "intData")
-    public void testIntegerSum(int lhs, int rhs, int expected) throws UnsupportedError {
-        NumberSumAggregator<Integer> aggregator = new NumberSumAggregator<>();
-        int result = 0;
+    Assert.assertEquals(result, expected);
+  }
 
-        try{
-            result = aggregator.merge(lhs, rhs);
-        } catch (UnsupportedError e) {
-            Assert.fail();
-        }
+  @DataProvider(name = "doubleData")
+  public Object[][] doubleData() {
+    return new Object[][] {
+      {1.0, 2.5, 3.5},
+      {-1.0, -2.0, -3.0},
+      {-3.0, 2.0, -1.0}
+    };
+  }
 
-        Assert.assertEquals(result, expected);
+  @Test(dataProvider = "doubleData")
+  public void testDoubleSum(Double lhs, Double rhs, Double expected) throws UnsupportedError {
+    NumberSumAggregator<Double> aggregator = new NumberSumAggregator<>();
+    double result = 0;
+
+    try {
+      result = aggregator.merge(lhs, rhs);
+    } catch (UnsupportedError e) {
+      Assert.fail();
     }
 
-    @DataProvider(name = "doubleData")
-    public Object[][] doubleData(){
-        return new Object[][]{
-                {1.0, 2.5, 3.5},
-                {-1.0, -2.0, -3.0},
-                {-3.0, 2.0, -1.0}
-        };
+    Assert.assertEquals(result, expected);
+  }
+
+  @DataProvider(name = "floatData")
+  public Object[][] floatData() {
+    float a = 1;
+    float b = 2;
+    float c = 3;
+    float d = -1;
+    return new Object[][] {
+      {a, b, c},
+      {d, c, b},
+    };
+  }
+
+  @Test(dataProvider = "floatData")
+  public void testFloatSum(Float lhs, Float rhs, Float expected) throws UnsupportedError {
+    NumberSumAggregator<Float> aggregator = new NumberSumAggregator<>();
+    float result = 0;
+
+    try {
+      result = aggregator.merge(lhs, rhs);
+    } catch (UnsupportedError e) {
+      Assert.fail();
     }
 
-    @Test(dataProvider = "doubleData")
-    public void testDoubleSum(Double lhs, Double rhs, Double expected) throws UnsupportedError {
-        NumberSumAggregator<Double> aggregator = new NumberSumAggregator<>();
-        double result = 0;
-
-        try{
-            result = aggregator.merge(lhs, rhs);
-        } catch (UnsupportedError e) {
-            Assert.fail();
-        }
-
-        Assert.assertEquals(result, expected);
-    }
-
-    @DataProvider(name = "floatData")
-    public Object[][] floatData(){
-        float a = 1;
-        float b = 2;
-        float c = 3;
-        float d = -1;
-        return new Object[][]{
-                {a, b, c},
-                {d,  c, b},
-        };
-    }
-
-    @Test(dataProvider = "floatData")
-    public void testFloatSum(Float lhs, Float rhs, Float expected) throws UnsupportedError {
-        NumberSumAggregator<Float> aggregator = new NumberSumAggregator<>();
-        float result = 0;
-
-        try{
-            result = aggregator.merge(lhs, rhs);
-        } catch (UnsupportedError e) {
-            Assert.fail();
-        }
-
-        Assert.assertEquals(result, expected);
-    }
+    Assert.assertEquals(result, expected);
+  }
 }


### PR DESCRIPTION
## Description
Adds a registry for the aggregators. Adds just the sum aggregator to get started. 

I changed it halfway through from requiring the IAggregator which extends BiFunction to anything that extends BiFunction. This is because I realized post lambdas are using the BiOperator which is a subclass of BiFunction. I'm not thrilled with the API though as it returns the BiFunction not the aggregator itself. It's fine since all the aggregators are required to have an apply() so it works the same. Take a peek and give your thoughts.

## Changes

- 6e9339e101b0987657c39a660cb33a038142cb58 Adds a global registry for aggregators on components
- 46327f50a8515c48045f6e261ec58186b1a2b5d2 Changes the registry to be class that extends BiFunction

## Related
Building out Java v1


- [X] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
