### PR TITLE
Renames add_metrics to add_metric as it only adds a singular metric

### DIFF
--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -104,7 +104,7 @@ class ResultSet(ABC):
         else:
             raise ValueError("Cannot add performance metrics to a result set with no profile!")
 
-    def add_metrics(self, name: str, metric: Metric) -> None:
+    def add_metric(self, name: str, metric: Metric) -> None:
         profile = self.profile()
         if profile:
             profile.add_dataset_metric(name, metric)


### PR DESCRIPTION
## Description
Renaming to a singular to add_metric to match the internal of only adding one metric at a time allowing transparency and names that match the implementation. 

## Related
#916 

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
