### PR TITLE
Uncomment pip install so notebook examples mostly just work

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,8 +7,8 @@ build:
   jobs:
     pre_create_environment:
       - asdf plugin add poetry
-      - asdf install poetry latest
-      - asdf global poetry latest
+      - asdf install poetry 1.2.0
+      - asdf global poetry 1.2.0
       - cd python && poetry export -E docs --without-hashes -f requirements.txt --output requirements.txt
       - cd python/docs && make pre-build
 sphinx:

--- a/python/examples/advanced/Condition_Count_Metrics.ipynb
+++ b/python/examples/advanced/Condition_Count_Metrics.ipynb
@@ -56,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install whylogs"
+    "%pip install whylogs"
    ]
   },
   {
@@ -1554,7 +1554,7 @@
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "8430e7bcc333486e417258c6fadac662061ebd166d9f3c5ccb12c1968aa41625"
+    "hash": "d39f874c9b8a97550ecbd783714b95e79c9b905449b34f44c40e3bf053b54b41"
    }
   }
  },

--- a/python/examples/advanced/Constraints_Suite.ipynb
+++ b/python/examples/advanced/Constraints_Suite.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install whylogs[viz]"
+    "%pip install whylogs[viz]"
    ]
   },
   {
@@ -3381,7 +3381,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.13 ('.venv': poetry)",
+   "display_name": "Python 3.8.10 ('.venv': poetry)",
    "language": "python",
    "name": "python3"
   },
@@ -3395,12 +3395,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.8.10"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "0f484380554f045e8316d9ef136659363ef199c84a7347221e49b73e46486d36"
+    "hash": "d39f874c9b8a97550ecbd783714b95e79c9b905449b34f44c40e3bf053b54b41"
    }
   }
  },

