### PR TITLE
Add .dockerignore to .gitignore to avoid release workflow failure

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -4,5 +4,6 @@
 .mypy_cache
 .pytest_cache
 .venv
+.dockerignore
 dist
 output.ipynb


### PR DESCRIPTION
## Description

Resolves #784 by ignoring changes to this file as a mitigation.