### PR TITLE
Handle numpy.bool_ when resolving metrics for bool types

### DIFF
--- a/python/tests/core/metrics/test_metrics.py
+++ b/python/tests/core/metrics/test_metrics.py
@@ -179,3 +179,23 @@ def test_cardinality_metric_row_booleans() -> None:
     # track a bool value of false in the same column and check that cardinality increased to near 2.
     profile.track(row={column_name: False})
     assert cardinality.estimate == pytest.approx(2, 0.1)
+
+
+def test_cardinality_metric_booleans_top_level_api() -> None:
+    input_rows = 5
+    col_name = "p"
+    d = {col_name: [bool(i % 2) for i in range(input_rows)]}
+    df = pd.DataFrame(data=d)
+
+    results = why.log(df)
+    col_prof = results.view().get_column(col_name)
+    cardinality: CardinalityMetric = col_prof.get_metric("cardinality")
+    assert cardinality is not None
+    assert cardinality.estimate == pytest.approx(2, 0.1)
+
+
+def test_cardinality_metric_booleans_all_false() -> None:
+    df = pd.DataFrame({"b": [False for i in range(3)]})
+    col_prof = why.log(df).view().get_column("b")
+    cardinality: CardinalityMetric = col_prof.get_metric("cardinality")
+    assert cardinality.estimate == pytest.approx(1, 0.1)

--- a/python/whylogs/core/datatypes.py
+++ b/python/whylogs/core/datatypes.py
@@ -54,7 +54,7 @@ class Integral(DataType[int]):
         if not isinstance(dtype_or_type, type):
             return False
 
-        if issubclass(dtype_or_type, (bool, int, np.number)):
+        if issubclass(dtype_or_type, (bool, int, np.number, np.bool_)):
             if np.issubdtype and np.issubdtype(dtype_or_type, np.floating):
                 return False
             if issubclass(dtype_or_type, (np.datetime64, np.timedelta64)):


### PR DESCRIPTION
## Description

numpy.bool_ is not a subclass of bool and misses our check for the type when resolving metrics so adding this as well.

## Changes

- add np.bool_ to the type check alongside bool when resolving metrics for numeric types.
- added some tests that catch this case.

## Related

Relates to  https://github.com/whylabs/whylogs/pull/904

Closes #912 


- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
