### PR TITLE
Make SummaryConfig optional

### DIFF
--- a/python/whylogs/core/metrics/column_metrics.py
+++ b/python/whylogs/core/metrics/column_metrics.py
@@ -19,7 +19,7 @@ class TypeCountersMetric(Metric):
     def namespace(self) -> str:
         return "types"
 
-    def to_summary_dict(self, cfg: SummaryConfig) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
         return {
             "integral": self.integral.value,
             "fractional": self.fractional.value,
@@ -109,7 +109,7 @@ class ColumnCountsMetric(Metric):
         self.null.set(null)
         return OperationResult.ok(data.len)
 
-    def to_summary_dict(self, cfg: SummaryConfig) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
         return {"n": self.n.value, "null": self.null.value}
 
     @classmethod

--- a/python/whylogs/core/metrics/column_metrics.py
+++ b/python/whylogs/core/metrics/column_metrics.py
@@ -19,7 +19,7 @@ class TypeCountersMetric(Metric):
     def namespace(self) -> str:
         return "types"
 
-    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Any]:
         return {
             "integral": self.integral.value,
             "fractional": self.fractional.value,
@@ -109,7 +109,7 @@ class ColumnCountsMetric(Metric):
         self.null.set(null)
         return OperationResult.ok(data.len)
 
-    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Any]:
         return {"n": self.n.value, "null": self.null.value}
 
     @classmethod

--- a/python/whylogs/core/metrics/compound_metric.py
+++ b/python/whylogs/core/metrics/compound_metric.py
@@ -92,7 +92,7 @@ class CompoundMetric(Metric, ABC):
                 res.append(sub_name + ":" + submetric.namespace + "/" + comp_name)
         return res
 
-    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Any]:
         cfg = cfg or SummaryConfig()
         summary = {}
         for sub_name, submetric in self.submetrics.items():

--- a/python/whylogs/core/metrics/compound_metric.py
+++ b/python/whylogs/core/metrics/compound_metric.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from copy import deepcopy
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from whylogs.core.configs import SummaryConfig
 from whylogs.core.errors import DeserializationError, UnsupportedError
@@ -92,7 +92,8 @@ class CompoundMetric(Metric, ABC):
                 res.append(sub_name + ":" + submetric.namespace + "/" + comp_name)
         return res
 
-    def to_summary_dict(self, cfg: SummaryConfig) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
+        cfg = cfg or SummaryConfig()
         summary = {}
         for sub_name, submetric in self.submetrics.items():
             sub_summary = submetric.to_summary_dict(cfg)

--- a/python/whylogs/core/metrics/condition_count_metric.py
+++ b/python/whylogs/core/metrics/condition_count_metric.py
@@ -159,7 +159,7 @@ class ConditionCountMetric(Metric):
 
         return MetricMessage(metric_components=msg)
 
-    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Any]:
         summary = {"total": self.total.value}
         for cond_name in self.matches.keys():
             summary[cond_name] = self.matches[cond_name].value

--- a/python/whylogs/core/metrics/condition_count_metric.py
+++ b/python/whylogs/core/metrics/condition_count_metric.py
@@ -159,7 +159,7 @@ class ConditionCountMetric(Metric):
 
         return MetricMessage(metric_components=msg)
 
-    def to_summary_dict(self, cfg: SummaryConfig) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
         summary = {"total": self.total.value}
         for cond_name in self.matches.keys():
             summary[cond_name] = self.matches[cond_name].value

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -134,7 +134,7 @@ class Metric(ABC):
         return res
 
     @abstractmethod
-    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Any]:
         raise NotImplementedError
 
     @abstractmethod
@@ -195,7 +195,7 @@ class IntsMetric(Metric):
     def zero(cls, config: Optional[MetricConfig] = None) -> "IntsMetric":
         return IntsMetric(max=MaxIntegralComponent(-sys.maxsize), min=MinIntegralComponent(sys.maxsize))
 
-    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Union[int, float, str, None]]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Union[int, float, str, None]]:
         return {"max": self.maximum, "min": self.minimum}
 
     @property
@@ -472,7 +472,7 @@ class FrequentItemsMetric(Metric):
 
         return OperationResult(successes=successes, failures=failures)
 
-    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Any]:
         cfg = cfg or SummaryConfig()
         all_freq_items = self.frequent_strings.value.get_frequent_items(
             cfg.frequent_items_error_type.to_datasketches_type()
@@ -535,7 +535,7 @@ class CardinalityMetric(Metric):
             failures = len(view.list.objs)
         return OperationResult(successes=successes, failures=failures)
 
-    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Any]:
         cfg = cfg or SummaryConfig()
         return {
             "est": self.hll.value.get_estimate(),
@@ -593,7 +593,7 @@ class CustomMetricBase(Metric, ABC):
     def get_component_paths(self) -> List[str]:
         return [_STRUCT_NAME]  # Assumes everything to be serde'd will be in the Struct
 
-    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Any]:
         return asdict(self, dict_factory=_drop_private_fields)
 
     def to_protobuf(self) -> MetricMessage:

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -134,7 +134,7 @@ class Metric(ABC):
         return res
 
     @abstractmethod
