### PR TITLE
Fix whylabs upload bug

### DIFF
--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -200,6 +200,7 @@ class WhyLabsWriter(Writer):
             else:
                 view.write(file=tmp_file)
             tmp_file.flush()
+            tmp_file.seek(0)
 
             dataset_timestamp = view.dataset_timestamp or datetime.datetime.now(datetime.timezone.utc)
             dataset_timestamp_epoch = int(dataset_timestamp.timestamp() * 1000)


### PR DESCRIPTION
## Description

There was a regression bug in release 1.1.11 where the WhyLabs writer's upload failed to correctly copy the profiles.

## Changes

Fixes the copy by calling seek(0) when using an open tempfile.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
