### PR TITLE
enable quantiles as a parameter for KS drift calculation

### DIFF
--- a/python/whylogs/viz/utils/drift_calculations.py
+++ b/python/whylogs/viz/utils/drift_calculations.py
@@ -33,7 +33,9 @@ class ColumnDriftStatistic(TypedDict):
 
 
 def _compute_ks_test_p_value(
-    target_distribution: kll_doubles_sketch, reference_distribution: kll_doubles_sketch
+    target_distribution: kll_doubles_sketch,
+    reference_distribution: kll_doubles_sketch,
+    quantiles: Optional[List[float]] = None,
 ) -> Optional[ColumnDriftValue]:
     """Compute the Kolmogorov-Smirnov test p-value of two continuous distributions.
 
@@ -48,6 +50,8 @@ def _compute_ks_test_p_value(
     reference_distribution : datasketches.kll_floats_sketch
         A kll_floats_sketch (quantiles sketch) from the reference (expected) distribution's values
         Can be generated from a theoretical distribution, or another sample for the same feature.
+    quantiles: Optional[List[float]], optional
+        Bucket of quantiles used to get the CDF's for both target and reference profiles.
 
     Returns
     -------
@@ -57,7 +61,10 @@ def _compute_ks_test_p_value(
 
     """
 
-    QUANTILES = KSTestConfig().quantiles
+    if not quantiles:
+        QUANTILES = KSTestConfig().quantiles
+    else:
+        QUANTILES = quantiles
 
     if reference_distribution.is_empty() or target_distribution.is_empty():
         return None


### PR DESCRIPTION
## Description

Enables a list of quantiles to be passed as parameter for KS drift calculation.

It was a change that enabled me to run experiments on number of buckets. I thought it could be useful to add this to improve customization by the user, if needed, and/or if anyone wants to reproduce the experiments that will be published.
## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
