### PR TITLE
move link check into separate action

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -7,7 +7,6 @@ defaults:
     working-directory: python
 jobs:
     markdown-link-check:
-    needs: docs-ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -10,7 +10,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
           use-quiet-mode: "yes"

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -12,3 +12,5 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+          use-quiet-mode: "yes"

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,14 +1,14 @@
-name: markdown-link-check
+name: markdown link check
 
 on: workflow_dispatch
 
 defaults:
   run:
     working-directory: python
+
 jobs:
-    markdown-link-check:
+  markdown-link-check:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          use-quiet-mode: "yes"
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -7,7 +7,6 @@ defaults:
     working-directory: python
 jobs:
     markdown-link-check:
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,16 @@
+name: markdown-link-check
+
+on: workflow_dispatch
+
+defaults:
+  run:
+    working-directory: python
+jobs:
+    markdown-link-check:
+    needs: docs-ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: "yes"

--- a/.github/workflows/whylogs-ci.yml
+++ b/.github/workflows/whylogs-ci.yml
@@ -192,12 +192,3 @@ jobs:
           branch: gh-pages
           folder: python/docs/_build/html
         if: ${{ github.ref == 'refs/heads/mainline' }}
-
-  markdown-link-check:
-    needs: docs-ci
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          use-quiet-mode: "yes"


### PR DESCRIPTION
## Description

run link check only on manual dispatch to reduce noise in the ci checks on PRs and merge.

We had seen noise in failure to connect to links in our docs that were external (and live) and the failures were frequent and intermittent.

## Changes

remove the link check from whylogs-ci and allow this tool to be run manually. Consider follow up to run this as part of release process or at some other cadence less frequent than PR checks.