### PR TITLE
Enable Fugue Implementation to take arbitrary column names

### DIFF
--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -451,30 +451,30 @@ scandir = ["scandir (>=1.5,<2.0)"]
 
 [[package]]
 name = "fugue"
-version = "0.7.2"
+version = "0.7.3.dev1"
 description = "An abstraction layer for distributed computation"
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 adagio = ">=0.2.4"
-fugue-sql-antlr = ">=0.1.0"
+fugue-sql-antlr = ">=0.1.1"
 jinja2 = "*"
 pandas = ">=1.0.2"
 pyarrow = ">=0.15.1"
 qpd = ">=0.3.1"
 sqlalchemy = "*"
-triad = ">=0.6.6"
+triad = ">=0.6.9"
 
 [package.extras]
-all = ["dask[dataframe,distributed]", "duckdb (>=0.3.2)", "fugue-sql-antlr[cpp] (>=0.1.0)", "ibis-framework (>=2)", "ipython (>=7.10.0)", "jupyterlab", "notebook", "pyarrow (>=5.0.0)", "pyarrow (>=7.0.0)", "pyspark", "qpd[dask] (>=0.3.1)", "ray (>=2.0.0)"]
-cpp_sql_parser = ["fugue-sql-antlr[cpp] (>=0.1.0)"]
+all = ["dask[dataframe,distributed]", "duckdb (>=0.5.0)", "fugue-sql-antlr[cpp] (>=0.1.0)", "ibis-framework (>=2.1.1)", "ibis-framework (>=3.2.0)", "ipython (>=7.10.0)", "jupyterlab", "notebook", "pyarrow (>=7.0.0)", "pyspark", "qpd[dask] (>=0.3.1)", "ray (>=2.0.0)"]
+cpp_sql_parser = ["fugue-sql-antlr[cpp] (>=0.1.1)"]
 dask = ["dask[dataframe,distributed]", "qpd[dask] (>=0.3.1)"]
-duckdb = ["duckdb (>=0.3.2)", "numpy", "pyarrow (>=5.0.0)"]
-ibis = ["ibis-framework (>=2.1.1)"]
+duckdb = ["duckdb (>=0.5.0)", "numpy", "pyarrow (>=7.0.0)"]
+ibis = ["ibis-framework (>=2.1.1)", "ibis-framework (>=3.2.0)"]
 notebook = ["ipython (>=7.10.0)", "jupyterlab", "notebook"]
-ray = ["duckdb (>=0.3.2)", "pyarrow (>=7.0.0)", "ray (>=2.0.0)"]
+ray = ["duckdb (>=0.5.0)", "pyarrow (>=7.0.0)", "ray (>=2.0.0)"]
 spark = ["pyspark"]
 
 [[package]]
