### PR TITLE
Creating DeepCopy 

### DIFF
--- a/java/core/src/main/java/com/whylogs/core/metrics/IntegralMetric.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/IntegralMetric.java
@@ -64,8 +64,8 @@ public class IntegralMetric extends Metric<IntegralMetric> {
   }
 
   @Override
-  public HashMap<String, MetricComponent> getComponents() {
-    HashMap<String, MetricComponent> components = new HashMap<>();
+  public HashMap<String, MetricComponent<?>> getComponents() {
+    HashMap<String, MetricComponent<?>> components = new HashMap<>();
     components.put(this.maxComponent.getTypeName(), this.maxComponent);
     components.put(this.minComponent.getTypeName(), this.minComponent);
     return components;
@@ -109,5 +109,10 @@ public class IntegralMetric extends Metric<IntegralMetric> {
     int min = Integer.min(this.minComponent.getValue(), other_.minComponent.getValue());
 
     return new IntegralMetric(new MaxIntegralComponent(max), new MinIntegralComponent(min));
+  }
+
+  @Override
+  public IntegralMetric copy() {
+    return new IntegralMetric(this.maxComponent.copy(), this.minComponent.copy());
   }
 }

--- a/java/core/src/main/java/com/whylogs/core/metrics/Metric.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/Metric.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Getter
 @Setter
 @RequiredArgsConstructor
-public abstract class Metric<TSubclass extends Metric> {
+public abstract class Metric<TSubclass extends Metric<?>> {
 
   @NonNull private String namespace;
 
@@ -20,11 +20,13 @@ public abstract class Metric<TSubclass extends Metric> {
 
   public abstract OperationResult columnarUpdate(PreprocessedColumn data);
 
-  public abstract HashMap<String, MetricComponent> getComponents();
+  public abstract HashMap<String, MetricComponent<?>> getComponents();
 
   public abstract TSubclass merge(Metric<?> other);
 
   public @NonNull String getNamespace() {
     return namespace;
   }
+
+  public abstract TSubclass copy();
 }

--- a/java/core/src/main/java/com/whylogs/core/metrics/MetricConfig.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/MetricConfig.java
@@ -79,4 +79,8 @@ public class MetricConfig {
           }
         });
   }
+
+  public MetricConfig copy() {
+    return new MetricConfig();
+  }
 }

--- a/java/core/src/main/java/com/whylogs/core/metrics/OperationResult.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/OperationResult.java
@@ -40,4 +40,8 @@ public class OperationResult {
     int new_nulls = this.nulls + other.getNulls();
     return new OperationResult(new_successes, new_failures, new_nulls);
   }
+
+  public OperationResult copy() {
+    return new OperationResult(this.successes, this.failures, this.nulls);
+  }
 }

--- a/java/core/src/main/java/com/whylogs/core/metrics/components/MetricComponent.java
+++ b/java/core/src/main/java/com/whylogs/core/metrics/components/MetricComponent.java
@@ -45,7 +45,7 @@ public class MetricComponent<T> {
   }
 
   public MetricComponent<T> copy() {
-    return new MetricComponent<T>(value);
+    return new MetricComponent<>(this.value);
   }
 
   public MetricComponent<T> merge(MetricComponent<T> other) {
@@ -56,7 +56,7 @@ public class MetricComponent<T> {
   // TODO to_protobuf
   // TODO from_protobuf
   // TODO: add a from_protobuf iwht registries passed in
-  public static <M extends MetricComponent> M from_protobuf(MetricComponentMessage message) {
+  public static <M extends MetricComponent<?>> M from_protobuf(MetricComponentMessage message) {
     // TODO: check that it's a MetricComponent dataclass
     throw new NotImplementedException();
   }

--- a/java/core/src/main/java/com/whylogs/core/resolvers/Resolver.java
+++ b/java/core/src/main/java/com/whylogs/core/resolvers/Resolver.java
@@ -7,4 +7,5 @@ import java.util.HashMap;
 public abstract class Resolver {
 
   public abstract HashMap<String, Metric<?>> resolve(ColumnSchema schema);
+  public abstract Resolver copy();
 }

--- a/java/core/src/main/java/com/whylogs/core/resolvers/Resolver.java
+++ b/java/core/src/main/java/com/whylogs/core/resolvers/Resolver.java
@@ -7,5 +7,6 @@ import java.util.HashMap;
 public abstract class Resolver {
 
   public abstract HashMap<String, Metric<?>> resolve(ColumnSchema schema);
+
   public abstract Resolver copy();
 }

--- a/java/core/src/main/java/com/whylogs/core/resolvers/StandardResolver.java
+++ b/java/core/src/main/java/com/whylogs/core/resolvers/StandardResolver.java
@@ -32,4 +32,9 @@ public class StandardResolver extends Resolver {
     }
     return resolvedMetrics;
   }
+
+  @Override
+  public Resolver copy() {
+    return new StandardResolver();
+  }
 }

--- a/java/core/src/main/java/com/whylogs/core/schemas/ColumnSchema.java
+++ b/java/core/src/main/java/com/whylogs/core/schemas/ColumnSchema.java
@@ -21,4 +21,8 @@ public class ColumnSchema {
   public HashMap<String, Metric<?>> getMetrics() {
     return this.resolver.resolve(this);
   }
+
+  public ColumnSchema copy() {
+    return new ColumnSchema(this.type, this.config, this.resolver);
+  }
 }

--- a/java/core/src/main/java/com/whylogs/core/schemas/DatasetSchema.java
+++ b/java/core/src/main/java/com/whylogs/core/schemas/DatasetSchema.java
@@ -59,10 +59,21 @@ public class DatasetSchema {
     }
   }
 
