### PR TITLE
implements hellinger distance as a drift calculation

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,6 +21,7 @@ typing-extensions = {version = ">=3.10", markers = "python_version < \"3.11\""}
 pybars3 = { version = "^0.9", optional = true }
 ipython = { version = "*", optional = true }
 scipy = { version = ">=1.5", python = "<3.11", optional = true }
+numpy = { version = "*", optional = true }
 
 # datasets module.
 pandas = { version = "*", optional = true}
@@ -98,6 +99,7 @@ docs = [
 viz = [
     "ipython",
     "pybars3",
+    "numpy",
     "scipy",
     "Pillow",
     "whylabs-client",

--- a/python/tests/viz/utils/test_drift_calculations.py
+++ b/python/tests/viz/utils/test_drift_calculations.py
@@ -9,6 +9,7 @@ from whylogs.viz.utils.drift_calculations import (
     _compute_chi_squared_test_p_value,
     _compute_ks_test_p_value,
     _get_chi2_p_value,
+    _get_hellinger_distance,
     _get_ks_p_value,
     calculate_drift_values,
 )
@@ -69,6 +70,12 @@ def test_get_chi2_p_value_returns_none(mock_view_column):
     assert not result
 
 
+def test_get_hellinger_distance_float(view_columns):
+    actual_result = _get_hellinger_distance(view_columns["weight"], view_columns["weight"])
+    assert actual_result["algorithm"] == "hellinger"
+    assert isinstance(actual_result["statistic"], float)
+
+
 def test_calculate_drift_values_result_format(profile_view):
     result_dict = calculate_drift_values(target_view=profile_view, reference_view=profile_view)
     expected_columns = profile_view.get_columns()
@@ -77,6 +84,14 @@ def test_calculate_drift_values_result_format(profile_view):
         assert key in expected_columns
         for dict_value_key in dict_value.keys():
             assert dict_value_key in ["p_value", "test"]
+
+    statistic_dict = calculate_drift_values(target_view=profile_view, reference_view=profile_view, statistic=True)
+    for key, dict_value in statistic_dict.items():
+        if key == "animal":
+            assert not dict_value
+        if key in ["legs", "weight"]:
+            for dict_value_key in dict_value.keys():
+                assert dict_value_key in ["statistic", "algorithm"]
 
 
 def test_compute_chi_squared_test_p_value(reference_distribution):

--- a/python/whylogs/viz/configs.py
+++ b/python/whylogs/viz/configs.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
-import numpy as np
 from typing import List
+
+import numpy as np
 
 
 @dataclass

--- a/python/whylogs/viz/configs.py
+++ b/python/whylogs/viz/configs.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass, field
+import numpy as np
+from typing import List
+
+
+@dataclass
+class HistogramConfig:
+    max_hist_buckets: int = 30
+    hist_avg_number_per_bucket: int = 4
+
+
+@dataclass
+class KSTestConfig:
+    quantiles: List[float] = field(default_factory=lambda: list(np.linspace(0, 1, 100)))
+
+
+@dataclass
+class HellingerConfig:
+    max_hist_buckets: int = 30
+    hist_avg_number_per_bucket: int = 4

--- a/python/whylogs/viz/utils/drift_calculations.py
+++ b/python/whylogs/viz/utils/drift_calculations.py
@@ -218,7 +218,7 @@ def calculate_hellinger_distance(target_pmf: List[float], reference_pmf: List[fl
 
 
 def _get_hellinger_distance(
-    target_view_column: ColumnProfileView, reference_view_column: ColumnProfileView, nbins=None
+    target_view_column: ColumnProfileView, reference_view_column: ColumnProfileView, nbins: Optional[int] = None
 ) -> Optional[ColumnDriftStatistic]:
     MAX_HIST_BUCKETS = HellingerConfig().max_hist_buckets
     HIST_AVG_NUMBER_PER_BUCKET = HellingerConfig().hist_avg_number_per_bucket

--- a/python/whylogs/viz/utils/histogram_calculations.py
+++ b/python/whylogs/viz/utils/histogram_calculations.py
@@ -6,12 +6,14 @@ from whylogs_sketching import kll_doubles_sketch  # type: ignore
 
 from whylogs.core.metrics import DistributionMetric
 from whylogs.core.view.column_profile_view import ColumnProfileView
+from whylogs.viz.configs import HistogramConfig
 from whylogs.viz.utils import _calculate_bins
 
 logger = getLogger(__name__)
 
-MAX_HIST_BUCKETS = 30
-HIST_AVG_NUMBER_PER_BUCKET = 4.0
+
+MAX_HIST_BUCKETS = HistogramConfig().max_hist_buckets
+HIST_AVG_NUMBER_PER_BUCKET = HistogramConfig().hist_avg_number_per_bucket
 
 
 class HistogramSummary(TypedDict):


### PR DESCRIPTION
## Description

Implements hellinger distance to be applied between two profile views.

Currently, this is meant to be used as a standalone function to get the Hellinger Distance statistic. Further work must be done to integrate it with the `viz` module, and the decision process of which kind of algorithm/drift test is applied in different circumstances.

This currently enables hellinger for any feature that has a Distribution Metric. FI Metrics-only features are still not supported.

This repository needs <!-- Add 1-2 sentences explaining the purpose of this PR. -->

The commits in this pull request will <!-- Summarize PR. -->

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
