### PR TITLE
Initialize RegressionMetricsMessage prediction_field to 0

### DIFF
--- a/python/whylogs/core/model_performance_metrics/regression_metrics.py
+++ b/python/whylogs/core/model_performance_metrics/regression_metrics.py
@@ -81,6 +81,8 @@ class RegressionMetrics:
         """
 
         return RegressionMetricsMessage(
+            prediction_field="0",
+            target_field="0",
             count=self.count,
             sum_abs_diff=self.sum_abs_diff,
             sum_diff=self.sum_diff,


### PR DESCRIPTION
Fixes #813 so that the fields continue to exist with non-empty string values.