+  private DatasetSchema(DatasetSchema other) {
+    this.types = new HashMap<>(other.types);
+    this.defaultConfig = other.getDefaultConfig().copy();
+    this.resolver = other.getResolver().copy();
+    this.cacheSize = other.getCacheSize();
+    this.schemaBasedAutomerge = other.isSchemaBasedAutomerge();
+
+    this.columns = new HashMap<>();
+    for(String colName : other.getColumns().keySet()) {
+      this.columns.put(colName, other.getColumns().get(colName).copy());
+    }
+  }
+
   public DatasetSchema copy() {
-    DatasetSchema copy = new DatasetSchema();
-    // TODO: copy over
-    return copy;
+    return new DatasetSchema(this);
   }
 
   public boolean resolve(HashMap<String, ?> data) {

--- a/java/core/src/main/java/com/whylogs/core/schemas/DatasetSchema.java
+++ b/java/core/src/main/java/com/whylogs/core/schemas/DatasetSchema.java
@@ -8,16 +8,20 @@ import java.util.HashMap;
 import java.util.Optional;
 import java.util.Set;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
 @Data
+@EqualsAndHashCode
+@Getter
 public class DatasetSchema {
   private HashMap<String, Type> types = new HashMap<>();
   private final int LARGE_CACHE_SIZE_LIMIT = 1024 * 100;
-  public HashMap<String, ColumnSchema> columns;
-  public MetricConfig defaultConfig;
-  public Resolver resolver;
-  public int cache_size = 1024;
-  public boolean schema_based_automerge = false;
+  private HashMap<String, ColumnSchema> columns;
+  private MetricConfig defaultConfig;
+  private Resolver resolver;
+  private int cacheSize = 1024;
+  private boolean schemaBasedAutomerge = false;
 
   public DatasetSchema() {
     this(Optional.empty(), Optional.empty());
@@ -29,19 +33,19 @@ public class DatasetSchema {
     this.resolver = resolver.orElse(new StandardResolver());
   }
 
-  public DatasetSchema(int cache_size, boolean schema_based_automerge) {
+  public DatasetSchema(int cacheSize, boolean schemaBasedAutomerge) {
     this.columns = new HashMap<>();
     this.defaultConfig = new MetricConfig();
     this.resolver = new StandardResolver();
-    this.cache_size = cache_size;
-    this.schema_based_automerge = schema_based_automerge;
+    this.cacheSize = cacheSize;
+    this.schemaBasedAutomerge = schemaBasedAutomerge;
 
-    if (cache_size < 0) {
+    if (cacheSize < 0) {
       // TODO: log warning
-      this.cache_size = 0;
+      this.cacheSize = 0;
     }
 
-    if (cache_size > LARGE_CACHE_SIZE_LIMIT) {
+    if (cacheSize > LARGE_CACHE_SIZE_LIMIT) {
       // TODO: log warning
     }
 

--- a/java/core/src/main/java/com/whylogs/core/schemas/DatasetSchema.java
+++ b/java/core/src/main/java/com/whylogs/core/schemas/DatasetSchema.java
@@ -67,7 +67,7 @@ public class DatasetSchema {
     this.schemaBasedAutomerge = other.isSchemaBasedAutomerge();
 
     this.columns = new HashMap<>();
-    for(String colName : other.getColumns().keySet()) {
+    for (String colName : other.getColumns().keySet()) {
       this.columns.put(colName, other.getColumns().get(colName).copy());
     }
   }

--- a/java/core/src/test/java/com/whylogs/core/TestColumnProfile.java
+++ b/java/core/src/test/java/com/whylogs/core/TestColumnProfile.java
@@ -140,4 +140,19 @@ public class TestColumnProfile {
     IntegralMetric metric = (IntegralMetric) view.getMetrics().get("ints");
     Assert.assertEquals((int) metric.getMaxComponent().getValue(), 2);
   }
+
+  @Test
+  public void testCopy() {
+    ColumnProfile<Integer> profileA = getDefaultColumnProfile();
+    ArrayList<Integer> column = new ArrayList<>();
+    column.add(1);
+    column.add(2);
+    column.add(null);
+    profileA.trackColumn(column);
+
+    ColumnProfile<Integer> profileB = profileA.copy();
+    Assert.assertEquals(profileA, profileB);
+    Assert.assertNotSame(profileA, profileB);
+    Assert.assertNotSame(profileA.getMetrics(), profileB.getMetrics());
+  }
 }

--- a/java/core/src/test/java/com/whylogs/core/TestDatasetProfile.java
+++ b/java/core/src/test/java/com/whylogs/core/TestDatasetProfile.java
@@ -107,6 +107,7 @@ public class TestDatasetProfile {
     Assert.assertEquals(profile.getTrackCount(), 1);
   }
 
+  @Test
   public void testView() {
     DatasetProfile profile = defaultProfile();
     DatasetProfileView view = profile.view();
@@ -114,6 +115,7 @@ public class TestDatasetProfile {
     Assert.assertEquals(view.getColumns().get("test").getMetrics().size(), 1);
   }
 
+  @Test
   public void testFlush() {
     DatasetProfile profile = defaultProfile();
     HashMap<String, Object> data = new HashMap<>();
@@ -121,5 +123,18 @@ public class TestDatasetProfile {
     data.put("test2", "2");
     profile.track(data);
     profile.flush();
+  }
+
+  @Test
+  public void testCopy() {
+    DatasetProfile profile = defaultProfile();
+    HashMap<String, Object> data = new HashMap<>();
+    data.put("test", 1);
+    data.put("test2", "2");
+    profile.track(data);
+
+    DatasetProfile copyProfile = profile.copy();
+    Assert.assertEquals(copyProfile, profile);
+    Assert.assertNotSame(copyProfile, profile);
   }
 }

--- a/java/core/src/test/java/com/whylogs/core/metrics/TestIntegralMetric.java
+++ b/java/core/src/test/java/com/whylogs/core/metrics/TestIntegralMetric.java
@@ -121,4 +121,16 @@ public class TestIntegralMetric {
     Assert.assertEquals((int) merged.getMaxComponent().getValue(), expectedMax);
     Assert.assertEquals((int) merged.getMinComponent().getValue(), expectedMin);
   }
+
+  @Test
+  public void test_copy() {
+    IntegralMetric metricA = IntegralMetric.zero();
+    IntegralMetric metricB = metricA.copy();
+
+    // Test values the same
+    Assert.assertEquals(metricA, metricB);
+
+    // test address is different
+    Assert.assertNotSame(metricA, metricB);
+  }
 }

--- a/java/core/src/test/java/com/whylogs/core/schemas/TestDatasetSchema.java
+++ b/java/core/src/test/java/com/whylogs/core/schemas/TestDatasetSchema.java
@@ -10,7 +10,7 @@ public class TestDatasetSchema {
   @Test
   public void test_dataset_schema() {
     DatasetSchema datasetSchema = new DatasetSchema();
-    Assert.assertEquals(datasetSchema.getCache_size(), 1024);
+    Assert.assertEquals(datasetSchema.getCacheSize(), 1024);
 
     HashMap<String, Object> data = new HashMap<>();
     data.put("test", 1);


### PR DESCRIPTION
## Description
 It's important to be able to have two of something without them being tied. For example: copying a profile at a certain point and time and having the original profile keep being updated with tracking. 

Deep copies allow for a copy profiles and views as expected without accidentally causing changes by the internal metrics changing for example. Given Java does not have a deep copy we need to implement this ourselves. 

This is rather easy to implement as we have a tree with no cycles and only a few places. So although not strictly required this is a ncie add to work as expected and fairly easy to implement. 

## Changes
This change adds deep copy to DatasetProfile, ColumnProfile, Metrics, Resolver, Config, Schemas and Components. 


## Related
Follow up from recent PR

- [ X] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
