### PR TITLE
Add segmented profile serialization to rolling logger

### DIFF
--- a/python/tests/api/logger/test_rolling.py
+++ b/python/tests/api/logger/test_rolling.py
@@ -159,6 +159,6 @@ def test_rolling_row_messages_with_segments(tmp_path: Any) -> None:
     initial_callback_count = rolling_callback.call_count
     assert initial_callback_count == 0
 
-    # after explicitly calling close on the logger, we trigger one more flush and callback
+    # after explicitly calling close on the logger, we trigger one more flush which has two segments and expect two callbacks
     rolling_logger.close()
-    assert rolling_callback.call_count > 0
+    assert rolling_callback.call_count == 2

--- a/python/tests/api/logger/test_rolling.py
+++ b/python/tests/api/logger/test_rolling.py
@@ -13,6 +13,8 @@ import whylogs as why
 from whylogs.api.store.local_store import LocalStore
 from whylogs.api.store.query import ProfileNameQuery
 from whylogs.core.errors import BadConfigError
+from whylogs.core.schema import DatasetSchema
+from whylogs.core.segmentation_partition import segment_on_column
 
 
 def test_closing(tmp_path: Any, lending_club_df: pd.DataFrame) -> None:
@@ -58,7 +60,7 @@ def test_rolling(tmp_path: Any) -> None:
 
 def test_rolling_with_callback(tmp_path: Any) -> None:
     rolling_callback = MagicMock()
