### PR TITLE
Update version to 1.1.2

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,15 +1,15 @@
 [bumpversion]
-current_version = 1.1.1
+current_version = 1.1.2
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = dev
-values =
+values = 
 	dev
 	prod
 

--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -55,3 +55,4 @@ repos:
       - id: forbid-new-submodules
       - id: mixed-line-ending
       - id: trailing-whitespace
+        exclude: .bumpversion.cfg|.dockerignore

--- a/python/Makefile
+++ b/python/Makefile
@@ -5,7 +5,7 @@ src.proto.dir := ../proto/src
 src.proto := $(shell find $(src.proto.dir) -type f -name "*.proto")
 src.proto.v0.dir := ../proto/v0
 src.proto.v0 := $(shell find $(src.proto.v0.dir) -type f -name "*.proto")
-version := 1.1.1
+version := 1.1.2
 
 dist.dir := dist
 egg.dir := .eggs

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -8,7 +8,7 @@ if shutil.which("pandoc") is None:
     print("Pandoc is required to build our documentation.")
     sys.exit(1)
 
-version = "1.1.1"
+version = "1.1.2"
 
 project = "whylogs"
 author = "whylogs developers"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "whylogs"
-version = "1.1.1"
+version = "1.1.2"
 description = "Profile and monitor your ML data pipeline end-to-end"
 authors = ["WhyLabs.ai <support@whylabs.ai>"]
 license = "Apache-2.0"

--- a/python/tests/smoketest.py
+++ b/python/tests/smoketest.py
@@ -12,7 +12,7 @@ intended to test the wheel in a production environment,
 not a development environment.
 """
 
-current_version = "1.1.1"
+current_version = "1.1.2"
 
 
 def test_package_version() -> None:


### PR DESCRIPTION
## Description

Ran `make bump-patch` to sync version with last release after hitting failure in the automatic PR generation.

Excluded .bumpversion.cfg from pre-commit hook checking trailing whitespace since bump2version adds trailing whitespace to this file while processing the version update.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
