### PR TITLE
Better whylabs support for logged images

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -32,7 +32,7 @@ RUN apt install less -y && \
 USER whyuser
 
 WORKDIR /home/whyuser
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python - && \
+RUN curl -sSL https://install.python-poetry.org | python3 - && \
     echo source /home/whyuser/.poetry/env >> .bashrc
 
 WORKDIR /workspace

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,6 +19,7 @@ RUN curl -LJO https://github.com/protocolbuffers/protobuf/releases/download/v3.1
     pip install pandas && \
     pip install sphinx && \
     apt install openjdk-11-jre-headless -y && \
+    apt install graphviz -y && \
     curl -fsSL https://deb.nodesource.com/setup_17.x | bash - && \
     apt install nodejs -y && \
     npm install --global yarn && \

--- a/python/Makefile
+++ b/python/Makefile
@@ -34,7 +34,7 @@ endif
 
 install-poetry:
 	@$(call i, Installing Poetry)
-	curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+	curl -sSL https://install.python-poetry.org | python3 -
 
 help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -99,7 +99,7 @@ tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy 
 
 [[package]]
 name = "autoflake"
-version = "1.6.0"
+version = "1.6.1"
 description = "Removes unused imports and unused variables"
 category = "dev"
 optional = false
@@ -184,14 +184,14 @@ dev = ["Sphinx (==4.3.2)", "black (==22.3.0)", "build (==0.8.0)", "flake8 (==4.0
 
 [[package]]
 name = "boto3"
-version = "1.24.77"
+version = "1.24.78"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 
 [package.dependencies]
-botocore = ">=1.27.77,<1.28.0"
+botocore = ">=1.27.78,<1.28.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -200,7 +200,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.27.77"
+version = "1.27.78"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -1149,7 +1149,7 @@ webpdf = ["pyppeteer (>=1,<1.1)"]
 
 [[package]]
 name = "nbformat"
-version = "5.5.0"
+version = "5.6.0"
 description = "The Jupyter Notebook format"
 category = "main"
 optional = false
@@ -1158,7 +1158,7 @@ python-versions = ">=3.7"
 [package.dependencies]
 fastjsonschema = "*"
 jsonschema = ">=2.6"
-jupyter_core = "*"
+jupyter-core = "*"
 traitlets = ">=5.1"
 
 [package.extras]
@@ -1680,7 +1680,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "pyzmq"
-version = "24.0.0"
+version = "24.0.1"
 description = "Python bindings for 0MQ"
 category = "main"
 optional = false
@@ -2128,7 +2128,7 @@ widechars = ["wcwidth"]
 
 [[package]]
 name = "tenacity"
-version = "8.0.1"
+version = "8.1.0"
 description = "Retry code until it succeeds"
 category = "dev"
 optional = false
@@ -2452,8 +2452,8 @@ attrs = [
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
 ]
 autoflake = [
-    {file = "autoflake-1.6.0-py2.py3-none-any.whl", hash = "sha256:d5de7da3786809bbdedbdbdeecbb410d55277b3492a4a3ede882998f1e87f156"},
-    {file = "autoflake-1.6.0.tar.gz", hash = "sha256:6d313038abf4ad829cb88c9b01cd16387369ac529842bcd7f25a967ab4e99b8f"},
+    {file = "autoflake-1.6.1-py2.py3-none-any.whl", hash = "sha256:dfef4c851fb07e6111f9115d3e7c8c52d8564cbf71c12ade2d8b8a2a7b8bd176"},
+    {file = "autoflake-1.6.1.tar.gz", hash = "sha256:72bce741144ef6db26005d47dba242c1fd6a91ea53f7f4c5a90ad4b051e394c2"},
 ]
 Babel = [
     {file = "Babel-2.10.3-py3-none-any.whl", hash = "sha256:ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb"},
@@ -2497,12 +2497,12 @@ bleach = [
     {file = "bleach-5.0.1.tar.gz", hash = "sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c"},
 ]
 boto3 = [
-    {file = "boto3-1.24.77-py3-none-any.whl", hash = "sha256:fc16e50263c24631d5fe75464e76f3a1b454b4c0015c864948a61691f9702a6e"},
-    {file = "boto3-1.24.77.tar.gz", hash = "sha256:16646de3303779d6dc9c192d8a863095244de81d2e0b94f50692fbde767c6f1b"},
+    {file = "boto3-1.24.78-py3-none-any.whl", hash = "sha256:d141f18d0ec63bc89e0f3d24f269b4f2e18377f1c5e39c56152d4cfd8e6c6ff7"},
+    {file = "boto3-1.24.78.tar.gz", hash = "sha256:da672d9133852dbb36ce9cd156dffcb28a2dc098af1731791ab614969a34f9f5"},
 ]
 botocore = [
-    {file = "botocore-1.27.77-py3-none-any.whl", hash = "sha256:d88509ed291b95525205cc06ca87b54d077aae996827039f5e32375949c5aaf7"},
-    {file = "botocore-1.27.77.tar.gz", hash = "sha256:77a43e970d0762080b4b79a7e00ea572ef2ae7a9f578c3c8e7f0a344ee4b4e6d"},
+    {file = "botocore-1.27.78-py3-none-any.whl", hash = "sha256:fc2ffdafce66c051c69ae6ac50599d6da11e84371c704ae9b7cf9e2742a4dc77"},
+    {file = "botocore-1.27.78.tar.gz", hash = "sha256:b45ae0680699ce100386ac1478e03fd3f29ef22d6bfb5a19169ffee6e67c5293"},
 ]
 bump2version = [
     {file = "bump2version-1.0.1-py2.py3-none-any.whl", hash = "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410"},
@@ -3135,8 +3135,8 @@ nbconvert = [
     {file = "nbconvert-7.0.0.tar.gz", hash = "sha256:fd1e361da30e30e4c5a5ae89f7cae95ca2a4d4407389672473312249a7ba0060"},
 ]
 nbformat = [
-    {file = "nbformat-5.5.0-py3-none-any.whl", hash = "sha256:eb21018bbcdb29e7a4b8b29068d4b6794cdad685db8fcd569b97a09a048dc2e4"},
-    {file = "nbformat-5.5.0.tar.gz", hash = "sha256:9ebe30e6c3b3e5b47d39ff0a3897a1acf523d2bfafcb4e2d04cdb70f8a66c507"},
+    {file = "nbformat-5.6.0-py3-none-any.whl", hash = "sha256:349db50afcf5f44cac6ddcf747fcb9330eafb751044c83994066c48e2f140b35"},
+    {file = "nbformat-5.6.0.tar.gz", hash = "sha256:6f9edb3b70119d82ba89b74b0ecfdbb83f35af8661e491e49ac0893657042674"},
 ]
 nbsphinx = [
     {file = "nbsphinx-0.8.9-py3-none-any.whl", hash = "sha256:a7d743762249ee6bac3350a91eb3717a6e1c75f239f2c2a85491f9aca5a63be1"},
@@ -3525,6 +3525,13 @@ PyYAML = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
@@ -3553,80 +3560,80 @@ PyYAML = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 pyzmq = [
-    {file = "pyzmq-24.0.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:38e9ff2918d50a588e56aa80dae0373ef9f67512fc5691f95db2f59edabc083e"},
-    {file = "pyzmq-24.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5439bef77fd3818c20e1bf5657836e105e4e48e1a7996e24ebb55402a681934e"},
-    {file = "pyzmq-24.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8698db54fd49af74333190fb154448dcfc67a382aa2b2d784ffe981b7cf421ec"},
-    {file = "pyzmq-24.0.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e24d7bda7a32ff35d0c914a52dd920a408f73d7e4b93d6755d7c67e819a8cd8c"},
-    {file = "pyzmq-24.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00a8a4f83259b91b238244c999a33e0a77c0427d496902fb75fdf1601e4c9d3d"},
-    {file = "pyzmq-24.0.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4985a82958d67eafd3f8c9c215c3da8f633592024f771420477f22f011846235"},
-    {file = "pyzmq-24.0.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0775b65e79cccfca2b017e80ffe6dbd224b035a47245c4140b08e93996425942"},
-    {file = "pyzmq-24.0.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2e5a398955b1cfdd85dd699f2390661b7bbe9edcbadd70a444c79c69e6c31c91"},
-    {file = "pyzmq-24.0.0-cp310-cp310-win32.whl", hash = "sha256:1bdec8988cad1f9a8453b4d00fd11598a91604cd9b205640e98b2f22e0435921"},
-    {file = "pyzmq-24.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:eadf1d3841c2155b68ef49147253fd4ac1447a972d01c08248114edc4d3ba9d5"},
-    {file = "pyzmq-24.0.0-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:99bb8cff279f7d1f516919d82b35ed0796c53ce7da7dca191fabfa4c53f47740"},
-    {file = "pyzmq-24.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:452c3d5bfbaf96f32ef20673e6ba238355891884009f0c87e0f97a985293ef42"},
-    {file = "pyzmq-24.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:65b532c95a4cde95bb4787b5545321ed5624fa8d7391bce17c4e2a0717b97bb7"},
-    {file = "pyzmq-24.0.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e9cd5c7449f297a1b53a4803413db907a8cad1178435e2879c1b92816f2bbe56"},
-    {file = "pyzmq-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f81f4065ff8ccd207204129463fd587b25c9f593128176a717dbabc03af9b233"},
-    {file = "pyzmq-24.0.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:3b5107313c7f28b0e074da7a9d8c0132cb8dc32fdd3b5a4c6a224d30e50d6324"},
-    {file = "pyzmq-24.0.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:1f200cdca2fc842749a3f263ccf9e4b50e732ad14f53b60faf68ef656b75c32a"},
-    {file = "pyzmq-24.0.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:ae33cb195304ac16996184b115f9e27eb9f0b14062e97fbd1d446e3e4a594ff0"},
-    {file = "pyzmq-24.0.0-cp311-cp311-win32.whl", hash = "sha256:62ee069fe338d0b057b81e752dad2b9b6b206ba8570a878dbbe8b93b7b99ebb1"},
-    {file = "pyzmq-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:e9e3fa94fa1e58763a7b824b8e0015d93c9fdd8e449d0218d13d01172e3d1539"},
-    {file = "pyzmq-24.0.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b94a3453a18bb914b2cac1ac38c09f980a3c86a8cd0bb744dd6bd03ab8ff958a"},
-    {file = "pyzmq-24.0.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e66d3237a7e8a11cdb8b470c77a6fb43f49fe9407936a2c9ac468ba2ba0982e"},
-    {file = "pyzmq-24.0.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:44c1dc858b76d2ab28f5ea040dd5e816a71624a8cf38d4ca3208006fd2a9375e"},
-    {file = "pyzmq-24.0.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:761016baa6ca720677ce01d453801e41db2d0e53cf052ed00ba8c2e6cae4d2cd"},
-    {file = "pyzmq-24.0.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:ef4bd725c06d6ee9e502419ceeb5dfaccb6bbe36f359fd0366b90a56b6dae647"},
-    {file = "pyzmq-24.0.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:40cdb50e82393253d340b6a357474588eb01cfd90b06231d5bfbc14490490b1b"},
-    {file = "pyzmq-24.0.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:eb3b8acb5dc33ec812d79f35b85fddc43d8f75b65c00c635ee3c0b527e11c8ea"},
-    {file = "pyzmq-24.0.0-cp36-cp36m-win32.whl", hash = "sha256:8988209d5efae9b5c9297fb48d153e2528384c1afe2c9fd8eeb474cd6e765199"},
-    {file = "pyzmq-24.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:52d881c33f8db5ffcb0aabc14cc71098453f4700511195cebca846000b44b080"},
-    {file = "pyzmq-24.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:844040d44cc4320cdffb258fe03768ff0b37e710d56a70dd1f6c2902738f1e28"},
-    {file = "pyzmq-24.0.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f05524f7cfa4f7398259a428fbb22ec4c3f0665c6a303a0d6afdd98457b19af3"},
-    {file = "pyzmq-24.0.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ff4e510a9509d36359c7af4684e73489cdd53c781dd4bc9b07dc808fab56cc48"},
-    {file = "pyzmq-24.0.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:dbb871b22acec52c1b046ef6aa3d16f83618c704772f126a49e7446a0c885278"},
-    {file = "pyzmq-24.0.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:f1ddc43cceb500e4a6495250d9d34cac93e6d9e89a46f0e34fcefcc3caf66ef3"},
-    {file = "pyzmq-24.0.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:a5cdbede23aae133e50f786adc4a2cacf60bddde649e3dc122c32368daa2c007"},
-    {file = "pyzmq-24.0.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ee24b94b5ae22af9148e597f512fae8383908ca07d3b7f99b349679fede4d7d3"},
-    {file = "pyzmq-24.0.0-cp37-cp37m-win32.whl", hash = "sha256:c37c0046d04c0fdd99a9a31d6a9ce7d703cca3b7fdde5738603503dfba58a25f"},
-    {file = "pyzmq-24.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:b1ef471c62c3d0681cfbaa8bbaf96f22e20cafd391ecad8a43317f6b1598478e"},
-    {file = "pyzmq-24.0.0-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:dfde6624d3d99d9a67235b60ae13be1a6ffce2f1de3cd2be9900f011d5d6a6a6"},
-    {file = "pyzmq-24.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fc2c363f68bbb9fea6b8137c432c6df9d7c8c76b01549c4410c506dac9e30663"},
-    {file = "pyzmq-24.0.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6814a6add1b7cb76e3fdfd961ce4c48c1f0a29e82bdb3d060a669b85bc6db454"},
-    {file = "pyzmq-24.0.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1a53c6030c4f45859af9a75cfc0d8b551b8924f9b2503397c69d0fa2f62d2370"},
-    {file = "pyzmq-24.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f328d28d0a1ea43d7030e1999ced9db252ba4ef2531af3e9bfc135cca77b8324"},
-    {file = "pyzmq-24.0.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8a43105683a66de78489b30037b97c9ce5f821f57035f6944f633bbd4baadd15"},
-    {file = "pyzmq-24.0.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:3823e5e613a61948b2e6b85fd91f872772717d24cd1df871836665d4c56d6b34"},
-    {file = "pyzmq-24.0.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:1c23568e1581f637b1a1e1fd15dcd5e9165332c94bf8101c562e7c50640d673e"},
-    {file = "pyzmq-24.0.0-cp38-cp38-win32.whl", hash = "sha256:8a93abd67a46c6b91f28a7513b9f8b9a5432fd573c3d6444c083e07209bf96e4"},
-    {file = "pyzmq-24.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:8361c90701fc6ff5f16c81c969563c6915402fbecb2ddc9c5063fec0238e5e52"},
-    {file = "pyzmq-24.0.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:4ec8847ab93200a94fd3e88e2824a6bba9a46d28161f1bf0be24f2237c40c291"},
-    {file = "pyzmq-24.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f969214a9ebf1175a8aba863d6f1220174130188686d4ed475d138a240e60c1c"},
-    {file = "pyzmq-24.0.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0a07fb73ae006a5b565d19232e5a6592fd7c93e57e67c2e592bf0b21f1676767"},
-    {file = "pyzmq-24.0.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1b978e1318311eb69523ed60f084b752f52f27ffea4ce2f60deab4d8a4cca6de"},
-    {file = "pyzmq-24.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f355d23a420a6b39241bbef2c803839b01d52d680d89aac39460505e57b2cd03"},
-    {file = "pyzmq-24.0.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5c1c2d7ebe991d8e36365ccd6b47297b6b96393ad453cad990901c21924add30"},
-    {file = "pyzmq-24.0.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e0128c7b723984e31c1b0df5bc532715defd13bf64d8d9eddd7207d093759ae4"},
-    {file = "pyzmq-24.0.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9ed10f5a942a2903a722d63806b7a9d2e0a966c038100dc763483d8fbe8ea074"},
-    {file = "pyzmq-24.0.0-cp39-cp39-win32.whl", hash = "sha256:201e4d5733cecfd469d9ceee57500a0f365f85d6f14dd524105e2a0be8cd93c1"},
-    {file = "pyzmq-24.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:460f0ff945d4b46c2d568941be33cf08954fca1e3239cf6a6ee03b1371de8f64"},
-    {file = "pyzmq-24.0.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:534d13940b2476e4bacb54558c7b9b62fb275c2839e06267597a3e4b2f291196"},
-    {file = "pyzmq-24.0.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ebdb43e947291c5cb80ef6c7d525f64bc4ed685de43f855ba0cf2b0fd8052e3a"},
-    {file = "pyzmq-24.0.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ce8c61297a751c67062d11e44352e9379da03a90d95aa352395d3b1e53e9f20a"},
-    {file = "pyzmq-24.0.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:adbf2bb11a616210735d6a112186d378f7934be3f2935e6d9dd760c110840c3a"},
-    {file = "pyzmq-24.0.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:0584420cbd2dac77f81bdc4b9da2635a54300563d4632433b08cb1f505341ef0"},
-    {file = "pyzmq-24.0.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:8ea1861512c7f32d0c585119a2caea6665eec6df429abf5810826b0df9587de1"},
-    {file = "pyzmq-24.0.0-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:be67e7f48fce8dbefd602f779c7382c874a1a1a3d08f375366c4d28baaa0bfd4"},
-    {file = "pyzmq-24.0.0-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ff6c9fdbcfb285e28fe35eaf5ba39644cbc65343aa41844217c2b5a99abbdd7e"},
-    {file = "pyzmq-24.0.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6736703c7581d18e3959c1d786035c620def2f096e762aefaf08cfa39844d1e"},
-    {file = "pyzmq-24.0.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:a5b9471e5e507f51f4c0acabec60a7ae2ea218ac6134a8e5ec5674845347a63a"},
-    {file = "pyzmq-24.0.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:dbece43299705eca217808759f4322c7cab41db2ba3ad8d7261ee2b17abe6488"},
-    {file = "pyzmq-24.0.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:025a0815d36ccd54cf002feb9cbe0e37c2253eca305ee4dc72ccdb4a814eefb4"},
-    {file = "pyzmq-24.0.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fc21a74f337298840f59f21a12fbf6ec1de798cd69d6b331ef9ed88ac8cb18f0"},
-    {file = "pyzmq-24.0.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf6477a083f8a1b54893ad24bc15f94dd0684b02320c69d2a69dcf36f70e73cb"},
-    {file = "pyzmq-24.0.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:aa6d0dfa94ce89d050dca0104389e10c537715bf10e5b0bfe5ece79f17f1719e"},
-    {file = "pyzmq-24.0.0.tar.gz", hash = "sha256:13b008bd142c9f6079ad75a30504eef2291502e9eac90e722b16fcf9ce856147"},
+    {file = "pyzmq-24.0.1-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:28b119ba97129d3001673a697b7cce47fe6de1f7255d104c2f01108a5179a066"},
+    {file = "pyzmq-24.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bcbebd369493d68162cddb74a9c1fcebd139dfbb7ddb23d8f8e43e6c87bac3a6"},
+    {file = "pyzmq-24.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae61446166983c663cee42c852ed63899e43e484abf080089f771df4b9d272ef"},
+    {file = "pyzmq-24.0.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87f7ac99b15270db8d53f28c3c7b968612993a90a5cf359da354efe96f5372b4"},
+    {file = "pyzmq-24.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9dca7c3956b03b7663fac4d150f5e6d4f6f38b2462c1e9afd83bcf7019f17913"},
+    {file = "pyzmq-24.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8c78bfe20d4c890cb5580a3b9290f700c570e167d4cdcc55feec07030297a5e3"},
+    {file = "pyzmq-24.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:48f721f070726cd2a6e44f3c33f8ee4b24188e4b816e6dd8ba542c8c3bb5b246"},
+    {file = "pyzmq-24.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:afe1f3bc486d0ce40abb0a0c9adb39aed3bbac36ebdc596487b0cceba55c21c1"},
+    {file = "pyzmq-24.0.1-cp310-cp310-win32.whl", hash = "sha256:3e6192dbcefaaa52ed81be88525a54a445f4b4fe2fffcae7fe40ebb58bd06bfd"},
+    {file = "pyzmq-24.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:86de64468cad9c6d269f32a6390e210ca5ada568c7a55de8e681ca3b897bb340"},
+    {file = "pyzmq-24.0.1-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:838812c65ed5f7c2bd11f7b098d2e5d01685a3f6d1f82849423b570bae698c00"},
+    {file = "pyzmq-24.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dfb992dbcd88d8254471760879d48fb20836d91baa90f181c957122f9592b3dc"},
+    {file = "pyzmq-24.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7abddb2bd5489d30ffeb4b93a428130886c171b4d355ccd226e83254fcb6b9ef"},
+    {file = "pyzmq-24.0.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:94010bd61bc168c103a5b3b0f56ed3b616688192db7cd5b1d626e49f28ff51b3"},
+    {file = "pyzmq-24.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:8242543c522d84d033fe79be04cb559b80d7eb98ad81b137ff7e0a9020f00ace"},
+    {file = "pyzmq-24.0.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ccb94342d13e3bf3ffa6e62f95b5e3f0bc6bfa94558cb37f4b3d09d6feb536ff"},
+    {file = "pyzmq-24.0.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:6640f83df0ae4ae1104d4c62b77e9ef39be85ebe53f636388707d532bee2b7b8"},
+    {file = "pyzmq-24.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a180dbd5ea5d47c2d3b716d5c19cc3fb162d1c8db93b21a1295d69585bfddac1"},
+    {file = "pyzmq-24.0.1-cp311-cp311-win32.whl", hash = "sha256:624321120f7e60336be8ec74a172ae7fba5c3ed5bf787cc85f7e9986c9e0ebc2"},
+    {file = "pyzmq-24.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:1724117bae69e091309ffb8255412c4651d3f6355560d9af312d547f6c5bc8b8"},
+    {file = "pyzmq-24.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:15975747462ec49fdc863af906bab87c43b2491403ab37a6d88410635786b0f4"},
+    {file = "pyzmq-24.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b947e264f0e77d30dcbccbb00f49f900b204b922eb0c3a9f0afd61aaa1cedc3d"},
+    {file = "pyzmq-24.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0ec91f1bad66f3ee8c6deb65fa1fe418e8ad803efedd69c35f3b5502f43bd1dc"},
+    {file = "pyzmq-24.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:db03704b3506455d86ec72c3358a779e9b1d07b61220dfb43702b7b668edcd0d"},
+    {file = "pyzmq-24.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:e7e66b4e403c2836ac74f26c4b65d8ac0ca1eef41dfcac2d013b7482befaad83"},
+    {file = "pyzmq-24.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:7a23ccc1083c260fa9685c93e3b170baba45aeed4b524deb3f426b0c40c11639"},
+    {file = "pyzmq-24.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:fa0ae3275ef706c0309556061185dd0e4c4cd3b7d6f67ae617e4e677c7a41e2e"},
+    {file = "pyzmq-24.0.1-cp36-cp36m-win32.whl", hash = "sha256:f01de4ec083daebf210531e2cca3bdb1608dbbbe00a9723e261d92087a1f6ebc"},
+    {file = "pyzmq-24.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:de4217b9eb8b541cf2b7fde4401ce9d9a411cc0af85d410f9d6f4333f43640be"},
+    {file = "pyzmq-24.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:78068e8678ca023594e4a0ab558905c1033b2d3e806a0ad9e3094e231e115a33"},
+    {file = "pyzmq-24.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77c2713faf25a953c69cf0f723d1b7dd83827b0834e6c41e3fb3bbc6765914a1"},
+    {file = "pyzmq-24.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8bb4af15f305056e95ca1bd086239b9ebc6ad55e9f49076d27d80027f72752f6"},
+    {file = "pyzmq-24.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:0f14cffd32e9c4c73da66db97853a6aeceaac34acdc0fae9e5bbc9370281864c"},
+    {file = "pyzmq-24.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:0108358dab8c6b27ff6b985c2af4b12665c1bc659648284153ee501000f5c107"},
+    {file = "pyzmq-24.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:d66689e840e75221b0b290b0befa86f059fb35e1ee6443bce51516d4d61b6b99"},
+    {file = "pyzmq-24.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ae08ac90aa8fa14caafc7a6251bd218bf6dac518b7bff09caaa5e781119ba3f2"},
+    {file = "pyzmq-24.0.1-cp37-cp37m-win32.whl", hash = "sha256:8421aa8c9b45ea608c205db9e1c0c855c7e54d0e9c2c2f337ce024f6843cab3b"},
+    {file = "pyzmq-24.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:54d8b9c5e288362ec8595c1d98666d36f2070fd0c2f76e2b3c60fbad9bd76227"},
+    {file = "pyzmq-24.0.1-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:acbd0a6d61cc954b9f535daaa9ec26b0a60a0d4353c5f7c1438ebc88a359a47e"},
+    {file = "pyzmq-24.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:47b11a729d61a47df56346283a4a800fa379ae6a85870d5a2e1e4956c828eedc"},
+    {file = "pyzmq-24.0.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:abe6eb10122f0d746a0d510c2039ae8edb27bc9af29f6d1b05a66cc2401353ff"},
+    {file = "pyzmq-24.0.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:07bec1a1b22dacf718f2c0e71b49600bb6a31a88f06527dfd0b5aababe3fa3f7"},
+    {file = "pyzmq-24.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f0d945a85b70da97ae86113faf9f1b9294efe66bd4a5d6f82f2676d567338b66"},
+    {file = "pyzmq-24.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:1b7928bb7580736ffac5baf814097be342ba08d3cfdfb48e52773ec959572287"},
+    {file = "pyzmq-24.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:b946da90dc2799bcafa682692c1d2139b2a96ec3c24fa9fc6f5b0da782675330"},
+    {file = "pyzmq-24.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c8840f064b1fb377cffd3efeaad2b190c14d4c8da02316dae07571252d20b31f"},
+    {file = "pyzmq-24.0.1-cp38-cp38-win32.whl", hash = "sha256:4854f9edc5208f63f0841c0c667260ae8d6846cfa233c479e29fdc85d42ebd58"},
+    {file = "pyzmq-24.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:42d4f97b9795a7aafa152a36fe2ad44549b83a743fd3e77011136def512e6c2a"},
+    {file = "pyzmq-24.0.1-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:52afb0ac962963fff30cf1be775bc51ae083ef4c1e354266ab20e5382057dd62"},
+    {file = "pyzmq-24.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8bad8210ad4df68c44ff3685cca3cda448ee46e20d13edcff8909eba6ec01ca4"},
+    {file = "pyzmq-24.0.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:dabf1a05318d95b1537fd61d9330ef4313ea1216eea128a17615038859da3b3b"},
+    {file = "pyzmq-24.0.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5bd3d7dfd9cd058eb68d9a905dec854f86649f64d4ddf21f3ec289341386c44b"},
+    {file = "pyzmq-24.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8012bce6836d3f20a6c9599f81dfa945f433dab4dbd0c4917a6fb1f998ab33d"},
+    {file = "pyzmq-24.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c31805d2c8ade9b11feca4674eee2b9cce1fec3e8ddb7bbdd961a09dc76a80ea"},
+    {file = "pyzmq-24.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:3104f4b084ad5d9c0cb87445cc8cfd96bba710bef4a66c2674910127044df209"},
+    {file = "pyzmq-24.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:df0841f94928f8af9c7a1f0aaaffba1fb74607af023a152f59379c01c53aee58"},
+    {file = "pyzmq-24.0.1-cp39-cp39-win32.whl", hash = "sha256:a435ef8a3bd95c8a2d316d6e0ff70d0db524f6037411652803e118871d703333"},
+    {file = "pyzmq-24.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:2032d9cb994ce3b4cba2b8dfae08c7e25bc14ba484c770d4d3be33c27de8c45b"},
+    {file = "pyzmq-24.0.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:bb5635c851eef3a7a54becde6da99485eecf7d068bd885ac8e6d173c4ecd68b0"},
+    {file = "pyzmq-24.0.1-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:83ea1a398f192957cb986d9206ce229efe0ee75e3c6635baff53ddf39bd718d5"},
+    {file = "pyzmq-24.0.1-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:941fab0073f0a54dc33d1a0460cb04e0d85893cb0c5e1476c785000f8b359409"},
+    {file = "pyzmq-24.0.1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e8f482c44ccb5884bf3f638f29bea0f8dc68c97e38b2061769c4cb697f6140d"},
+    {file = "pyzmq-24.0.1-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:613010b5d17906c4367609e6f52e9a2595e35d5cc27d36ff3f1b6fa6e954d944"},
+    {file = "pyzmq-24.0.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:65c94410b5a8355cfcf12fd600a313efee46ce96a09e911ea92cf2acf6708804"},
+    {file = "pyzmq-24.0.1-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:20e7eeb1166087db636c06cae04a1ef59298627f56fb17da10528ab52a14c87f"},
+    {file = "pyzmq-24.0.1-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a2712aee7b3834ace51738c15d9ee152cc5a98dc7d57dd93300461b792ab7b43"},
+    {file = "pyzmq-24.0.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a7c280185c4da99e0cc06c63bdf91f5b0b71deb70d8717f0ab870a43e376db8"},
+    {file = "pyzmq-24.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:858375573c9225cc8e5b49bfac846a77b696b8d5e815711b8d4ba3141e6e8879"},
+    {file = "pyzmq-24.0.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:80093b595921eed1a2cead546a683b9e2ae7f4a4592bb2ab22f70d30174f003a"},
+    {file = "pyzmq-24.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f3f3154fde2b1ff3aa7b4f9326347ebc89c8ef425ca1db8f665175e6d3bd42f"},
+    {file = "pyzmq-24.0.1-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abb756147314430bee5d10919b8493c0ccb109ddb7f5dfd2fcd7441266a25b75"},
+    {file = "pyzmq-24.0.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44e706bac34e9f50779cb8c39f10b53a4d15aebb97235643d3112ac20bd577b4"},
+    {file = "pyzmq-24.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:687700f8371643916a1d2c61f3fdaa630407dd205c38afff936545d7b7466066"},
+    {file = "pyzmq-24.0.1.tar.gz", hash = "sha256:216f5d7dbb67166759e59b0479bca82b8acf9bed6015b526b8eb10143fb08e77"},
 ]
 qpd = [
     {file = "qpd-0.3.3-py3-none-any.whl", hash = "sha256:600b200fbc4fcd701ce06ff4eeedab9fa68bb395add89e2aaa9bd43c519b4fba"},
@@ -3816,12 +3823,11 @@ sqlparse = [
 ]
 tabulate = [
     {file = "tabulate-0.8.10-py3-none-any.whl", hash = "sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc"},
-    {file = "tabulate-0.8.10-py3.8.egg", hash = "sha256:436f1c768b424654fce8597290d2764def1eea6a77cfa5c33be00b1bc0f4f63d"},
     {file = "tabulate-0.8.10.tar.gz", hash = "sha256:6c57f3f3dd7ac2782770155f3adb2db0b1a269637e42f27599925e64b114f519"},
 ]
 tenacity = [
-    {file = "tenacity-8.0.1-py3-none-any.whl", hash = "sha256:f78f4ea81b0fabc06728c11dc2a8c01277bfc5181b321a4770471902e3eb844a"},
-    {file = "tenacity-8.0.1.tar.gz", hash = "sha256:43242a20e3e73291a28bcbcacfd6e000b02d3857a9a9fff56b297a27afdc932f"},
+    {file = "tenacity-8.1.0-py3-none-any.whl", hash = "sha256:35525cd47f82830069f0d6b73f7eb83bc5b73ee2fff0437952cedf98b27653ac"},
+    {file = "tenacity-8.1.0.tar.gz", hash = "sha256:e48c437fdf9340f5666b92cd7990e96bc5fc955e1298baf4a907e3972067a445"},
 ]
 textwrap3 = [
     {file = "textwrap3-0.9.2-py2.py3-none-any.whl", hash = "sha256:bf5f4c40faf2a9ff00a9e0791fed5da7415481054cef45bb4a3cfb1f69044ae0"},

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -3823,6 +3823,7 @@ sqlparse = [
 ]
 tabulate = [
     {file = "tabulate-0.8.10-py3-none-any.whl", hash = "sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc"},
+    {file = "tabulate-0.8.10-py3.8.egg", hash = "sha256:436f1c768b424654fce8597290d2764def1eea6a77cfa5c33be00b1bc0f4f63d"},
     {file = "tabulate-0.8.10.tar.gz", hash = "sha256:6c57f3f3dd7ac2782770155f3adb2db0b1a269637e42f27599925e64b114f519"},
 ]
 tenacity = [

--- a/python/tests/extras/test_image_metric.py
+++ b/python/tests/extras/test_image_metric.py
@@ -69,7 +69,7 @@ def test_image_metric() -> None:
     for component in ["fractional", "boolean", "string", "object"]:
         assert summary[f"types_ImagePixelWidth/{component}"] == 0
 
-    for tag in ["ImagePixelWidth", "PhotometricInterpretation", "Orientation",  "ResolutionUnit"]:
+    for tag in ["ImagePixelWidth", "PhotometricInterpretation", "Orientation", "ResolutionUnit"]:
         assert summary[f"counts_{tag}/n"] == summary[f"dist_{tag}/n"]
         assert summary[f"counts_{tag}/null"] == 0
 

--- a/python/tests/extras/test_image_metric.py
+++ b/python/tests/extras/test_image_metric.py
@@ -52,13 +52,32 @@ def test_image_metric() -> None:
     metric = ImageMetric.zero(ImageMetricConfig())
     metric.columnar_update(ppc)
     summary = metric.to_summary_dict(SummaryConfig())
-    assert summary["ImagePixelWidth/mean"] > 0
+    assert summary["dist_ImagePixelWidth/mean"] > 0
+    assert summary["dist_ImagePixelWidth/n"] == 1
     # these should be discovered EXIF tags
-    assert summary["ImageWidth/max"] == 1733
-    assert summary["PhotometricInterpretation/min"] == 2
-    assert summary["Orientation/max"] == 1
-    assert summary["ResolutionUnit/max"] == 2
-    assert "Software/frequent_strings" in summary
+    assert summary["dist_ImageWidth/max"] == 1733
+    assert summary["dist_PhotometricInterpretation/min"] == 2
+    assert summary["dist_Orientation/max"] == 1
+    assert summary["dist_ResolutionUnit/max"] == 2
+    assert "fi_Software/frequent_strings" in summary
+
+    # resolved int submetrics
+    for prefix in ["counts", "types", "card", "dist", "ints", "fi"]:
+        assert f"{prefix}_ImagePixelWidth" in metric.submetrics.keys()
+    assert summary["types_ImagePixelWidth/integral"] == summary["dist_ImagePixelWidth/n"]
+
+    for component in ["fractional", "boolean", "string", "object"]:
+        assert summary[f"types_ImagePixelWidth/{component}"] == 0
+
+    for tag in ["ImagePixelWidth", "PhotometricInterpretation", "Orientation",  "ResolutionUnit"]:
+        assert summary[f"counts_{tag}/n"] == summary[f"dist_{tag}/n"]
+        assert summary[f"counts_{tag}/null"] == 0
+
+    # resolved string submetrics
+    for prefix in ["counts", "types", "card", "fi"]:
+        assert f"{prefix}_Software" in metric.submetrics.keys()
+    assert "dist_Software" not in metric.submetrics.keys()
+    assert "ints_Software" not in metric.submetrics.keys()
 
 
 def test_allowed_exif_tags() -> None:
@@ -70,9 +89,9 @@ def test_allowed_exif_tags() -> None:
     metric = ImageMetric.zero(config)
     metric.columnar_update(ppc)
     summary = metric.to_summary_dict(SummaryConfig())
-    assert summary["ImagePixelWidth/mean"] > 0  # image stat, not an EXIF tag
-    assert "PhotometricInterpretation/min" in summary  # allowed EXIF tag
-    assert "ResolutionUnit/max" not in summary  # not an allowed EXIF tag
+    assert summary["dist_ImagePixelWidth/mean"] > 0  # image stat, not an EXIF tag
+    assert "dist_PhotometricInterpretation/min" in summary  # allowed EXIF tag
+    assert "dist_ResolutionUnit/max" not in summary  # not an allowed EXIF tag
 
 
 def test_forbidden_exif_tags() -> None:
@@ -84,9 +103,9 @@ def test_forbidden_exif_tags() -> None:
     metric = ImageMetric.zero(config)
     metric.columnar_update(ppc)
     summary = metric.to_summary_dict(SummaryConfig())
-    assert summary["ImagePixelWidth/mean"] > 0  # image stat, not an EXIF tag
-    assert "PhotometricInterpretation/min" not in summary  # forbidden EXIF tag
-    assert "ResolutionUnit/max" in summary  # empty allowed_exif_tags means allow anything not explicitly forbidden
+    assert summary["dist_ImagePixelWidth/mean"] > 0  # image stat, not an EXIF tag
+    assert "dist_PhotometricInterpretation/min" not in summary  # forbidden EXIF tag
+    assert "dist_ResolutionUnit/max" in summary  # empty allowed_exif_tags means allow anything not explicitly forbidden
 
 
 def test_forbidden_overrules_allowed_exif_tags() -> None:
@@ -100,9 +119,9 @@ def test_forbidden_overrules_allowed_exif_tags() -> None:
     metric = ImageMetric.zero(config)
     metric.columnar_update(ppc)
     summary = metric.to_summary_dict(SummaryConfig())
-    assert summary["ImagePixelWidth/mean"] > 0  # image stat, not an EXIF tag
-    assert "PhotometricInterpretation/min" not in summary  # forbidden > allowed
-    assert "ResolutionUnit/max" not in summary  # non-empty allowed_exif_tags means only explicitly allowed tags
+    assert summary["dist_ImagePixelWidth/mean"] > 0  # image stat, not an EXIF tag
+    assert "dist_PhotometricInterpretation/min" not in summary  # forbidden > allowed
+    assert "dist_ResolutionUnit/max" not in summary  # non-empty allowed_exif_tags means only explicitly allowed tags
 
 
 def test_log_image() -> None:
@@ -110,7 +129,7 @@ def test_log_image() -> None:
     img = image_loader(image_path)
     results = log_image(img).view()
     logger.info(results.get_column("image").to_summary_dict())
-    assert results.get_column("image").to_summary_dict()["image/ImagePixelWidth/mean"] > 0
+    assert results.get_column("image").to_summary_dict()["image/dist_ImagePixelWidth/mean"] > 0
 
 
 def test_log_interface() -> None:
@@ -121,7 +140,7 @@ def test_log_interface() -> None:
 
     results = why.log(row={"image_col": img}, schema=schema).view().get_column("image_col")
     logger.info(results.to_summary_dict())
-    assert results.to_summary_dict()["image/ImagePixelWidth/mean"] > 0
+    assert results.to_summary_dict()["image/dist_ImagePixelWidth/mean"] > 0
 
 
 def test_uncompound_profile() -> None:
@@ -131,5 +150,10 @@ def test_uncompound_profile() -> None:
     uncompounded = _uncompund_dataset_profile(profile_view)
     assert "image_column" in uncompounded._columns
     assert "image" in uncompounded._columns["image_column"]._metrics  # original compound metric
-    assert "image_column.image.ImagePixelWidth" in uncompounded._columns
-    assert "distribution" in uncompounded._columns["image_column.image.ImagePixelWidth"]._metrics  # uncompounded
+    assert "image_column.ImagePixelWidth" in uncompounded._columns
+
+    for metric in ["counts", "types", "cardinality", "distribution", "ints", "frequent_items"]:
+        assert metric in uncompounded._columns["image_column.ImagePixelWidth"]._metrics  # uncompounded
+
+    for metric in ["counts", "types", "cardinality", "frequent_items"]:
+        assert metric in uncompounded._columns["image_column.Software"]._metrics

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -72,7 +72,8 @@ def _ugly_hack(col_name: str, metric_name: str, metric: CompoundMetric) -> Dict[
             result[new_col_name] = ColumnProfileView(metrics)
 
     return result
-    
+
+
 def _uncompound_metric(col_name: str, metric_name: str, metric: CompoundMetric) -> Dict[str, ColumnProfileView]:
     if isinstance(metric, ImageMetric):
         return _ugly_hack(col_name, metric_name, metric)

--- a/python/whylogs/core/metrics/metric_components.py
+++ b/python/whylogs/core/metrics/metric_components.py
@@ -150,13 +150,22 @@ class FractionalComponent(MetricComponent[float]):
 class KllComponent(MetricComponent[ds.kll_doubles_sketch]):
     mtype = ds.kll_doubles_sketch
 
+    def __deepcopy__(self, memo) -> "KllComponent":
+        return KllComponent.from_protobuf(self.to_protobuf())
+
 
 class HllComponent(MetricComponent[ds.hll_sketch]):
     mtype = ds.hll_sketch
 
+    def __deepcopy__(self, memo) -> "HllComponent":
+        return HllComponent.from_protobuf(self.to_protobuf())
+
 
 class FrequentStringsComponent(MetricComponent[ds.frequent_strings_sketch]):
     mtype = ds.frequent_strings_sketch
+
+    def __deepcopy__(self, memo) -> "FrequentStringsComponent":
+        return FrequentStringsComponent.from_protobuf(self.to_protobuf())
 
 
 class CustomComponent(Generic[T], MetricComponent[T]):

--- a/python/whylogs/extras/image_metric.py
+++ b/python/whylogs/extras/image_metric.py
@@ -1,11 +1,13 @@
 import logging
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from itertools import chain
-from typing import Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 import whylogs as why
 from whylogs.api.logger.result_set import ResultSet
-from whylogs.core.datatypes import DataType
+from whylogs.core.datatypes import DataType, Integral, Fractional, String, StandardTypeMapper, TypeMapper
+from whylogs.core.metrics import StandardMetric
 from whylogs.core.metrics.compound_metric import CompoundMetric
 from whylogs.core.metrics.metrics import (
     DistributionMetric,
@@ -102,24 +104,68 @@ def image_based_metadata(img):
     }
 
 
+class ImageResolver(ABC):
+    @abstractmethod
+    def prefixes(self) -> Set[str]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def resolve(self, name: str, why_type: DataType, fi_disabled: bool=False) -> Dict[str, Metric]:
+        raise NotImplementedError
+
+
+class StandardResolver(ImageResolver):
+    def prefixes(self) -> Set[str]:
+        return {"counts", "types", "dist", "ints", "card", "fi"}
+
+    def resolve(self, name: str, why_type: DataType, fi_disabled: bool=False) -> Dict[str, Metric]:
+        metrics: Dict[str, Metric] = {
+            f"counts_{name}": StandardMetric.counts.zero(MetricConfig()),
+            f"types_{name}": StandardMetric.types.zero(MetricConfig()),
+            f"card_{name}": StandardMetric.cardinality.zero(MetricConfig())
+        }
+
+        if isinstance(why_type, Integral):
+            metrics[f"dist_{name}"] = StandardMetric.distribution.zero(MetricConfig())
+            metrics[f"ints_{name}"] = StandardMetric.ints.zero(MetricConfig())
+            if not fi_disabled:
+                metrics[f"fi_{name}"] = StandardMetric.frequent_items.zero(MetricConfig())
+        elif isinstance(why_type, Fractional):
+            metrics[f"dist_{name}"] = StandardMetric.distribution.zero(MetricConfig())
+        elif isinstance(why_type, String) and not fi_disabled:
+            metrics[f"fi_{name}"] = StandardMetric.frequent_items.zero(MetricConfig())
+
+        return metrics
+    
+
 @dataclass(frozen=True)
 class ImageMetricConfig(MetricConfig):
     allowed_exif_tags: Set[str] = field(default_factory=set)
     forbidden_exif_tags: Set[str] = field(default_factory=set)
+    resolver: Resolver = field(default_factory=StandardResolver)
+    type_mapper: TypeMapper = field(default_factory=StandardTypeMapper)
 
 
 class ImageMetric(CompoundMetric):
     def __init__(
         self,
         submetrics: Dict[str, Metric],
+        attribute_names: Optional[Set[str]] = None,
         allowed_exif_tags: Optional[Set[str]] = None,
         forbidden_exif_tags: Optional[Set[str]] = None,
+        resolver: Optional[Resolver] = None,
+        type_mapper: Optional[TypeMapper] = None,
+        fi_disabled: bool = False,
     ):
         if ImageType is None:
             logger.error("Install Pillow for image support")
         super(ImageMetric, self).__init__(submetrics)
+        self._attribute_names = attribute_names or set()
         self._allowed_exif_tags = allowed_exif_tags or set()
         self._forbidden_exif_tags = forbidden_exif_tags or set()
+        self._resolver = resolver or StandardResolver()
+        self._type_mapper = type_mapper or StandardTypeMapper()
+        self._fi_disabled = fi_disabled
 
     @property
     def namespace(self) -> str:
@@ -132,45 +178,57 @@ class ImageMetric(CompoundMetric):
             return True
         return exif_tag in self._allowed_exif_tags
 
+    def _discover_submetrics(self, name: str, value: Any) -> None:
+        if name not in self._attribute_names:
+            if self._wants_to_track(name):
+                submetrics = self._resolver.resolve(name, self._type_mapper(type(value)), self._fi_disabled)
+                self.submetrics.update(submetrics)
+                self._attribute_names.add(name)
+
+    def _update_relevant_submetrics(self, name: str, data: PreprocessedColumn) -> None:
+        for prefix in self._resolver.prefixes():
+            submetric_name = f"{prefix}_{name}"
+            if submetric_name in self.submetrics:
+                self.submetrics[submetric_name].columnar_update(data)
+
     def columnar_update(self, view: PreprocessedColumn) -> OperationResult:
-        submetric_names = self.submetrics.keys()
         count = 0
         for image in list(chain.from_iterable(view.raw_iterator())):
             if isinstance(image, ImageType):
                 metadata = get_pil_image_metadata(image)
-                for attr in metadata.keys():
-                    if attr not in submetric_names:  # EXIF tag discovery
-                        if self._wants_to_track(attr):
-                            # TODO: add a resolver to ImageMetricConfig
-                            if isinstance(metadata[attr], int) or isinstance(metadata[attr], float):
-                                self.submetrics[attr] = DistributionMetric.zero(MetricConfig())
-                            elif isinstance(metadata[attr], str):
-                                self.submetrics[attr] = FrequentItemsMetric.zero(MetricConfig())
-
-                    if attr in submetric_names:
-                        self.submetrics[attr].columnar_update(PreprocessedColumn.apply([metadata[attr]]))
+                for name, value in metadata.items():
+                    self._discover_submetrics(name, value)  # EXIF tag discovery
+                    data = PreprocessedColumn.apply([metadata[name]])
+                    self._update_relevant_submetrics(name, data)
 
                 count += 1
         return OperationResult.ok(count)
 
     @classmethod
-    def zero(cls, config: MetricConfig) -> "ImageMetric":
+    def zero(cls, config: Optional[MetricConfig]=None) -> "ImageMetric":
+        config = config or ImageMetricConfig()
         if not isinstance(config, ImageMetricConfig):
-            logger.warning("ImageMetric.zero() needs an ImageMetricConfig")
+            logger.error("ImageMetric.zero() needs an ImageMetricConfig")
             config = ImageMetricConfig()
 
         dummy_image = new_image("HSV", (1, 1))
         metadata = get_pil_image_metadata(dummy_image)  # any EXIF tags will be discovered as images are logged
-        submetrics: Dict[str, Metric] = dict()
-        for tag, value in metadata.items():
-            if isinstance(value, int):
-                submetrics[tag] = DistributionMetric.zero(config)
-            elif isinstance(value, float):
-                submetrics[tag] = DistributionMetric.zero(config)
-            elif isinstance(value, str) and not config.fi_disabled:
-                submetrics[tag] = FrequentItemsMetric.zero(config)
+        attribute_names = set(metadata.keys())
 
-        return ImageMetric(submetrics, config.allowed_exif_tags, config.forbidden_exif_tags)
+        submetrics: Dict[str, Metric] = dict()
+        for name, value in metadata.items():
+            attribute_metrics = config.resolver.resolve(name, config.type_mapper(type(value)), config.fi_disabled)
+            submetrics.update(attribute_metrics)
+
+        return ImageMetric(
+            submetrics,
+            attribute_names,
+            config.allowed_exif_tags,
+            config.forbidden_exif_tags,
+            config.resolver,
+            config.type_mapper,
+            config.fi_disabled
+        )
 
 
 def log_image(

--- a/python/whylogs/extras/image_metric.py
+++ b/python/whylogs/extras/image_metric.py
@@ -6,16 +6,17 @@ from typing import Any, Dict, List, Optional, Set, Union
 
 import whylogs as why
 from whylogs.api.logger.result_set import ResultSet
-from whylogs.core.datatypes import DataType, Integral, Fractional, String, StandardTypeMapper, TypeMapper
+from whylogs.core.datatypes import (
+    DataType,
+    Fractional,
+    Integral,
+    StandardTypeMapper,
+    String,
+    TypeMapper,
+)
 from whylogs.core.metrics import StandardMetric
 from whylogs.core.metrics.compound_metric import CompoundMetric
-from whylogs.core.metrics.metrics import (
-    DistributionMetric,
-    FrequentItemsMetric,
-    Metric,
-    MetricConfig,
-    OperationResult,
-)
+from whylogs.core.metrics.metrics import Metric, MetricConfig, OperationResult
 from whylogs.core.preprocessing import PreprocessedColumn
 from whylogs.core.resolvers import Resolver
 from whylogs.core.schema import ColumnSchema, DatasetSchema
@@ -110,7 +111,7 @@ class ImageResolver(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def resolve(self, name: str, why_type: DataType, fi_disabled: bool=False) -> Dict[str, Metric]:
+    def resolve(self, name: str, why_type: DataType, fi_disabled: bool = False) -> Dict[str, Metric]:
         raise NotImplementedError
 
 
@@ -118,11 +119,11 @@ class StandardResolver(ImageResolver):
     def prefixes(self) -> Set[str]:
         return {"counts", "types", "dist", "ints", "card", "fi"}
 
-    def resolve(self, name: str, why_type: DataType, fi_disabled: bool=False) -> Dict[str, Metric]:
+    def resolve(self, name: str, why_type: DataType, fi_disabled: bool = False) -> Dict[str, Metric]:
         metrics: Dict[str, Metric] = {
             f"counts_{name}": StandardMetric.counts.zero(MetricConfig()),
             f"types_{name}": StandardMetric.types.zero(MetricConfig()),
-            f"card_{name}": StandardMetric.cardinality.zero(MetricConfig())
+            f"card_{name}": StandardMetric.cardinality.zero(MetricConfig()),
         }
 
         if isinstance(why_type, Integral):
@@ -136,7 +137,7 @@ class StandardResolver(ImageResolver):
             metrics[f"fi_{name}"] = StandardMetric.frequent_items.zero(MetricConfig())
 
         return metrics
-    
+
 
 @dataclass(frozen=True)
 class ImageMetricConfig(MetricConfig):
@@ -205,7 +206,7 @@ class ImageMetric(CompoundMetric):
         return OperationResult.ok(count)
 
     @classmethod
-    def zero(cls, config: Optional[MetricConfig]=None) -> "ImageMetric":
+    def zero(cls, config: Optional[MetricConfig] = None) -> "ImageMetric":
         config = config or ImageMetricConfig()
         if not isinstance(config, ImageMetricConfig):
             logger.error("ImageMetric.zero() needs an ImageMetricConfig")
@@ -227,7 +228,7 @@ class ImageMetric(CompoundMetric):
             config.forbidden_exif_tags,
             config.resolver,
             config.type_mapper,
-            config.fi_disabled
+            config.fi_disabled,
         )
 
 


### PR DESCRIPTION
This depends on #860 

It adds a resolver to the `ImageMetric` analogous to the `DatasetSchema`'s to create the standard metrics (counts, types, cardinality, etc.) that the visualizer & whylabs seem to require. The logical submetric name is prefixed with a metric type code so that the related metrics can be aggregated into some `ColumnProfileView` when the `ImageMetric` is "uncompounded" to send it to whylabs.