### PR TITLE
Release 0.7.10

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.9
+current_version = 0.7.10
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ src.python.pyc := $(shell find ./src -type f -name "*.pyc")
 src.proto.dir := ./proto/src
 src.proto := $(shell find $(src.proto.dir) -type f -name "*.proto")
 
-version := 0.7.9
+version := 0.7.10
 
 dist.dir := dist
 egg.dir := .eggs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,7 @@ copyright = "2020, WhyLabs, Inc"
 # built documents.
 #
 # The short X.Y version.
-version = "0.7.9"
+version = "0.7.10-dev0"
 # The full version, including alpha/beta/rc tags.
 release = ""  # Is set by calling `setup.py docs`
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,7 @@ copyright = "2020, WhyLabs, Inc"
 # built documents.
 #
 # The short X.Y version.
-version = "0.7.10-dev0"
+version = "0.7.10"
 # The full version, including alpha/beta/rc tags.
 release = ""  # Is set by calling `setup.py docs`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "whylogs"
-version = "0.7.9"
+version = "0.7.10"
 description = "Profile and monitor your ML data pipeline end-to-end"
 authors = ["WhyLabs.ai <support@whylabs.ai>"]
 license = "Apache-2.0"

--- a/src/whylogs/_version.py
+++ b/src/whylogs/_version.py
@@ -1,3 +1,3 @@
 """WhyLabs version number."""
 
-__version__ = "0.7.9"
+__version__ = "0.7.10"


### PR DESCRIPTION
## Description

Update version info consistent with last maintenance release of whylogs 0.7.10 and merge back into maintenance/0.7.x branch

## Changes

Update version info from release_0.7.10 branch.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
