### PR TITLE
break mypy return signature on preprocessing.py

### DIFF
--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -93,7 +93,7 @@ class PreprocessedColumn:
         self.bool_count_where_true = 0
         self.len = -1
 
-    def _pandas_split(self, series: pd.Series, parse_numeric_string: bool = False) -> None:
+    def _pandas_split(self, series: pd.Series, parse_numeric_string: bool = False) -> bool:
         """
         Split a Pandas Series into numpy array and other Pandas series.
 


### PR DESCRIPTION
## Description

do no merge, example of something mypy pre-commit hook should catch: return type inconsistent with method return.
