### PR TITLE
Fix bug in compound metric to_summary_dict

### DIFF
--- a/python/examples/advanced/String_Tracking.ipynb
+++ b/python/examples/advanced/String_Tracking.ipynb
@@ -594,7 +594,7 @@
     }
    ],
    "source": [
-    "profile_view_df['unicode_range/unicode_range/alpha/mean']"
+    "profile_view_df['unicode_range/alpha/mean']"
    ]
   },
   {
@@ -639,7 +639,7 @@
     }
    ],
    "source": [
-    "profile_view_df['unicode_range/unicode_range/UNKNOWN/mean']"
+    "profile_view_df['unicode_range/UNKNOWN/mean']"
    ]
   },
   {
@@ -677,7 +677,7 @@
     }
    ],
    "source": [
-    "profile_view_df['unicode_range/unicode_range/string_length/min']"
+    "profile_view_df['unicode_range/string_length/min']"
    ]
   },
   {

--- a/python/tests/core/metrics/test_compound_metric.py
+++ b/python/tests/core/metrics/test_compound_metric.py
@@ -108,10 +108,10 @@ def test_compound_metric_summary() -> None:
     metric.columnar_update(col)
     summary = metric.to_summary_dict(None)
 
-    assert "good/Metric1/mean" in summary
-    assert "good/Metric1/stddev" in summary
-    assert "good/Metric2/n" in summary
-    assert "good/Metric2/median" in summary
+    assert "Metric1/mean" in summary
+    assert "Metric1/stddev" in summary
+    assert "Metric2/n" in summary
+    assert "Metric2/median" in summary
 
 
 def test_compound_metric_merge() -> None:

--- a/python/tests/core/metrics/test_unicode_range.py
+++ b/python/tests/core/metrics/test_unicode_range.py
@@ -98,9 +98,9 @@ def test_unicode_range_metric_summary() -> None:
     metric.columnar_update(col)
     summary = metric.to_summary_dict(None)
 
-    assert "unicode_range/digits/mean" in summary
-    assert "unicode_range/alpha/mean" in summary
-    assert f"unicode_range/{_STRING_LENGTH}/mean" in summary
+    assert "digits/mean" in summary
+    assert "alpha/mean" in summary
+    assert f"{_STRING_LENGTH}/mean" in summary
 
 
 def test_unicode_range_metric_merge() -> None:

--- a/python/tests/extras/test_image_metric.py
+++ b/python/tests/extras/test_image_metric.py
@@ -51,7 +51,7 @@ def test_image_metric() -> None:
     ppc.list = ListView(objs=[img])
     metric = ImageMetric.zero(MetricConfig())
     metric.columnar_update(ppc)
-    assert metric.to_summary_dict(SummaryConfig())["image/ImagePixelWidth/mean"] > 0
+    assert metric.to_summary_dict(SummaryConfig())["ImagePixelWidth/mean"] > 0
 
 
 def test_log_image() -> None:
@@ -59,7 +59,7 @@ def test_log_image() -> None:
     img = image_loader(image_path)
     results = log_image(img).view()
     logger.info(results.get_column("image").to_summary_dict())
-    assert results.get_column("image").to_summary_dict()["image/image/ImagePixelWidth/mean"] > 0
+    assert results.get_column("image").to_summary_dict()["image/ImagePixelWidth/mean"] > 0
 
 
 def test_log_interface() -> None:
@@ -70,7 +70,7 @@ def test_log_interface() -> None:
 
     results = why.log(row={"image_col": img}, schema=schema).view().get_column("image_col")
     logger.info(results.to_summary_dict())
-    assert results.to_summary_dict()["image/image/ImagePixelWidth/mean"] > 0
+    assert results.to_summary_dict()["image/ImagePixelWidth/mean"] > 0
 
 
 def test_uncompound_profile() -> None:

--- a/python/whylogs/core/metrics/compound_metric.py
+++ b/python/whylogs/core/metrics/compound_metric.py
@@ -84,7 +84,7 @@ class CompoundMetric(Metric, ABC):
         for sub_name, submetric in self.submetrics.items():
             sub_summary = submetric.to_summary_dict(cfg)
             for comp_name, comp_msg in sub_summary.items():
-                summary["/".join([self.namespace, sub_name, comp_name])] = comp_msg
+                summary["/".join([sub_name, comp_name])] = comp_msg
         return summary
 
     def columnar_update(self, view: PreprocessedColumn) -> OperationResult:


### PR DESCRIPTION
## Description

There was an extra metric namespace prefix in the summary dictionary keys :(

## Changes

- removes extra namespace prefix

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
