### PR TITLE
Hardcode en/latest into Announcement URL.  Otherwise is coming up 404.

### DIFF
--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -102,7 +102,7 @@ myst_enable_extensions = [
 
 html_theme_options: Dict[str, Any] = {
     "announcement": """<em>whylogs v1</em> has been launched! Make sure you checkout the
-    <a href="/migration/basics.html" alt="Link to migration guide">the migration guide</a> to ensure a smooth
+    <a href="/en/latest/migration/basics.html" alt="Link to migration guide">the migration guide</a> to ensure a smooth
     transition""",
     "light_logo": "images/logo.png",
     "dark_logo": "images/logo.png",


### PR DESCRIPTION
## Description

Currently the announcement [link](https://whylogs.readthedocs.io/migration/basics.html) on the live site (click on the "whylogs v1 has been launched! Make sure you checkout the [the migration guide](https://whylogs.readthedocs.io/migration/basics.html) to ensure a smooth transition" link) is 404ing because there is no `/en/latest` in the url, which is prepended by readthedocs.  This patch hardcodes the `/en/latest`, which isn't technically correct (since it really should go to the version of the code that you're reading), but is the best we can probably do since this is raw html included in the announcement text and not a Sphinx-link that can be massaged.

<img width="858" alt="Screen Shot 2022-09-09 at 3 17 27 PM" src="https://user-images.githubusercontent.com/95350/189453393-1760b371-9fb6-41f3-934d-67f1bf3487ae.png">
