### PR TITLE
Changing quantiles for KS drift detection from 9 to 100 buckets.

### DIFF
--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -18,6 +18,7 @@ If you're willing to learn more how to use and get going with whylogs, take a lo
   - [Constraints Suite](https://nbviewer.org/github/whylabs/whylogs/blob/mainline/python/examples/advanced/Constraints_Suite.ipynb) - A collection of simple out-of-the-box constraints for the most common use-cases
   - [Custom Metrics](https://nbviewer.org/github/whylabs/whylogs/blob/mainline/python/examples/advanced/Custom_Metrics.ipynb) - Create your own metrics and metric components
   - [String Tracking](https://nbviewer.org/github/whylabs/whylogs/blob/mainline/python/examples/advanced/String_Tracking.ipynb) - Track unicode ranges and character length distribution metrics for your textual features
+  - [Image Logging](https://nbviewer.org/github/whylabs/whylogs/blob/mainline/python/examples/advanced/Image_Logging.ipynb) - Track image-related metrics
   - [Segments](https://nbviewer.org/github/whylabs/whylogs/blob/mainline/python/examples/advanced/Segments.ipynb) - Segment your data to improve visibility to the sub-group level
 - Integrations - Use whylogs with external platforms
   - [Pyspark](https://nbviewer.org/github/whylabs/whylogs/blob/mainline/python/examples/integrations/Pyspark_Profiling.ipynb) - Use whylogs with pyspark

--- a/python/whylogs/viz/utils/drift_calculations.py
+++ b/python/whylogs/viz/utils/drift_calculations.py
@@ -12,7 +12,7 @@ from whylogs.viz.utils.frequent_items_calculations import (
     zero_padding_frequent_items,
 )
 
-QUANTILES = [0.0, 0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99, 1.0]
+QUANTILES = list(np.linspace(0, 1, 100))
 
 
 class ColumnDriftValue(TypedDict):


### PR DESCRIPTION
## Description

In previous experiments, it was determined that increasing the number of buckets for quantiles for KS test drift detection reduces the error compared to scipy's implementation on the complete dataset.


## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