@@ -1241,10 +1241,10 @@ python-versions = ">=3.7.1"
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
     {version = ">=1.17.3", markers = "platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
     {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
     {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
 ]
 python-dateutil = ">=2.7.3"
 pytz = ">=2017.3"
@@ -2214,11 +2214,11 @@ test = ["pre-commit", "pytest"]
 
 [[package]]
 name = "triad"
-version = "0.6.8"
+version = "0.6.9"
 description = "A collection of python utils for Fugue projects"
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 fs = "*"
@@ -2403,13 +2403,13 @@ image = ["Pillow"]
 mlflow = ["mlflow-skinny"]
 s3 = ["boto3"]
 spark = ["pyarrow", "pyspark"]
-viz = ["ipython", "pybars3", "scipy"]
+viz = ["ipython", "pybars3", "scipy", "Pillow", "whylabs-client", "requests"]
 whylabs = ["whylabs-client", "requests"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1, <4"
-content-hash = "bf9db79da0d285ca90e425c07d40ca346a8a5b57092c6190587e933e643f3f50"
+content-hash = "0118912b2449322b6f71b59fbe445df24b2bf78c0e2bd6d2f6ee9f0f7b67a2df"
 
 [metadata.files]
 2to3 = [
@@ -2743,8 +2743,8 @@ fs = [
     {file = "fs-2.4.16.tar.gz", hash = "sha256:ae97c7d51213f4b70b6a958292530289090de3a7e15841e108fbe144f069d313"},
 ]
 fugue = [
-    {file = "fugue-0.7.2-py3-none-any.whl", hash = "sha256:ffb0c2754eb95c6730725da9dfa265c39df8cbf189fabcbce02a1177145005fa"},
-    {file = "fugue-0.7.2.tar.gz", hash = "sha256:8009315e371ab622aed326438c69ba4ad03126c618d48e839c3b18fa1917d441"},
+    {file = "fugue-0.7.3.dev1-py3-none-any.whl", hash = "sha256:8a3b04fd0349696c01680a892b4800f476b523c5cb2683161f7c8817160f6c47"},
+    {file = "fugue-0.7.3.dev1.tar.gz", hash = "sha256:38a5b2ec6b48de7842e345514f3d9369111ecb43bc2e71d8a793c17333cdbbd7"},
 ]
 fugue-sql-antlr = [
     {file = "fugue-sql-antlr-0.1.1.tar.gz", hash = "sha256:e276badd471cf3e1659e94ba181896e2b1887de63ef53ac2badc73483b1c9332"},
@@ -3823,7 +3823,6 @@ sqlparse = [
 ]
 tabulate = [
     {file = "tabulate-0.8.10-py3-none-any.whl", hash = "sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc"},
-    {file = "tabulate-0.8.10-py3.8.egg", hash = "sha256:436f1c768b424654fce8597290d2764def1eea6a77cfa5c33be00b1bc0f4f63d"},
     {file = "tabulate-0.8.10.tar.gz", hash = "sha256:6c57f3f3dd7ac2782770155f3adb2db0b1a269637e42f27599925e64b114f519"},
 ]
 tenacity = [
@@ -3868,8 +3867,8 @@ traitlets = [
     {file = "traitlets-5.4.0.tar.gz", hash = "sha256:3f2c4e435e271592fe4390f1746ea56836e3a080f84e7833f0f801d9613fec39"},
 ]
 triad = [
-    {file = "triad-0.6.8-py3-none-any.whl", hash = "sha256:a19da626f0cee4a91f2472270bb4cfe0851bf8766d5263ae499a5c03c552daf3"},
-    {file = "triad-0.6.8.tar.gz", hash = "sha256:588cf30e41fec815f7466e913d9b9d4e5119ea789a77748e4bf4546502580c1a"},
+    {file = "triad-0.6.9-py3-none-any.whl", hash = "sha256:140e39cd3745a25b714eea8ca0b7afff36c13293bba479a7d465b79473e0ee3a"},
+    {file = "triad-0.6.9.tar.gz", hash = "sha256:777d5930f325a64b3a11c2b0fb6322e30d981d32846a4abca2f8ae07f5b7f971"},
 ]
 twine = [
     {file = "twine-4.0.1-py3-none-any.whl", hash = "sha256:42026c18e394eac3e06693ee52010baa5313e4811d5a11050e7d48436cf41b9e"},

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -451,7 +451,7 @@ scandir = ["scandir (>=1.5,<2.0)"]
 
 [[package]]
 name = "fugue"
-version = "0.7.3.dev1"
+version = "0.7.3"
 description = "An abstraction layer for distributed computation"
 category = "main"
 optional = true
@@ -2409,7 +2409,7 @@ whylabs = ["whylabs-client", "requests"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1, <4"
-content-hash = "0118912b2449322b6f71b59fbe445df24b2bf78c0e2bd6d2f6ee9f0f7b67a2df"
+content-hash = "3342a5a2121b16c2f7da33a04620dd445e98ed3c459e6cad16cd1189094ed3e7"
 
 [metadata.files]
 2to3 = [
@@ -2743,8 +2743,8 @@ fs = [
     {file = "fs-2.4.16.tar.gz", hash = "sha256:ae97c7d51213f4b70b6a958292530289090de3a7e15841e108fbe144f069d313"},
 ]
 fugue = [
-    {file = "fugue-0.7.3.dev1-py3-none-any.whl", hash = "sha256:8a3b04fd0349696c01680a892b4800f476b523c5cb2683161f7c8817160f6c47"},
-    {file = "fugue-0.7.3.dev1.tar.gz", hash = "sha256:38a5b2ec6b48de7842e345514f3d9369111ecb43bc2e71d8a793c17333cdbbd7"},
+    {file = "fugue-0.7.3-py3-none-any.whl", hash = "sha256:731951134821c5b77442f4ce575b4430aa84fa1451cc381238dde69e5ac2f92c"},
+    {file = "fugue-0.7.3.tar.gz", hash = "sha256:6d9ac12b473905770f2496f70a8581ed7bed26b535c686fa994c18e23453d507"},
 ]
 fugue-sql-antlr = [
     {file = "fugue-sql-antlr-0.1.1.tar.gz", hash = "sha256:e276badd471cf3e1659e94ba181896e2b1887de63ef53ac2badc73483b1c9332"},

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -52,7 +52,7 @@ pyspark = {version = "^3.0.0", optional = true}
 Pillow = {version = "^9.2.0", optional = true}
 
 # Fugue related dependencies
-fugue = {version = "^0.7.2", optional = true}
+fugue = {version = "^0.7.3.dev1", optional = true}
 requests = "^2.27"
 
 [tool.poetry.dev-dependencies]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -52,7 +52,7 @@ pyspark = {version = "^3.0.0", optional = true}
 Pillow = {version = "^9.2.0", optional = true}
 
 # Fugue related dependencies
-fugue = {version = "^0.7.3.dev1", optional = true}
+fugue = {version = "^0.7.3", optional = true}
 requests = "^2.27"
 
 [tool.poetry.dev-dependencies]

--- a/python/tests/api/fugue/test_profiler.py
+++ b/python/tests/api/fugue/test_profiler.py
@@ -24,7 +24,6 @@ def _test_df():
 
 
 def _is_testable_version():
-    return True
     # TODO: Due to https://github.com/fugue-project/triad/issues/91
     # this test doesn't work on very rare cases, will re-enable when
     # the issue is resolved

--- a/python/tests/api/fugue/test_profiler.py
+++ b/python/tests/api/fugue/test_profiler.py
@@ -18,7 +18,7 @@ def _test_df():
             "1": np.random.choice([1, 2, 3], n),
             "a b": np.random.choice(["a", "b"], n),
             "_1": np.random.random(n),
-            "d": np.random.choice(["xy", "z"], n),
+            "d e": np.random.choice(["xy", "z"], n),
         }
     )
 

--- a/python/tests/api/fugue/test_profiler.py
+++ b/python/tests/api/fugue/test_profiler.py
@@ -14,21 +14,25 @@ def _test_df():
     n = 100
     np.random.seed(0)
     return pd.DataFrame(
-        dict(
-            a=np.random.choice([1, 2, 3], n),
-            b=np.random.choice(["a", "b"], n),
-            c=np.random.random(n),
-            d=np.random.choice(["xy", "z"], n),
-        )
+        {
+            "1": np.random.choice([1, 2, 3], n),
+            "a b": np.random.choice(["a", "b"], n),
+            "_1": np.random.random(n),
+            "d": np.random.choice(["xy", "z"], n),
+        }
     )
 
 
+def _is_testable_version():
+    return True
+    # TODO: Due to https://github.com/fugue-project/triad/issues/91
+    # this test doesn't work on very rare cases, will re-enable when
+    # the issue is resolved
+    return sys.version_info < (3, 10)
+
+
+@pytest.mark.skipif(not _is_testable_version(), reason="not a testable python version")
 def test_no_partition(_test_df):
-    if sys.version_info >= (3, 10):
-        # TODO: Due to https://github.com/fugue-project/triad/issues/91
-        # this test doesn't work on very rare cases, will re-enable when
-        # the issue is resolved
-        return
     for engine in [None, "spark"]:
         t1 = datetime(2020, 1, 1)
         t2 = datetime(2020, 1, 2)
@@ -47,22 +51,21 @@ def test_no_partition(_test_df):
         assert v.dataset_timestamp == t1
         assert v.creation_timestamp == t2
 
-        pf = fugue_profile(_test_df, profile_cols=["b", "c"], engine=engine).to_pandas()
+        profile_cols = [_test_df.columns[1], _test_df.columns[2]]
+        pf = fugue_profile(_test_df, profile_cols=profile_cols, engine=engine).to_pandas()
         assert len(pf) == 2
         assert pf["counts/n"].tolist() == [100, 100]
-        assert set(pf.index) == set(["b", "c"])
+        assert set(pf.index) == set(profile_cols)
 
 
+@pytest.mark.skipif(not _is_testable_version(), reason="not a testable python version")
 def test_with_partition(_test_df):
-    if sys.version_info >= (3, 10):
-        # TODO: Due to https://github.com/fugue-project/triad/issues/91
-        # this test doesn't work on very rare cases, will re-enable when
-        # the issue is resolved
-        return
     for engine in [None, "spark"]:
+        part_keys = [_test_df.columns[0], _test_df.columns[1]]
+        profile_cols = [_test_df.columns[2], _test_df.columns[3]]
         df = fugue_profile(
             _test_df,
-            partition={"by": ["a", "b"]},
+            partition={"by": part_keys},
             profile_field="x",
             engine=engine,
             engine_conf={"fugue.spark.use_pandas_udf": True},
@@ -71,16 +74,16 @@ def test_with_partition(_test_df):
         df["ct"] = df.x.apply(lambda x: DatasetProfileView.deserialize(x).to_pandas()["counts/n"].iloc[0])
         # get counts of profiled cols of each group should always be 4
         df["pct"] = df.x.apply(lambda x: len(DatasetProfileView.deserialize(x).to_pandas()))
-        df = df[["a", "b", "ct", "pct"]].set_index(["a", "b"])
+        df = df[part_keys + ["ct", "pct"]].set_index(part_keys)
         # compute group counts in a different way
-        ct = _test_df.groupby(["a", "b"])["c"].count()
+        ct = _test_df.groupby(part_keys)[_test_df.columns[2]].count()
         df["ct_true"] = ct
         # assert counts match
         assert all(df.ct == df.ct_true)
         assert all(df.pct == 4)
 
         df = fugue_profile(
-            _test_df, partition={"by": ["a", "b"]}, profile_cols=["b", "c"], profile_field="x", engine=engine
+            _test_df, partition={"by": part_keys}, profile_cols=profile_cols, profile_field="x", engine=engine
         )
         df["pct"] = df.x.apply(lambda x: len(DatasetProfileView.deserialize(x).to_pandas()))
         assert all(df.pct == 2)

--- a/python/whylogs/api/fugue/profiler.py
+++ b/python/whylogs/api/fugue/profiler.py
@@ -11,7 +11,10 @@ from fugue import (
     transform,
     transformer,
 )
-from fugue.dataframe.utils import normalize_dataframe_column_names, rename_dataframe_column_names
+from fugue.dataframe.utils import (
+    normalize_dataframe_column_names,
+    rename_dataframe_column_names,
+)
 
 import whylogs as why
 from whylogs.core.view.column_profile_view import ColumnProfileView

--- a/python/whylogs/api/fugue/profiler.py
+++ b/python/whylogs/api/fugue/profiler.py
@@ -11,6 +11,7 @@ from fugue import (
     transform,
     transformer,
 )
+from fugue.dataframe.utils import normalize_dataframe_column_names, rename_dataframe_column_names
 
 import whylogs as why
 from whylogs.core.view.column_profile_view import ColumnProfileView
@@ -33,9 +34,14 @@ def fugue_profile(
     engine_conf: Any = None,
     **kwargs,
 ) -> Any:
+    if not isinstance(df, str):
+        df, renames = normalize_dataframe_column_names(df)
+    else:
+        renames = {}
     profiler = _FugueProfiler(
         partition,
         profile_cols,
+        renames=renames,
         dataset_timestamp=dataset_timestamp,
         creation_timestamp=creation_timestamp,
         profile_field=profile_field,
@@ -53,6 +59,7 @@ class _FugueProfiler:
         self,
         partition,
         cols,
+        renames: Dict[str, Any],
         dataset_timestamp: Optional[datetime] = None,
         creation_timestamp: Optional[datetime] = None,
         profile_field: str = DF_PROFILE_FIELD,
@@ -61,14 +68,19 @@ class _FugueProfiler:
 
         self._dataset_timestamp = dataset_timestamp or now
         self._creation_timestamp = creation_timestamp or now
+        self._cols_to_orig = renames
+        self._orig_to_cols = {v: k for k, v in renames.items()}
 
-        self._partition = PartitionSpec(partition)
-        self._by = self._partition.partition_by
+        part = PartitionSpec(partition)
+        self._by = [self._orig_to_cols.get(x, x) for x in part.partition_by]
+        self._partition = PartitionSpec(part, by=self._by)
         self._cols = cols
         self._profile_field = profile_field
         self._profile_schema = Schema([(profile_field, bytes)])
 
     def to_col_profiles(self, df: pd.DataFrame) -> Iterable[Dict[str, Any]]:
+        if len(self._cols_to_orig) > 0:
+            df = df.rename(columns=self._cols_to_orig)
         res = why.log(df[self._cols] if self._cols is not None else df)
         for col_name, col_profile in res.view().get_columns().items():
             yield {_COL_NAME_FIELD: col_name, _COL_PROFILE_FIELD: col_profile.serialize()}
@@ -90,7 +102,11 @@ class _FugueProfiler:
         yield {self._profile_field: profile_view.serialize()}
 
     def profile_partition(self, df: pd.DataFrame) -> pd.DataFrame:
-        res = why.log(df[self._cols] if self._cols is not None else df).view().serialize()
+        if len(self._cols_to_orig) > 0:
+            pdf = df.rename(columns=self._cols_to_orig)
+        else:
+            pdf = df
+        res = why.log(pdf[self._cols] if self._cols is not None else pdf).view().serialize()
         return df.head(1)[self._by].assign(**{self._profile_field: res})
 
     # ---------------- Starting Fugue related logic
@@ -109,7 +125,7 @@ class _FugueProfiler:
         return DatasetProfileView.deserialize(dag.run(engine)["result"].as_array()[0][0])
 
     def transform_with_logical_partition(self, df: Any, engine: Any, engine_conf: Any, **kwargs: Any) -> Any:
-        return transform(
+        res = transform(
             df,
             transformer(lambda pdf: pdf.schema.extract(self._by) + self._profile_schema)(self.profile_partition),
             partition=self._partition,
@@ -117,3 +133,4 @@ class _FugueProfiler:
             engine_conf=engine_conf,
             **kwargs,
         )
+        return rename_dataframe_column_names(res, self._cols_to_orig)

--- a/python/whylogs/api/fugue/profiler.py
+++ b/python/whylogs/api/fugue/profiler.py
@@ -110,7 +110,7 @@ class _FugueProfiler:
         else:
             pdf = df
         res = why.log(pdf[self._cols] if self._cols is not None else pdf).view().serialize()
-        return df.head(1)[self._by].assign(**{self._profile_field: res})
+        return df.head(1)[self._by].assign(**{self._profile_field: res})  # type: ignore
 
     # ---------------- Starting Fugue related logic
 


### PR DESCRIPTION
## Description

The commits lets Fugue take arbitrary column names. By design Fugue has more strict naming rules on dataframe columns. This change adds internal conversions to remove the constraint

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
