### PR TITLE
Count booleans in cardinality metric, and add tests

### DIFF
--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -529,6 +529,16 @@ class CardinalityMetric(Metric):
             self.hll.value.update_str_list(view.list.strings)
             successes += len(view.list.strings)
 
+        # special handling for bool counts
+        if view.bool_count > 0:
+            if view.bool_count_where_true > 0 and view.bool_count > view.bool_count_where_true:
+                self.hll.value.update_int_list([1, 0])
+            elif view.bool_count_where_true > 0:
+                self.hll.value.update(1)
+            else:
+                self.hll.value.update(0)
+            successes += view.bool_count
+
         failures = 0
         if view.list.objs:
             failures = len(view.list.objs)


### PR DESCRIPTION
## Description

Booleans are not added to the numpy or pandas views of the PreprocessedColumns and then are not counted by cardinality metric.

## Changes

This adds special handling to look for the counts of booleans when processing cardinality metric, so that we can correctly count the boolean values. We use integer values 0, 1 to count the unique booleans since the HLL sketch does not directly support boolean (and this seemed like the least surprising way to track these, consistent with C++ and that python treats these as numeric types.)

Also added a test to cover this case.

## Related

Closes #901 

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
