### PR TITLE
Add separate NaN and inf counts, added tests

### DIFF
--- a/python/tests/core/test_preprocessing.py
+++ b/python/tests/core/test_preprocessing.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 from logging import getLogger
 from typing import Any, List, Optional, Union
@@ -32,6 +33,49 @@ class TestListElements(object):
         assert res.pandas.strings.tolist() == ["str"]  # type: ignore
         assert_zero_len(res.pandas.objs)  # type: ignore
         assert res.null_count == 1
+
+    def test_none_and_math_nan(self) -> None:
+        mixed = pd.Series([None, math.nan, "hi"])
+
+        res = PreprocessedColumn.apply(mixed)
+        assert_zero_len(res.pandas.objs)  # type: ignore
+        assert res.null_count == 2
+        assert res.nan_count == 1
+
+    def test_none_and_math_inf(self) -> None:
+        mixed = pd.Series([math.inf, None])  # when all types are numeric None->NaN
+
+        res = PreprocessedColumn.apply(mixed)
+        assert_zero_len(res.pandas.objs)  # type: ignore
+        assert res.null_count == 1
+        assert res.nan_count == 1
+        assert res.inf_count == 1
+
+    def test_none_and_np_nan(self) -> None:
+        mixed = pd.Series([np.nan, None, "test"])
+
+        res = PreprocessedColumn.apply(mixed)
+        assert_zero_len(res.pandas.objs)  # type: ignore
+        assert res.null_count == 2
+        assert res.nan_count == 1
+
+    def test_none_and_np_inf_mixed(self) -> None:
+        mixed = pd.Series([np.inf, None, "t"])
+
+        res = PreprocessedColumn.apply(mixed)
+        assert_zero_len(res.pandas.objs)  # type: ignore
+        assert res.null_count == 1
+        assert res.nan_count == 0
+        assert res.inf_count == 1
+
+    def test_none_and_np_inf_and_nan(self) -> None:
+        mixed = pd.Series([np.inf, None, float("nan"), "t"])
+
+        res = PreprocessedColumn.apply(mixed)
+        assert_zero_len(res.pandas.objs)  # type: ignore
+        assert res.null_count == 2
+        assert res.nan_count == 1
+        assert res.inf_count == 1
 
     def test_bools_and_ints(self) -> None:
         mixed = pd.Series([True, True, False, 2, 1, 0])

--- a/python/whylogs/core/metrics/column_metrics.py
+++ b/python/whylogs/core/metrics/column_metrics.py
@@ -92,6 +92,8 @@ class TypeCountersMetric(Metric):
 class ColumnCountsMetric(Metric):
     n: IntegralComponent
     null: IntegralComponent
+    nan: IntegralComponent
+    inf: IntegralComponent
 
     @property
     def namespace(self) -> str:
@@ -100,6 +102,9 @@ class ColumnCountsMetric(Metric):
     def columnar_update(self, data: PreprocessedColumn) -> OperationResult:
         n: int = self.n.value
         null: int = self.null.value
+        nan: int = self.nan.value
+        inf: int = self.inf.value
+
         if data.len <= 0:
             return OperationResult.ok(0)
         n += data.len
@@ -107,11 +112,20 @@ class ColumnCountsMetric(Metric):
 
         null += data.null_count
         self.null.set(null)
+
+        nan += data.nan_count
+        self.nan.set(nan)
+
+        inf += data.inf_count
+        self.inf.set(inf)
+
         return OperationResult.ok(data.len)
 
     def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Any]:
-        return {"n": self.n.value, "null": self.null.value}
+        return {"n": self.n.value, "null": self.null.value, "nan": self.nan.value, "inf": self.inf.value}
 
     @classmethod
     def zero(cls, config: Optional[MetricConfig] = None) -> "ColumnCountsMetric":
-        return ColumnCountsMetric(n=IntegralComponent(0), null=IntegralComponent(0))
+        return ColumnCountsMetric(
+            n=IntegralComponent(0), null=IntegralComponent(0), nan=IntegralComponent(0), inf=IntegralComponent(0)
+        )

--- a/python/whylogs/migration/converters.py
+++ b/python/whylogs/migration/converters.py
@@ -211,7 +211,12 @@ def _extract_schema_message_v0(col_prof: ColumnProfileView) -> SchemaMessageV0:
 def _extract_col_counts(msg: ColumnMessageV0) -> ColumnCountsMetric:
     count_n = msg.counters.count
     count_null = msg.counters.null_count
-    return ColumnCountsMetric(n=IntegralComponent(count_n or 0), null=IntegralComponent(count_null.value or 0))
+    return ColumnCountsMetric(
+        n=IntegralComponent(count_n or 0),
+        null=IntegralComponent(count_null.value or 0),
+        inf=IntegralComponent(0),
+        nan=IntegralComponent(0),
+    )
 
 
 def _extract_counters_v0(col_prof: ColumnProfileView) -> CountersV0:


### PR DESCRIPTION
## Description
NaN and inf values can be useful to count separately, add support for splitting these out.

Also added a latency performance test, since some of the None checking was one of the more expensive parts of processing a column.

closes #700 
- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
