### PR TITLE
Using our dedicated stats endpoint for telemetry collection

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -4,7 +4,7 @@ isort:skip_file
 """
 import os
 
-os.environ["HEAP_APPID_DEV"] = "3002560559"  # noqa: E402
+os.environ["TELEMETRY_DEV"] = "1"  # noqa: E402
 
 import pandas as pd
 import pytest

--- a/python/tests/smoketest.py
+++ b/python/tests/smoketest.py
@@ -1,6 +1,6 @@
 import os
 
-os.environ["HEAP_APPID_DEV"] = "3002560559"
+os.environ["TELEMETRY_DEV"] = "1"  # noqa: E402
 
 from whylogs import __version__, package_version  # noqa
 

--- a/python/whylogs/api/pyspark/experimental/profiler.py
+++ b/python/whylogs/api/pyspark/experimental/profiler.py
@@ -7,8 +7,10 @@ import whylogs as why
 from whylogs.core.stubs import pd
 from whylogs.core.view.column_profile_view import ColumnProfileView
 from whylogs.core.view.dataset_profile_view import DatasetProfileView
+from whylogs.api.usage_stats import emit_usage
 
 logger = getLogger(__name__)
+emit_usage("pyspark")
 
 try:  # type: ignore
     from pyspark.sql import DataFrame as SparkDataFrame  # types: ignore

--- a/python/whylogs/api/pyspark/experimental/profiler.py
+++ b/python/whylogs/api/pyspark/experimental/profiler.py
@@ -4,10 +4,10 @@ from logging import getLogger
 from typing import Dict, Iterable, Optional, Tuple
 
 import whylogs as why
+from whylogs.api.usage_stats import emit_usage
 from whylogs.core.stubs import pd
 from whylogs.core.view.column_profile_view import ColumnProfileView
 from whylogs.core.view.dataset_profile_view import DatasetProfileView
-from whylogs.api.usage_stats import emit_usage
 
 logger = getLogger(__name__)
 emit_usage("pyspark")

--- a/python/whylogs/api/reader/reader.py
+++ b/python/whylogs/api/reader/reader.py
@@ -16,7 +16,6 @@ class Reader(ABC):
         Must be implemented by all inherited Readers, declaring
         how to fetch files from their locations to a local temp dir
         """
-        pass
 
     @abstractmethod
     def option(self: T, **kwargs: Any) -> T:

--- a/python/whylogs/api/usage_stats/__init__.py
+++ b/python/whylogs/api/usage_stats/__init__.py
@@ -39,7 +39,6 @@ try:
 except:  # noqa
     logger.info("Encounter exception when checking file system. Disable telemetry by default")
     _TELEMETRY_DISABLED = True
-    pass
 
 
 def emit_usage(event: str) -> None:

--- a/python/whylogs/api/usage_stats/__init__.py
+++ b/python/whylogs/api/usage_stats/__init__.py
@@ -15,10 +15,10 @@ from urllib import request
 
 import whylogs
 
-TELEMETRY_ENDPOINT = "https://stats.whylogs.com/"
+_TELEMETRY_ENDPOINT = "https://stats.whylogs.com/"
 if os.getenv("TELEMETRY_DEV"):
-    TELEMETRY_ENDPOINT = "https://staging-stats.whylogs.com"
-TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+    _TELEMETRY_ENDPOINT = "https://staging-stats.whylogs.com"
+_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 logger = logging.getLogger(__name__)
 
 ANALYTICS_OPT_OUT = "WHYLOGS_NO_ANALYTICS"
