### PR TITLE
remove TransientLogger::flush() and ::close()

### DIFF
--- a/python/whylogs/api/logger/logger.py
+++ b/python/whylogs/api/logger/logger.py
@@ -85,7 +85,6 @@ class Logger(ABC):
 
         return ProfileResultSet(profiles[0])
 
-    @abstractmethod
     def close(self) -> None:
         self._is_closed = True
 

--- a/python/whylogs/api/logger/rolling.py
+++ b/python/whylogs/api/logger/rolling.py
@@ -210,4 +210,4 @@ class TimedRollingLogger(Logger):
         if not self._is_closed:
             self._scheduler.stop()
             self._do_rollover()
-        self._is_closed: bool = True
+        super(TimedRollingLogger, self).close()

--- a/python/whylogs/api/logger/transient.py
+++ b/python/whylogs/api/logger/transient.py
@@ -13,9 +13,3 @@ class TransientLogger(Logger):
         self, obj: Any = None, *, pandas: Optional[pd.DataFrame] = None, row: Optional[Dict[str, Any]] = None
     ) -> List[DatasetProfile]:
         return [DatasetProfile(schema=self._schema)]
-
-    def flush(self) -> None:
-        pass
-
-    def close(self) -> None:
-        pass


### PR DESCRIPTION
`flush()` was a no-op, `close()` is inherited.