-    messages = [{"col1": [i], "col2": [i * i * 1.2], "col3": ["a"]} for i in range(10)]
+    messages = [{"col1": i, "col2": i * i * 1.2, "col3": "a"} for i in range(10)]
 
     rolling_logger = why.logger(
         mode="rolling", interval=1, when="S", base_name="test_base_name", callback=rolling_callback
@@ -88,18 +90,16 @@ def test_rolling_skip_empty(tmp_path: Any) -> None:
     with why.logger(mode="rolling", interval=1, when="S", base_name="test_base_name", skip_empty=True) as logger:
         logger.append_writer("local", base_dir=tmp_path)
         logger.log(df)
-        time.sleep(2)
+        time.sleep(2.1)
 
-        # Note that the number of files generated is depend on the elapsed amount
+        # Note we sleep for over 2 seconds and have rolling interval of 1 second, so we should see at
+        # least two elapsed intervals, but have only one file with skip_empty true
         assert count_files(tmp_path) == 1
 
+        # log one more time, but don't wait and rely on the lifecycle of exiting the above with clause
+        # to trigger at least one more flush with some new data
         logger.log(df)
-        time.sleep(2)
-        assert count_files(tmp_path) == 2
-
-        logger.log(df)
-
-    assert count_files(tmp_path) == 3
+    assert count_files(tmp_path) == 2
 
 
 def test_bad_whylabs_writer_config() -> None:
@@ -132,3 +132,33 @@ def test_rolling_with_local_store_writes() -> None:
 
         query = ProfileNameQuery(profile_name="test_base_name")
         assert store.get(query=query)
+
+
+def test_rolling_row_messages_with_segments(tmp_path: Any) -> None:
+    rolling_callback = MagicMock()
+    segment_column = "col1"
+    messages = [{"col1": i % 2, "col2": i * i * 1.2, "col3": "a"} for i in range(10)]
+
+    segment_schema = DatasetSchema(segments=segment_on_column(segment_column))
+
+    rolling_logger = why.logger(
+        schema=segment_schema,
+        mode="rolling",
+        interval=60,
+        when="S",
+        base_name="test_base_name",
+        callback=rolling_callback,
+    )
+    rolling_logger.append_writer("local", base_dir=tmp_path)
+    # process the 10 input messages, and wait a second to allow the rolling logger to hit an interval
+    for message in messages:
+        rolling_logger.log(message)
+
+    # without an explicit call to rolling_logger.flush we expect that the elapsed time
+    # is less than the 60s interval, so the callback should not have been triggered
+    initial_callback_count = rolling_callback.call_count
+    assert initial_callback_count == 0
+
+    # after explicitly calling close on the logger, we trigger one more flush and callback
+    rolling_logger.close()
+    assert rolling_callback.call_count > 0

--- a/python/tests/api/logger/test_rolling.py
+++ b/python/tests/api/logger/test_rolling.py
@@ -156,8 +156,7 @@ def test_rolling_row_messages_with_segments(tmp_path: Any) -> None:
 
     # without an explicit call to rolling_logger.flush we expect that the elapsed time
     # is less than the 60s interval, so the callback should not have been triggered
-    initial_callback_count = rolling_callback.call_count
-    assert initial_callback_count == 0
+    assert rolling_callback.call_count == 0
 
     # after explicitly calling close on the logger, we trigger one more flush which has two segments and expect two callbacks
     rolling_logger.close()

--- a/python/whylogs/api/logger/logger.py
+++ b/python/whylogs/api/logger/logger.py
@@ -32,6 +32,7 @@ class Logger(ABC):
         self._writers: List[Writer] = []
         atexit.register(self.close)
         self._store_list: List[ProfileStore] = []
+        self._segment_cache = None
 
     def check_writer(self, _: Writer) -> None:
         """Checks if a writer is configured correctly for this class"""
@@ -76,7 +77,7 @@ class Logger(ABC):
 
         # If segments are defined use segment_processing to return a SegmentedResultSet
         if self._schema and self._schema.segments:
-            return segment_processing(self._schema, obj, pandas, row)
+            return segment_processing(self._schema, obj, pandas, row, self._segment_cache)
 
         profiles = self._get_matching_profiles(obj, pandas=pandas, row=row)
 

--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -93,7 +93,9 @@ class ResultSet(ABC):
 
     def set_dataset_timestamp(self, dataset_timestamp: datetime) -> None:
         profile = self.profile()
-        if profile:
+        if profile is None:
+            raise ValueError("Cannot set timestamp on a result set without a profile!")
+        else:
             profile.set_dataset_timestamp(dataset_timestamp)
 
     @property

--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
 from logging import getLogger
 from typing import Any, Dict, List, Optional
 
@@ -90,6 +91,11 @@ class ResultSet(ABC):
     def get_writables(self) -> Optional[List[Writable]]:
         return [self.view()]
 
+    def set_dataset_timestamp(self, dataset_timestamp: datetime) -> None:
+        profile = self.profile()
+        if profile:
+            profile.set_dataset_timestamp(dataset_timestamp)
+
     @property
     def performance_metrics(self) -> Optional[ModelPerformanceMetrics]:
         profile = self.profile()
@@ -167,6 +173,16 @@ class SegmentedResultSet(ResultSet):
     @property
     def partitions(self) -> Optional[List[SegmentationPartition]]:
         return self._partitions
+
+    def set_dataset_timestamp(self, dataset_timestamp: datetime) -> None:
+        # TODO: pull dataset_timestamp up into a result set scoped property
+        segment_keys = self.segments()
+        if not segment_keys:
+            return
+        for key in segment_keys:
+            profile = self.profile(segment=key)
+            if profile:
+                profile.set_dataset_timestamp(dataset_timestamp)
 
     def segments(self, restrict_to_parition_id: Optional[str] = None) -> Optional[List[Segment]]:
         result: Optional[List[Segment]] = None

--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -99,6 +99,13 @@ class ResultSet(ABC):
             profile.set_dataset_timestamp(dataset_timestamp)
 
     @property
+    def count(self) -> int:
+        result = 0
+        if self.view() is not None:
+            result = 1
+        return result
+
+    @property
     def performance_metrics(self) -> Optional[ModelPerformanceMetrics]:
         profile = self.profile()
         if profile:

--- a/python/whylogs/api/logger/rolling.py
+++ b/python/whylogs/api/logger/rolling.py
@@ -195,7 +195,7 @@ class TimedRollingLogger(Logger):
         if not profiles:
             return
         number_of_profiles = len(profiles)
-        logger.debug(f"about to write {number_of_profiles}.")
+        logger.debug(f"about to write {number_of_profiles} profiles.")
 
         pid = 0
         if self.fork:

--- a/python/whylogs/api/logger/rolling.py
+++ b/python/whylogs/api/logger/rolling.py
@@ -192,9 +192,13 @@ class TimedRollingLogger(Logger):
             return
 
         profiles = results.get_writables()
-        if not profiles:
+        if profiles is None:
+            logger.debug("The result set's writable is None, skipping flush of result set.")
             return
         number_of_profiles = len(profiles)
+        if number_of_profiles == 0:
+            logger.debug("The result set's writable list has length zero, skipping flush of result set.")
+            return
         logger.debug(f"about to write {number_of_profiles} profiles.")
 
         pid = 0

--- a/python/whylogs/api/logger/segment_cache.py
+++ b/python/whylogs/api/logger/segment_cache.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+import logging
+import time
+from typing import Dict, Optional
+from whylogs.api.logger.result_set import SegmentedResultSet
+from whylogs.core.dataset_profile import DatasetProfile
+from whylogs.core.schema import DatasetSchema
+from whylogs.core.segment import Segment
+
+logger = logging.getLogger(__name__)
+
+class SegmentCache(object):
+    """
+    Container for segmented profiles.
+
+    Stores DatasetProfiles while processing inputs using a segmentation DatasetSchema.
+    The contained profiles may be stored in memory or on disk.
+    """
+
+    def __init__(self, schema: DatasetSchema, segments: Optional[Dict[Segment, DatasetProfile]] = None):
+        self._schema = schema
+        self._cache = segments or dict()
+
+    def get_or_create_matching_profile(self, segment_key: Segment) -> DatasetProfile:
+        profile = self._cache.get(segment_key)
+        if profile is None:
+            profile = DatasetProfile(schema=self._schema)
+            self._cache[segment_key] = profile
+        return profile
+
+    def get_segments(self) -> Dict[Segment, DatasetProfile]:
+        return self._cache
+
+    def flush(self, dataset_timestamp: Optional[datetime]) -> SegmentedResultSet:
+        segmented_profiles = dict()
+        for segment_key in self._cache:
+            segments = segmented_profiles.get(segment_key.parent_id)
+            if segments is None:
+                segments = dict()
+                segmented_profiles[segment_key.parent_id] = segments
+            while self._cache[segment_key].is_active:
+                time.sleep(1)
+            segments[segment_key] = self._cache[segment_key]
+
+        results = SegmentedResultSet(segments=segmented_profiles, partitions=list(self._schema.segments.values()))
+        self._cache = dict()
+        if dataset_timestamp:
+            results.set_dataset_timestamp(dataset_timestamp)
+        return results
+

--- a/python/whylogs/api/logger/segment_cache.py
+++ b/python/whylogs/api/logger/segment_cache.py
@@ -1,13 +1,15 @@
-from datetime import datetime
 import logging
 import time
+from datetime import datetime
 from typing import Dict, Optional
+
 from whylogs.api.logger.result_set import SegmentedResultSet
 from whylogs.core.dataset_profile import DatasetProfile
 from whylogs.core.schema import DatasetSchema
 from whylogs.core.segment import Segment
 
 logger = logging.getLogger(__name__)
+
 
 class SegmentCache(object):
     """
@@ -32,7 +34,7 @@ class SegmentCache(object):
         return self._cache
 
     def flush(self, dataset_timestamp: Optional[datetime]) -> SegmentedResultSet:
-        segmented_profiles = dict()
+        segmented_profiles: Dict[str, Dict[Segment, DatasetProfile]] = dict()
         for segment_key in self._cache:
             segments = segmented_profiles.get(segment_key.parent_id)
             if segments is None:
@@ -47,4 +49,3 @@ class SegmentCache(object):
         if dataset_timestamp:
             results.set_dataset_timestamp(dataset_timestamp)
         return results
-

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -207,6 +207,7 @@ class WhyLabsWriter(Writer):
                 dataset_timestamp=dataset_timestamp_epoch,
                 profile_path=tmp_file.name,
             )
+        # TODO: retry
         return response
 
     def _validate_api_key(self) -> None:

--- a/python/whylogs/core/view/segmented_dataset_profile_view.py
+++ b/python/whylogs/core/view/segmented_dataset_profile_view.py
@@ -68,7 +68,10 @@ class SegmentedDatasetProfileView(Writable):
         return self.profile_view.creation_timestamp
 
     def get_default_path(self) -> str:
-        return f"profile_{self._profile_view.creation_timestamp}_{self._segment.parent_id}_{'_'.join(self._segment.key)}.bin"
+        return f"profile_{self._profile_view.creation_timestamp}_{self.get_segment_string()}.bin"
+
+    def get_segment_string(self) -> str:
+        return f"{self._segment.parent_id}_{'_'.join(self._segment.key)}"
 
     def _write_as_v0_message(self, path: Optional[str] = None, **kwargs: Any) -> Tuple[bool, str]:
         message_v0 = v1_to_dataset_profile_message_v0(self.profile_view, self.segment, self.partition)


### PR DESCRIPTION
## Description
Add segmented profile serialization support to rolling logger


## Changes

* Add a SegmentedCache to store and track profiles as the rolling logger encounters new segments
* Replace segment_processing references to ProfileStore with SegmentedCache since these are different use cases.
* Add new tests, tighten the time in existing rolling logger tests
* Fix rolling logger callback to support no writer case for testing or customer serialization hook.
* Add set_dataset_timestamp to ResultSet

## Related

Fixes #911 

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
