### PR TITLE
Comment out *.doc* lfs pattern in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,6 @@
 *.tar* filter=lfs diff=lfs merge=lfs -text
 *.xls* filter=lfs diff=lfs merge=lfs -text
 *.zip filter=lfs diff=lfs merge=lfs -text
-*.doc* filter=lfs diff=lfs merge=lfs -text
+# *.doc* filter=lfs diff=lfs merge=lfs -text
 # *.jp*g filter=lfs diff=lfs merge=lfs -text
 # *.png filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Description

We are hitting errors in the release automation with related to a .dockerignore file and lfs, and we have a filter in .gitattributes for *.doc*

comment this out to reduce noise.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
