### PR TITLE
Fix stubs to allow isinstance checks

### DIFF
--- a/python/whylogs/core/stubs.py
+++ b/python/whylogs/core/stubs.py
@@ -16,22 +16,26 @@ except ImportError:  # noqa
         logger.error("Pandas is installed but numpy is not. Your environment is probably broken.")
 
 
+class _StubClass:
+    pass
+
+
 @dataclass(frozen=True)
 class NumpyStub:
-    dtype: None = None
-    number: None = None
-    floating: None = None
-    ndarray: None = None
-    timedelta64: None = None
-    datetime64: None = None
-    unicode_: None = None
-    issubdtype: None = None
+    dtype: type = _StubClass
+    number: type = _StubClass
+    floating: type = _StubClass
+    ndarray: type = _StubClass
+    timedelta64: type = _StubClass
+    datetime64: type = _StubClass
+    unicode_: type = _StubClass
+    issubdtype: type = _StubClass
 
 
 @dataclass(frozen=True)
 class PandasStub(object):
-    Series: None = None
-    DataFrame: None = None
+    Series: type = _StubClass
+    DataFrame: type = _StubClass
 
 
 if _np is None:


### PR DESCRIPTION
## Description

This repository needs to work logging rows when pandas is not installed. Fix stubs to have a class value rather than None so it can be used in isinstance checks. Closes #890 

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
