### PR TITLE
Allow test to run on automated version bump PR

### DIFF
--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -94,7 +94,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v4.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.VERSION_UPDATE }}
           commit-message: Update version ${{ env.VERSION }}
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
Use a different token for the automated PR to allow the CI tests to run on this change.

## Description

Following suggestion in the docs to allow tests which are github actions to be triggered by this automated PR which is also a github action. https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

## Changes

Created a new token to allow creation of the automated bump version PR called VERSION_UPDATE and added that to the github repository.

Update the bump version PR creation workflow to run with that new token, so that it can then trigger other workflows that run with the standard github token.

Note we may need to update that token if the permissions are too restrictive, or when it expires.

addresses #907 

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