-    def to_summary_dict(self, cfg: SummaryConfig) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
         raise NotImplementedError
 
     @abstractmethod
@@ -195,7 +195,7 @@ class IntsMetric(Metric):
     def zero(cls, config: Optional[MetricConfig] = None) -> "IntsMetric":
         return IntsMetric(max=MaxIntegralComponent(-sys.maxsize), min=MinIntegralComponent(sys.maxsize))
 
-    def to_summary_dict(self, cfg: SummaryConfig) -> Dict[str, Union[int, float, str, None]]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Union[int, float, str, None]]:
         return {"max": self.maximum, "min": self.minimum}
 
     @property
@@ -217,7 +217,7 @@ class DistributionMetric(Metric):
     def namespace(self) -> str:
         return "distribution"
 
-    def to_summary_dict(self, cfg: SummaryConfig = None) -> Dict[str, Union[int, float, str, None]]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Union[int, float, str, None]]:
         if self.n == 0:
             quantiles = [None, None, None, None, None, None, None, None, None]
         else:
@@ -472,7 +472,8 @@ class FrequentItemsMetric(Metric):
 
         return OperationResult(successes=successes, failures=failures)
 
-    def to_summary_dict(self, cfg: SummaryConfig) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
+        cfg = cfg or SummaryConfig()
         all_freq_items = self.frequent_strings.value.get_frequent_items(
             cfg.frequent_items_error_type.to_datasketches_type()
         )
@@ -487,7 +488,7 @@ class FrequentItemsMetric(Metric):
     def strings(self) -> List[FrequentItem]:
         if self.frequent_strings.value.is_empty():
             return []
-        summary = self.to_summary_dict(cfg=SummaryConfig())
+        summary = self.to_summary_dict()
         return summary["frequent_strings"]
 
     @classmethod
@@ -534,7 +535,8 @@ class CardinalityMetric(Metric):
             failures = len(view.list.objs)
         return OperationResult(successes=successes, failures=failures)
 
-    def to_summary_dict(self, cfg: SummaryConfig) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
+        cfg = cfg or SummaryConfig()
         return {
             "est": self.hll.value.get_estimate(),
             f"upper_{cfg.hll_stddev}": self.hll.value.get_upper_bound(cfg.hll_stddev),
@@ -591,7 +593,7 @@ class CustomMetricBase(Metric, ABC):
     def get_component_paths(self) -> List[str]:
         return [_STRUCT_NAME]  # Assumes everything to be serde'd will be in the Struct
 
-    def to_summary_dict(self, cfg: SummaryConfig) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
         return asdict(self, dict_factory=_drop_private_fields)
 
     def to_protobuf(self) -> MetricMessage:

--- a/python/whylogs/core/metrics/multimetric.py
+++ b/python/whylogs/core/metrics/multimetric.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC
 from copy import deepcopy
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from whylogs.core.configs import SummaryConfig
 from whylogs.core.errors import DeserializationError, UnsupportedError
@@ -116,7 +116,8 @@ class MultiMetric(Metric, ABC):
 
         return res
 
-    def to_summary_dict(self, cfg: SummaryConfig) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
+        cfg = cfg or SummaryConfig()
         summary = {}
         for sub_name, metrics in self.submetrics.items():
             for namespace, metric in metrics.items():

--- a/python/whylogs/core/metrics/multimetric.py
+++ b/python/whylogs/core/metrics/multimetric.py
@@ -116,7 +116,7 @@ class MultiMetric(Metric, ABC):
 
         return res
 
-    def to_summary_dict(self, cfg: Optional[SummaryConfig]=None) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Any]:
         cfg = cfg or SummaryConfig()
         summary = {}
         for sub_name, metrics in self.submetrics.items():

--- a/python/whylogs/core/view/column_profile_view.py
+++ b/python/whylogs/core/view/column_profile_view.py
@@ -84,9 +84,7 @@ class ColumnProfileView(object):
     def to_summary_dict(
         self, *, column_metric: Optional[str] = None, cfg: Optional[SummaryConfig] = None
     ) -> Dict[str, Any]:
-        if cfg is None:
-            cfg = SummaryConfig()
-
+        cfg = cfg or SummaryConfig()
         res = {}
         for metric_name, metric in self._metrics.items():
             if column_metric is not None and metric_name != column_metric:


### PR DESCRIPTION
Makes `SummaryConfig` an optional argument to `to_summary_dict()` with `SummaryConfig()` as the default if it's not passed.

https://app.clickup.com/t/3nn9vh1