### PR TITLE
MetricConfig was supposed to be an optional argument to Metric::zero()

### DIFF
--- a/python/tests/core/metrics/test_compound_metric.py
+++ b/python/tests/core/metrics/test_compound_metric.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from typing import Optional
 
 from whylogs.core.metrics.compound_metric import CompoundMetric
 from whylogs.core.metrics.metrics import DistributionMetric, MetricConfig, custom_metric
@@ -15,7 +16,7 @@ class GoodCM(CompoundMetric):
         return "good"
 
     @classmethod
-    def zero(cls, config: MetricConfig) -> "GoodCM":
+    def zero(cls, config: Optional[MetricConfig]=None) -> "GoodCM":
         return cls({})
 
 
@@ -45,7 +46,7 @@ def test_colon_in_namespace_fails() -> None:
                 return "bad:namespace"
 
             @classmethod
-            def zero(cls, config: MetricConfig) -> "BadCM1":
+            def zero(cls, config: Optional[MetricConfig]=None) -> "BadCM1":
                 return cls({})
 
 
@@ -59,7 +60,7 @@ def test_slash_in_namespace_fails() -> None:
                 return "bad/namespace"
 
             @classmethod
-            def zero(cls, config: MetricConfig) -> "BadCM2":
+            def zero(cls, config: Optional[MetricConfig]=None) -> "BadCM2":
                 return cls({})
 
 

--- a/python/tests/core/metrics/test_compound_metric.py
+++ b/python/tests/core/metrics/test_compound_metric.py
@@ -1,6 +1,7 @@
+from typing import Optional
+
 import numpy as np
 import pytest
-from typing import Optional
 
 from whylogs.core.metrics.compound_metric import CompoundMetric
 from whylogs.core.metrics.metrics import DistributionMetric, MetricConfig, custom_metric
@@ -16,7 +17,7 @@ class GoodCM(CompoundMetric):
         return "good"
 
     @classmethod
-    def zero(cls, config: Optional[MetricConfig]=None) -> "GoodCM":
+    def zero(cls, config: Optional[MetricConfig] = None) -> "GoodCM":
         return cls({})
 
 
@@ -46,7 +47,7 @@ def test_colon_in_namespace_fails() -> None:
                 return "bad:namespace"
 
             @classmethod
-            def zero(cls, config: Optional[MetricConfig]=None) -> "BadCM1":
+            def zero(cls, config: Optional[MetricConfig] = None) -> "BadCM1":
                 return cls({})
 
 
@@ -60,7 +61,7 @@ def test_slash_in_namespace_fails() -> None:
                 return "bad/namespace"
 
             @classmethod
-            def zero(cls, config: Optional[MetricConfig]=None) -> "BadCM2":
+            def zero(cls, config: Optional[MetricConfig] = None) -> "BadCM2":
                 return cls({})
 
 

--- a/python/whylogs/core/metrics/__init__.py
+++ b/python/whylogs/core/metrics/__init__.py
@@ -27,6 +27,6 @@ class StandardMetric(Enum):
     def __init__(self, clz: Metric):
         self._clz = clz
 
-    def zero(self, config: Optional[MetricConfig]=None) -> Metric:  # type: ignore
+    def zero(self, config: Optional[MetricConfig] = None) -> Metric:  # type: ignore
         config = config or MetricConfig()
         return self._clz.zero(config)

--- a/python/whylogs/core/metrics/__init__.py
+++ b/python/whylogs/core/metrics/__init__.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Optional
 
 from whylogs.core.metrics.column_metrics import ColumnCountsMetric, TypeCountersMetric
 from whylogs.core.metrics.condition_count_metric import ConditionCountMetric
@@ -26,5 +27,6 @@ class StandardMetric(Enum):
     def __init__(self, clz: Metric):
         self._clz = clz
 
-    def zero(self, config: MetricConfig) -> Metric:  # type: ignore
+    def zero(self, config: Optional[MetricConfig]=None) -> Metric:  # type: ignore
+        config = config or MetricConfig()
         return self._clz.zero(config)

