### PR TITLE
'Check out our docs' link in Inspecting Profiles notebook is 404ing

### DIFF
--- a/python/examples/basic/Inspecting_Profiles.ipynb
+++ b/python/examples/basic/Inspecting_Profiles.ipynb
@@ -518,12 +518,6 @@
         "That's it!\n",
         "If you want to know more about whylogs, check our [documentation](https://whylogs.readthedocs.io/en/latest/)."
       ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "1d4a65ad",
-      "metadata": {},
-      "source": []
     }
   ],
   "metadata": {

--- a/python/examples/basic/Inspecting_Profiles.ipynb
+++ b/python/examples/basic/Inspecting_Profiles.ipynb
@@ -516,8 +516,14 @@
       },
       "source": [
         "That's it!\n",
-        "If you want to know more about whylogs, check our documentation at https://whylogs.readthedocs.io/en/1.0.x/"
+        "If you want to know more about whylogs, check our [documentation](https://whylogs.readthedocs.io/en/latest/)."
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "1d4a65ad",
+      "metadata": {},
+      "source": []
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Description

Point to more general URL.

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
