### PR TITLE
Add zero() to result_set and DatasetProfileView and test merge

### DIFF
--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -137,6 +137,10 @@ class ViewResultSet(ResultSet):
     def view(self) -> Optional[DatasetProfileView]:
         return self._view
 
+    @staticmethod
+    def zero() -> "ViewResultSet":
+        return ViewResultSet(DatasetProfileView.zero())
+
 
 class ProfileResultSet(ResultSet):
     def __init__(self, profile: DatasetProfile) -> None:
@@ -147,6 +151,10 @@ class ProfileResultSet(ResultSet):
 
     def view(self) -> Optional[DatasetProfileView]:
         return self._profile.view()
+
+    @staticmethod
+    def zero() -> "ProfileResultSet":
+        return ProfileResultSet(DatasetProfile())
 
 
 class SegmentedResultSet(ResultSet):
@@ -283,3 +291,7 @@ class SegmentedResultSet(ResultSet):
         if segment.parent_id in self._segments:
             profile = self._segments[segment.parent_id][segment]
             profile.add_model_performance_metrics(metrics)
+
+    @staticmethod
+    def zero() -> "SegmentedResultSet":
+        return SegmentedResultSet(segments=dict())

--- a/python/whylogs/core/view/dataset_profile_view.py
+++ b/python/whylogs/core/view/dataset_profile_view.py
@@ -47,8 +47,8 @@ class DatasetProfileView(Writable):
         self,
         *,
         columns: Dict[str, ColumnProfileView],
-        dataset_timestamp: datetime,
-        creation_timestamp: datetime,
+        dataset_timestamp: Optional[datetime],
+        creation_timestamp: Optional[datetime],
         metrics: Optional[Dict[str, Any]] = None,
     ):
         self._columns = columns.copy()
@@ -57,11 +57,11 @@ class DatasetProfileView(Writable):
         self._metrics = metrics
 
     @property
-    def dataset_timestamp(self) -> datetime:
+    def dataset_timestamp(self) -> Optional[datetime]:
         return self._dataset_timestamp
 
     @property
-    def creation_timestamp(self) -> datetime:
+    def creation_timestamp(self) -> Optional[datetime]:
         return self._creation_timestamp
 
     @property
@@ -186,6 +186,10 @@ class DatasetProfileView(Writable):
         self._do_write(f)
         f.seek(0)
         return f.read()
+
+    @classmethod
+    def zero(cls) -> "DatasetProfileView":
+        return DatasetProfileView(columns=dict(), dataset_timestamp=None, creation_timestamp=None)
 
     @classmethod
     def deserialize(cls, data: bytes) -> "DatasetProfileView":

--- a/python/whylogs/core/view/segmented_dataset_profile_view.py
+++ b/python/whylogs/core/view/segmented_dataset_profile_view.py
@@ -1,4 +1,5 @@
 import tempfile
+from datetime import datetime
 from logging import getLogger
 from typing import Any, Dict, Optional, Tuple
 
@@ -60,11 +61,11 @@ class SegmentedDatasetProfileView(Writable):
         return self._profile_view
 
     @property
-    def dataset_timestamp(self):
+    def dataset_timestamp(self) -> Optional[datetime]:
         return self.profile_view.dataset_timestamp
 
     @property
-    def creation_timestamp(self):
+    def creation_timestamp(self) -> Optional[datetime]:
         return self.profile_view.creation_timestamp
 
     def get_default_path(self) -> str:


### PR DESCRIPTION
## Description

In a map reduce context, we often need an element we can use a zero element, or seed for accumulation, adding these for DatasetProfileView and ResultSet* with some tests.

## Changes

- DatasetProfileView is already mergeable and adding a zero method makes constructing this easier. Fixed type on timestamps since these can be empty in the underlying DatasetProfile
- Added some tests around merging and checking DatasetProfileView instances are doing the right thing when merging, with zero instances.

## Related

Relates to #902 but doesn't fully address that issue. Will do in a follow up change.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