--- a/python/whylogs/core/metrics/column_metrics.py
+++ b/python/whylogs/core/metrics/column_metrics.py
@@ -78,7 +78,7 @@ class TypeCountersMetric(Metric):
         return OperationResult.ok(successes)
 
     @classmethod
-    def zero(cls, config: Optional[MetricConfig]=None) -> "TypeCountersMetric":
+    def zero(cls, config: Optional[MetricConfig] = None) -> "TypeCountersMetric":
         return TypeCountersMetric(
             integral=IntegralComponent(0),
             fractional=IntegralComponent(0),
@@ -113,5 +113,5 @@ class ColumnCountsMetric(Metric):
         return {"n": self.n.value, "null": self.null.value}
 
     @classmethod
-    def zero(cls, config: Optional[MetricConfig]=None) -> "ColumnCountsMetric":
+    def zero(cls, config: Optional[MetricConfig] = None) -> "ColumnCountsMetric":
         return ColumnCountsMetric(n=IntegralComponent(0), null=IntegralComponent(0))

--- a/python/whylogs/core/metrics/column_metrics.py
+++ b/python/whylogs/core/metrics/column_metrics.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from whylogs.core.configs import SummaryConfig
 from whylogs.core.metrics.metric_components import IntegralComponent
@@ -78,7 +78,7 @@ class TypeCountersMetric(Metric):
         return OperationResult.ok(successes)
 
     @classmethod
-    def zero(cls, config: MetricConfig) -> "TypeCountersMetric":
+    def zero(cls, config: Optional[MetricConfig]=None) -> "TypeCountersMetric":
         return TypeCountersMetric(
             integral=IntegralComponent(0),
             fractional=IntegralComponent(0),
@@ -113,5 +113,5 @@ class ColumnCountsMetric(Metric):
         return {"n": self.n.value, "null": self.null.value}
 
     @classmethod
-    def zero(cls, config: MetricConfig) -> "ColumnCountsMetric":
+    def zero(cls, config: Optional[MetricConfig]=None) -> "ColumnCountsMetric":
         return ColumnCountsMetric(n=IntegralComponent(0), null=IntegralComponent(0))

--- a/python/whylogs/core/metrics/condition_count_metric.py
+++ b/python/whylogs/core/metrics/condition_count_metric.py
@@ -4,7 +4,7 @@ from copy import copy
 from dataclasses import dataclass, field
 from enum import Enum
 from itertools import chain
-from typing import Any, Callable, Dict, List, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 from whylogs.core.configs import SummaryConfig
 from whylogs.core.metrics.metric_components import IntegralComponent, MetricComponent
@@ -142,8 +142,9 @@ class ConditionCountMetric(Metric):
         return OperationResult.ok(count)
 
     @classmethod
-    def zero(cls, config: MetricConfig) -> "ConditionCountMetric":
-        if config is None or not isinstance(config, ConditionCountConfig):
+    def zero(cls, config: Optional[MetricConfig]=None) -> "ConditionCountMetric":
+        config = config or ConditionCountConfig()
+        if not isinstance(config, ConditionCountConfig):
             raise ValueError("ConditionCountMetric.zero() requires ConditionCountConfig argument")
 
         return ConditionCountMetric(

--- a/python/whylogs/core/metrics/condition_count_metric.py
+++ b/python/whylogs/core/metrics/condition_count_metric.py
@@ -142,7 +142,7 @@ class ConditionCountMetric(Metric):
         return OperationResult.ok(count)
 
     @classmethod
-    def zero(cls, config: Optional[MetricConfig]=None) -> "ConditionCountMetric":
+    def zero(cls, config: Optional[MetricConfig] = None) -> "ConditionCountMetric":
         config = config or ConditionCountConfig()
         if not isinstance(config, ConditionCountConfig):
             raise ValueError("ConditionCountMetric.zero() requires ConditionCountConfig argument")

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -90,10 +90,9 @@ class OperationResult:
 
 class Metric(ABC):
     @classmethod
-    def get_namespace(cls, config: Optional[MetricConfig] = None) -> str:
-        if config is None:
-            config = MetricConfig()
-        return cls.zero(config).namespace
+    # TODO: deprecate config argument
+    def get_namespace(cls, config: Optional[MetricConfig]=None) -> str:
+        return cls.zero().namespace
 
     @property
     @abstractmethod
@@ -144,7 +143,7 @@ class Metric(ABC):
 
     @classmethod
     @abstractmethod
-    def zero(cls: Type[METRIC], config: MetricConfig) -> METRIC:
+    def zero(cls: Type[METRIC], config: Optional[MetricConfig]=None) -> METRIC:
         pass
 
     @classmethod
@@ -193,7 +192,7 @@ class IntsMetric(Metric):
         return OperationResult.ok(successes)
 
     @classmethod
-    def zero(cls, config: MetricConfig) -> "IntsMetric":
+    def zero(cls, config: Optional[MetricConfig]=None) -> "IntsMetric":
         return IntsMetric(max=MaxIntegralComponent(-sys.maxsize), min=MinIntegralComponent(sys.maxsize))
 
     def to_summary_dict(self, cfg: SummaryConfig) -> Dict[str, Union[int, float, str, None]]:
@@ -414,7 +413,8 @@ class DistributionMetric(Metric):
         return self.kll.value.get_min_value()
 
     @classmethod
-    def zero(cls, config: MetricConfig) -> "DistributionMetric":
+    def zero(cls, config: Optional[MetricConfig]=None) -> "DistributionMetric":
+        config = config or MetricConfig()
         configured_kll_k = config.kll_k_large if config.large_kll_k else config.kll_k
         sk = ds.kll_doubles_sketch(k=configured_kll_k)
         return DistributionMetric(
@@ -491,7 +491,8 @@ class FrequentItemsMetric(Metric):
         return summary["frequent_strings"]
 
     @classmethod
-    def zero(cls, config: MetricConfig) -> "FrequentItemsMetric":
+    def zero(cls, config: Optional[MetricConfig]=None) -> "FrequentItemsMetric":
+        config = config or MetricConfig()
         sk = ds.frequent_strings_sketch(lg_max_k=config.fi_lg_max_k)
         return FrequentItemsMetric(frequent_strings=FrequentStringsComponent(sk))
 
@@ -565,7 +566,8 @@ class CardinalityMetric(Metric):
         return result
 
     @classmethod
-    def zero(cls, config: MetricConfig) -> "CardinalityMetric":
+    def zero(cls, config: Optional[MetricConfig]=None) -> "CardinalityMetric":
+        config = config or MetricConfig()
         sk = ds.hll_sketch(config.hll_lg_k)
         return CardinalityMetric(hll=HllComponent(sk))
 

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -91,7 +91,7 @@ class OperationResult:
 class Metric(ABC):
     @classmethod
     # TODO: deprecate config argument
-    def get_namespace(cls, config: Optional[MetricConfig]=None) -> str:
+    def get_namespace(cls, config: Optional[MetricConfig] = None) -> str:
         return cls.zero().namespace
 
     @property
@@ -143,7 +143,7 @@ class Metric(ABC):
 
     @classmethod
     @abstractmethod
-    def zero(cls: Type[METRIC], config: Optional[MetricConfig]=None) -> METRIC:
+    def zero(cls: Type[METRIC], config: Optional[MetricConfig] = None) -> METRIC:
         pass
 
     @classmethod
@@ -192,7 +192,7 @@ class IntsMetric(Metric):
         return OperationResult.ok(successes)
 
     @classmethod
-    def zero(cls, config: Optional[MetricConfig]=None) -> "IntsMetric":
+    def zero(cls, config: Optional[MetricConfig] = None) -> "IntsMetric":
         return IntsMetric(max=MaxIntegralComponent(-sys.maxsize), min=MinIntegralComponent(sys.maxsize))
 
     def to_summary_dict(self, cfg: SummaryConfig) -> Dict[str, Union[int, float, str, None]]:
@@ -413,7 +413,7 @@ class DistributionMetric(Metric):
         return self.kll.value.get_min_value()
 
     @classmethod
-    def zero(cls, config: Optional[MetricConfig]=None) -> "DistributionMetric":
+    def zero(cls, config: Optional[MetricConfig] = None) -> "DistributionMetric":
         config = config or MetricConfig()
         configured_kll_k = config.kll_k_large if config.large_kll_k else config.kll_k
         sk = ds.kll_doubles_sketch(k=configured_kll_k)
@@ -491,7 +491,7 @@ class FrequentItemsMetric(Metric):
         return summary["frequent_strings"]
 
     @classmethod
-    def zero(cls, config: Optional[MetricConfig]=None) -> "FrequentItemsMetric":
+    def zero(cls, config: Optional[MetricConfig] = None) -> "FrequentItemsMetric":
         config = config or MetricConfig()
         sk = ds.frequent_strings_sketch(lg_max_k=config.fi_lg_max_k)
         return FrequentItemsMetric(frequent_strings=FrequentStringsComponent(sk))
@@ -566,7 +566,7 @@ class CardinalityMetric(Metric):
         return result
 
     @classmethod
-    def zero(cls, config: Optional[MetricConfig]=None) -> "CardinalityMetric":
+    def zero(cls, config: Optional[MetricConfig] = None) -> "CardinalityMetric":
         config = config or MetricConfig()
         sk = ds.hll_sketch(config.hll_lg_k)
         return CardinalityMetric(hll=HllComponent(sk))

--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -1,6 +1,6 @@
 import unicodedata
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from whylogs.core.metrics.compound_metric import CompoundMetric
 from whylogs.core.metrics.metrics import (
@@ -97,7 +97,8 @@ class UnicodeRangeMetric(CompoundMetric):
         return OperationResult.ok(len(data))
 
     @classmethod
-    def zero(cls, config: MetricConfig) -> "UnicodeRangeMetric":
+    def zero(cls, config: Optional[MetricConfig]=None) -> "UnicodeRangeMetric":
+        config = config or MetricConfig()
         return cls(config.unicode_ranges, lower_case=config.lower_case, normalize=config.normalize)
 
     @classmethod

--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -97,7 +97,7 @@ class UnicodeRangeMetric(CompoundMetric):
         return OperationResult.ok(len(data))
 
     @classmethod
-    def zero(cls, config: Optional[MetricConfig]=None) -> "UnicodeRangeMetric":
+    def zero(cls, config: Optional[MetricConfig] = None) -> "UnicodeRangeMetric":
         config = config or MetricConfig()
         return cls(config.unicode_ranges, lower_case=config.lower_case, normalize=config.normalize)
 

--- a/python/whylogs/extras/image_metric.py
+++ b/python/whylogs/extras/image_metric.py
@@ -1,6 +1,6 @@
 import logging
 from itertools import chain
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 import whylogs as why
 from whylogs.api.logger.result_set import ResultSet
@@ -124,7 +124,8 @@ class ImageMetric(CompoundMetric):
         return OperationResult.ok(count)
 
     @classmethod
-    def zero(cls, config: MetricConfig) -> "ImageMetric":
+    def zero(cls, config: Optional[MetricConfig]=None) -> "ImageMetric":
+        config = config or MetricConfig()
         dummy_image = new_image("HSV", (1, 1))
         metadata = get_pil_image_metadata(dummy_image)
         submetrics: Dict[str, Metric] = dict()

--- a/python/whylogs/extras/image_metric.py
+++ b/python/whylogs/extras/image_metric.py
@@ -124,7 +124,7 @@ class ImageMetric(CompoundMetric):
         return OperationResult.ok(count)
 
     @classmethod
-    def zero(cls, config: Optional[MetricConfig]=None) -> "ImageMetric":
+    def zero(cls, config: Optional[MetricConfig] = None) -> "ImageMetric":
         config = config or MetricConfig()
         dummy_image = new_image("HSV", (1, 1))
         metadata = get_pil_image_metadata(dummy_image)


### PR DESCRIPTION
This PR makes the config an optional argument to `zero()` and tries to cope reasonably with its absence.