--- a/python/examples/advanced/Custom_Metrics.ipynb
+++ b/python/examples/advanced/Custom_Metrics.ipynb
@@ -24,7 +24,7 @@
       },
       "outputs": [],
       "source": [
-        "# %pip install whylogs"
+        "%pip install whylogs"
       ]
     },
     {

--- a/python/examples/advanced/Log_Rotation_for_Streaming_Data/Streaming_Data_with_Log_Rotation.ipynb
+++ b/python/examples/advanced/Log_Rotation_for_Streaming_Data/Streaming_Data_with_Log_Rotation.ipynb
@@ -80,7 +80,7 @@
     }
    ],
    "source": [
-    "# %pip install -q whylogs;"
+    "%pip install -q whylogs;"
    ]
   },
   {

--- a/python/examples/advanced/Segments.ipynb
+++ b/python/examples/advanced/Segments.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install whylogs[whylabs]"
+    "%pip install whylogs[whylabs]"
    ]
   },
   {

--- a/python/examples/advanced/String_Tracking.ipynb
+++ b/python/examples/advanced/String_Tracking.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install whylogs"
+    "%pip install whylogs"
    ]
   },
   {

--- a/python/examples/basic/Getting_Started.ipynb
+++ b/python/examples/basic/Getting_Started.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install -q whylogs"
+    "%pip install -q whylogs"
    ]
   },
   {

--- a/python/examples/basic/Inspecting_Profiles.ipynb
+++ b/python/examples/basic/Inspecting_Profiles.ipynb
@@ -55,8 +55,8 @@
       "outputs": [],
       "source": [
         "# install whylogs & pandas if needed\n",
-        "# %pip install -q whylogs\n",
-        "# %pip install pandas "
+        "%pip install -q whylogs\n",
+        "%pip install pandas "
       ]
     },
     {

--- a/python/examples/basic/Logging_Different_Data.ipynb
+++ b/python/examples/basic/Logging_Different_Data.ipynb
@@ -47,7 +47,7 @@
     }
    ],
    "source": [
-    "# %pip install -q whylogs"
+    "%pip install -q whylogs"
    ]
   },
   {

--- a/python/examples/basic/Merging_Profiles.ipynb
+++ b/python/examples/basic/Merging_Profiles.ipynb
@@ -53,7 +53,7 @@
    },
    "outputs": [],
    "source": [
-    "# %pip install whylogs"
+    "%pip install whylogs"
    ]
   },
   {

--- a/python/examples/basic/Metric_Constraints.ipynb
+++ b/python/examples/basic/Metric_Constraints.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install 'whylogs[viz]'"
+    "%pip install 'whylogs[viz]'"
    ]
   },
   {

--- a/python/examples/basic/Notebook_Profile_Visualizer.ipynb
+++ b/python/examples/basic/Notebook_Profile_Visualizer.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install -q 'whylogs[viz]'"
+    "%pip install -q 'whylogs[viz]'"
    ]
   },
   {

--- a/python/examples/basic/Schema_Configuration.ipynb
+++ b/python/examples/basic/Schema_Configuration.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install whylogs"
+    "%pip install whylogs"
    ]
   },
   {
@@ -169,7 +169,7 @@
    "outputs": [],
    "source": [
     "# Install pandas if you don't have it already\n",
-    "# %pip install pandas\n"
+    "%pip install pandas\n"
    ]
   },
   {

--- a/python/examples/datasets/weather.ipynb
+++ b/python/examples/datasets/weather.ipynb
@@ -41,7 +41,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# %pip install -q whylogs[datasets]"
+        "%pip install -q whylogs[datasets]"
       ]
     },
     {

--- a/python/examples/integrations/Feature_Stores_and_whylogs.ipynb
+++ b/python/examples/integrations/Feature_Stores_and_whylogs.ipynb
@@ -105,7 +105,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# %pip install whylogs[viz] -U -qq"
+        "%pip install whylogs[viz] -U -qq"
       ]
     },
     {

--- a/python/examples/integrations/Mlflow_Logging.ipynb
+++ b/python/examples/integrations/Mlflow_Logging.ipynb
@@ -41,7 +41,7 @@
    },
    "outputs": [],
    "source": [
-    "# %pip install -q 'whylogs[mlflow]'"
+    "%pip install -q 'whylogs[mlflow]'"
    ]
   },
   {

--- a/python/examples/integrations/Pyspark_Profiling.ipynb
+++ b/python/examples/integrations/Pyspark_Profiling.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install 'whylogs[spark]'"
+    "%pip install 'whylogs[spark]'"
    ]
   },
   {

--- a/python/examples/integrations/flask_streaming/flask_with_whylogs.ipynb
+++ b/python/examples/integrations/flask_streaming/flask_with_whylogs.ipynb
@@ -71,7 +71,7 @@
    ],
    "source": [
     "%pip install -q pandas utils joblib scikit-learn Flask\n",
-    "# %pip install -q 'whylogs[whylabs]'"
+    "%pip install -q 'whylogs[whylabs]'"
    ]
   },
   {

--- a/python/examples/integrations/kafka-example/Kafka_Example.ipynb
+++ b/python/examples/integrations/kafka-example/Kafka_Example.ipynb
@@ -34,8 +34,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install -q whylogs\n",
-    "# %pip install -q kafka-python"
+    "%pip install -q whylogs\n",
+    "%pip install -q kafka-python"
    ]
   },
   {

--- a/python/examples/integrations/writers/Writing_Classification_Performance_Metrics_to_WhyLabs.ipynb
+++ b/python/examples/integrations/writers/Writing_Classification_Performance_Metrics_to_WhyLabs.ipynb
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install whylogs[whylabs,datasets]"
+    "%pip install whylogs[whylabs,datasets]"
    ]
   },
   {

--- a/python/examples/integrations/writers/Writing_Profiles.ipynb
+++ b/python/examples/integrations/writers/Writing_Profiles.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install whylogs"
+    "%pip install whylogs"
    ]
   },
   {
@@ -505,7 +505,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install -q 'whylogs[s3]'"
+    "%pip install -q 'whylogs[s3]'"
    ]
   },
   {

--- a/python/examples/integrations/writers/Writing_Reference_Profiles_to_WhyLabs.ipynb
+++ b/python/examples/integrations/writers/Writing_Reference_Profiles_to_WhyLabs.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install whylogs[whylabs]"
+    "%pip install whylogs[whylabs]"
    ]
   },
   {

--- a/python/examples/integrations/writers/Writing_Regression_Performance_Metrics_to_WhyLabs.ipynb
+++ b/python/examples/integrations/writers/Writing_Regression_Performance_Metrics_to_WhyLabs.ipynb
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install whylogs[whylabs,datasets]"
+    "%pip install whylogs[whylabs,datasets]"
    ]
   },
   {

--- a/python/examples/integrations/writers/Writing_to_WhyLabs.ipynb
+++ b/python/examples/integrations/writers/Writing_to_WhyLabs.ipynb
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install whylogs[whylabs]"
+    "%pip install whylogs[whylabs]"
    ]
   },
   {


### PR DESCRIPTION
## Description

Notebook examples need to work when users run all cells.

## Changes

Uncomment out all `pip install whylogs` commands.

## Related

Fixes #835 also fixes #838

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
