### PR TITLE
Allow passing schema to log method

### DIFF
--- a/python/tests/api/logger/test_logger.py
+++ b/python/tests/api/logger/test_logger.py
@@ -20,6 +20,24 @@ DATETIME_TYPES = [np.datetime64, pd.Timestamp]
 TIMEDELTA_TYPES = ["timedelta64[s]", "timedelta64[ms]"]
 
 
+def test_basic_log_schema() -> None:
+    d = {"col1": [1, 2]}
+    df = pd.DataFrame(data=d)
+    logger = why.logger()
+    results = logger.log(df, schema=DatasetSchema())
+    profile = results.profile()
+    assert profile._columns["col1"]._schema.dtype == np.int64
+
+
+def test_basic_log_schem_constructor() -> None:
+    d = {"col1": [1, 2]}
+    df = pd.DataFrame(data=d)
+    logger = why.logger(schema=DatasetSchema())
+    results = logger.log(df)
+    profile = results.profile()
+    assert profile._columns["col1"]._schema.dtype == np.int64
+
+
 def test_basic_log() -> None:
     d = {"col1": [1, 2], "col2": [3.0, 4.0], "col3": ["a", "b"]}
     df = pd.DataFrame(data=d)

--- a/python/whylogs/api/logger/rolling.py
+++ b/python/whylogs/api/logger/rolling.py
@@ -140,8 +140,18 @@ class TimedRollingLogger(Logger):
         return rounded_now
 
     def _get_matching_profiles(
-        self, obj: Any = None, *, pandas: Optional[pd.DataFrame] = None, row: Optional[Dict[str, Any]] = None
+        self,
+        obj: Any = None,
+        *,
+        pandas: Optional[pd.DataFrame] = None,
+        row: Optional[Dict[str, Any]] = None,
+        schema: Optional[DatasetSchema] = None,
     ) -> List[DatasetProfile]:
+        if schema:
+            raise ValueError(
+                "You cannot pass a DatasetSchema to an instance of TimedRollingLogger.log(),"
+                "because schema is set once when instantiated, please use TimedRollingLogger(schema) instead."
+            )
         return [self._current_profile]
 
     def _do_rollover(self) -> None:

--- a/python/whylogs/api/logger/rolling.py
+++ b/python/whylogs/api/logger/rolling.py
@@ -147,7 +147,7 @@ class TimedRollingLogger(Logger):
         row: Optional[Dict[str, Any]] = None,
         schema: Optional[DatasetSchema] = None,
     ) -> List[DatasetProfile]:
-        if schema:
+        if schema and schema is not self._schema:
             raise ValueError(
                 "You cannot pass a DatasetSchema to an instance of TimedRollingLogger.log(),"
                 "because schema is set once when instantiated, please use TimedRollingLogger(schema) instead."

--- a/python/whylogs/api/logger/transient.py
+++ b/python/whylogs/api/logger/transient.py
@@ -10,6 +10,12 @@ class TransientLogger(Logger):
         super(TransientLogger, self).__init__(schema)
 
     def _get_matching_profiles(
-        self, obj: Any = None, *, pandas: Optional[pd.DataFrame] = None, row: Optional[Dict[str, Any]] = None
+        self,
+        obj: Any = None,
+        *,
+        pandas: Optional[pd.DataFrame] = None,
+        row: Optional[Dict[str, Any]] = None,
+        schema: Optional[DatasetSchema] = None,
     ) -> List[DatasetProfile]:
-        return [DatasetProfile(schema=self._schema)]
+        active_schema = schema or self._schema
+        return [DatasetProfile(schema=active_schema)]


### PR DESCRIPTION
## Description

The base class of Logger allows passing a DatasetSchema into the log calls but the implementations do not correctly support this.

## Changes

Add optional schema parameter to implementations of Logger to allow this. Note that on the rolling logger this is not supported as it would change the potentially already aggregated profile based on the schema used at instantiation so integrators should pass the schema while creating rolling loggers.


## Related

Closes #956 

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
