### PR TITLE
Fix stubs to handle no pandas scenario

### DIFF
--- a/python/tests/smoketest.py
+++ b/python/tests/smoketest.py
@@ -2,7 +2,7 @@ import os
 
 os.environ["TELEMETRY_DEV"] = "1"  # noqa: E402
 
-from whylogs import __version__, package_version  # noqa
+from whylogs import __version__, log, package_version  # noqa
 
 """
 This is here to verify that the produced wheel includes
@@ -30,6 +30,16 @@ def test_version() -> None:
     assert __version__ == current_version
 
 
+def test_basic_log() -> None:
+    """test basic log scenario on row data."""
+    column_name = "a_column_name"
+    results = log(row={column_name: 3})
+    assert results is not None
+    column_profile_dictionary = results.view().get_columns()
+    assert column_name in column_profile_dictionary
+
+
 test_package_version()
 test_package_version_not_found()
 test_version()
+test_basic_log()

--- a/python/whylogs/core/datatypes.py
+++ b/python/whylogs/core/datatypes.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from decimal import Decimal
 from typing import Any, Generic, List, Optional, Type, TypeVar, Union
 
-from whylogs.core.stubs import np
+from whylogs.core.stubs import is_not_stub, np
 
 try:
     from pandas.core.api import CategoricalDtype
@@ -55,7 +55,7 @@ class Integral(DataType[int]):
             return False
 
         if issubclass(dtype_or_type, (bool, int, np.number, np.bool_)):
-            if np.issubdtype and np.issubdtype(dtype_or_type, np.floating):
+            if is_not_stub(np.issubdtype) and np.issubdtype(dtype_or_type, np.floating):
                 return False
             if issubclass(dtype_or_type, (np.datetime64, np.timedelta64)):
                 return False

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -208,7 +208,7 @@ class PreprocessedColumn:
                     null_count += 1
 
             result.null_count = null_count
-            if np.ndarray:
+            if is_not_stub(np.ndarray):
                 ints = np.asarray(int_list, dtype=int)
                 floats = np.asarray(float_list, dtype=float)
 

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -3,8 +3,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Iterable, Iterator, List, Optional
 
-from whylogs.core.stubs import np as np
-from whylogs.core.stubs import pd as pd
+from whylogs.core.stubs import is_not_stub, np, pd
 
 logger = logging.getLogger("whylogs.core.views")
 
@@ -188,7 +187,7 @@ class PreprocessedColumn:
 
         if isinstance(data, List):
             result.len = len(data)
-            if pd.Series:
+            if is_not_stub(pd.Series):
                 return PreprocessedColumn.apply(pd.Series(data, dtype="object"))
 
             int_list = []

--- a/python/whylogs/core/stubs.py
+++ b/python/whylogs/core/stubs.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import dataclass
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,7 @@ class _StubClass:
 class NumpyStub:
     dtype: type = _StubClass
     number: type = _StubClass
+    bool_: type = _StubClass
     floating: type = _StubClass
     ndarray: type = _StubClass
     timedelta64: type = _StubClass
@@ -36,6 +38,12 @@ class NumpyStub:
 class PandasStub(object):
     Series: type = _StubClass
     DataFrame: type = _StubClass
+
+
+def is_not_stub(stubbed_class: Any) -> bool:
+    if stubbed_class and stubbed_class is not _StubClass and not isinstance(stubbed_class, (PandasStub, NumpyStub)):
+        return True
+    return False
 
 
 if _np is None:


### PR DESCRIPTION
## Description

Our CI installs optional dependencies before running tests, so we didn't catch this regression where a dependency on numpy wasn't correctly stubbed (np.bool_).

## Changes
* This change adds a utility to check for stubbed classes or methods.
* Adds numpy bool_ to the NumpyStub class
* Adds a smoke test that could repro the bug if we run it without pandas / numpy installed.

## Related

closes #929 
verified we catch regressions now with this setup on missing pandas or numpy from core logging.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