@@ -132,12 +132,12 @@ def _send_stats_event(event_name: str, identity: str, properties: Dict[str, Any]
     data = {
         "identity": identity,
         "event": event_name,
-        "timestamp": datetime.utcnow().strftime(TIMESTAMP_FORMAT),
+        "timestamp": datetime.utcnow().strftime(_TIMESTAMP_FORMAT),
         "properties": properties or {},
     }
     global _TELEMETRY_DISABLED
     json_data = json.dumps(data).encode()
-    req = request.Request(TELEMETRY_ENDPOINT, data=json_data, method="POST")
+    req = request.Request(_TELEMETRY_ENDPOINT, data=json_data, method="POST")
     req.add_header("Content-Type", "application/json")
 
     resp: http.client.HTTPResponse = None  # type: ignore

--- a/python/whylogs/api/usage_stats/__init__.py
+++ b/python/whylogs/api/usage_stats/__init__.py
@@ -15,10 +15,9 @@ from urllib import request
 
 import whylogs
 
-HEAP_APPID_PROD = "2496309831"
-
-HEAP_ENDPOINT = "https://heapanalytics.com/api/track"
-HEAP_HEADERS = {"Content-Type": "application/json"}
+TELEMETRY_ENDPOINT = "https://stats.whylogs.com/"
+if os.getenv("TELEMETRY_DEV"):
+    TELEMETRY_ENDPOINT = "https://staging-stats.whylogs.com"
 TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 logger = logging.getLogger(__name__)
 
@@ -26,29 +25,31 @@ ANALYTICS_OPT_OUT = "WHYLOGS_NO_ANALYTICS"
 
 # Flag to disable it internally
 _TELEMETRY_DISABLED = False
-
+_TRACKED_EVENTS: Dict[str, bool] = {}
 
 _SITE_PACKAGES = site.getsitepackages()
+
+if os.getenv(ANALYTICS_OPT_OUT) is not None:
+    logger.debug("Opted out of usage statistics. Skipping.")
+    _TELEMETRY_DISABLED = True
+
+try:
+    if os.path.exists(os.path.expanduser("~/.whylogs/disable_telemetry")):
+        _TELEMETRY_DISABLED = True
+except:  # noqa
+    logger.info("Encounter exception when checking file system. Disable telemetry by default")
+    _TELEMETRY_DISABLED = True
+    pass
 
 
 def emit_usage(event: str) -> None:
     global _TELEMETRY_DISABLED
+    global _TRACKED_EVENTS
     if _TELEMETRY_DISABLED:
         return
-
-    if os.getenv(ANALYTICS_OPT_OUT) is not None:
-        logger.debug("Opted out of usage statistics. Skipping.")
-        _TELEMETRY_DISABLED = True
+    if _TRACKED_EVENTS.get(event):
         return
-
-    try:
-        if os.path.exists(os.path.expanduser("~/.whylogs/disable_telemetry")):
-            _TELEMETRY_DISABLED = True
-            return
-    except:  # noqa
-        logger.info("Encounter exception when checking file system. Disable telemetry by default")
-        _TELEMETRY_DISABLED = True
-        pass
+    _TRACKED_EVENTS[event] = True
 
     t = Thread(target=_do_emit_usage, args=(event,))
     t.start()
@@ -75,7 +76,7 @@ def _do_emit_usage(event: str) -> None:
     if _metadata is None:
         _metadata = _build_metadata()
 
-    _send_heap_event(event, _identity, _metadata)
+    _send_stats_event(event, _identity, _metadata)
 
 
 def _calc_identity() -> str:
@@ -91,7 +92,7 @@ def _calc_identity() -> str:
 
 
 def _build_metadata() -> Dict[str, Any]:
-    """Hash system and project data to send to Heap."""
+    """Hash system and project data to send to our stats endpoint."""
 
     project_version = whylogs.__version__
     (major, minor, macro, _, _) = sys.version_info
@@ -128,18 +129,8 @@ def _build_metadata() -> Dict[str, Any]:
     return metadata
 
 
-def _get_heap_app_id() -> str:
-    """
-    Get the Heap App ID to send the data to.
-    This will be the development ID if it's set as an
-    environment variable, otherwise it will be the production ID.
-    """
-    return os.environ.get("HEAP_APPID_DEV", HEAP_APPID_PROD)
-
-
-def _send_heap_event(event_name: str, identity: str, properties: Dict[str, Any] = None) -> None:
+def _send_stats_event(event_name: str, identity: str, properties: Dict[str, Any] = None) -> None:
     data = {
-        "app_id": _get_heap_app_id(),
         "identity": identity,
         "event": event_name,
         "timestamp": datetime.utcnow().strftime(TIMESTAMP_FORMAT),
@@ -147,8 +138,9 @@ def _send_heap_event(event_name: str, identity: str, properties: Dict[str, Any] 
     }
     global _TELEMETRY_DISABLED
     json_data = json.dumps(data).encode()
-    req = request.Request(HEAP_ENDPOINT, data=json_data, method="POST")
+    req = request.Request(TELEMETRY_ENDPOINT, data=json_data, method="POST")
     req.add_header("Content-Type", "application/json")
+
     resp: http.client.HTTPResponse = None  # type: ignore
     try:
         resp = request.urlopen(req, timeout=3)


### PR DESCRIPTION
## Description

Using our private stats endpoint instead of Heap: https://stats.whylogs.com


## Changes
- Remove redundant checks
- Enable dev endpoint

## Related

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
