### PR TITLE
Move .dockerignore to root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ ENV/
 env.bak/
 venv.bak/
 pythonenv*
+.dockerignore
 
 # Spyder project settings
 .spyderproject

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -4,6 +4,5 @@
 .mypy_cache
 .pytest_cache
 .venv
-.dockerignore
 dist
 output.ipynb


### PR DESCRIPTION
## Description

Previous mitigation fix for #851 was not in the root of the repo, moving there.