### PR TITLE
Add timezone info to default dataset_timestamp

### DIFF
--- a/python/tests/api/store/test_local.py
+++ b/python/tests/api/store/test_local.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from glob import glob
 from pathlib import Path
 from typing import List
@@ -32,7 +32,7 @@ class TestLocalStore(object):
     def test_get_profile_timestamp(self):
         actual_timestamp = LocalStore._get_profile_filename()
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         assert isinstance(actual_timestamp, str)
         assert f"profile_{now.date()}_{now.hour}:{now.minute}" in actual_timestamp
@@ -69,7 +69,7 @@ class TestLocalStore(object):
         store.write(profile_view=profile_view, profile_name="test_name")
         store.write(profile_view=profile_view, profile_name="test_name")
 
-        query = DateQuery(start_date=datetime.utcnow(), profile_name="test_name")
+        query = DateQuery(start_date=datetime.now(timezone.utc), profile_name="test_name")
         read_profile = store.get(query=query)
 
         assert read_profile is not None
@@ -77,8 +77,8 @@ class TestLocalStore(object):
 
         query = DateQuery(
             profile_name="test_name",
-            start_date=datetime.utcnow() - timedelta(days=7),
-            end_date=datetime.utcnow(),
+            start_date=datetime.now(timezone.utc) - timedelta(days=7),
+            end_date=datetime.now(timezone.utc),
         )
         read_profile = store.get(query=query)
 
@@ -94,6 +94,6 @@ class TestLocalStore(object):
 
     def test_get_ignores_files_that_dont_match_pattern(self, store, profile_view):
         store.write(profile_view=profile_view, profile_name="test_name")
-        query = DateQuery(start_date=datetime.utcnow(), profile_name="test_name")
+        query = DateQuery(start_date=datetime.now(timezone.utc), profile_name="test_name")
         Path(os.path.join(store._default_path, query.profile_name, "profile_2022-02-01_23123.bin")).touch()
         assert store.get(query=query)

--- a/python/tests/core/view/test_dataset_profile.py
+++ b/python/tests/core/view/test_dataset_profile.py
@@ -1,3 +1,4 @@
+import datetime
 from logging import getLogger
 
 import numpy as np
@@ -84,3 +85,16 @@ def test_track_with_custom_schema() -> None:
     df = pd.DataFrame({"col1": ["foo"], "col2": np.array([1], dtype=np.int32), "col3": ["bar"]})
     prof.track(pandas=df)
     assert prof._columns.keys() == prof._schema._columns.keys()
+
+
+def test_default_dataset_timestamp() -> None:
+    prof = DatasetProfile()
+    t1 = datetime.datetime.now(datetime.timezone.utc)
+    assert prof.dataset_timestamp is not None
+    assert prof.dataset_timestamp.tzinfo
+    timestamp_delta = t1.timestamp() - prof.dataset_timestamp.timestamp()
+
+    assert timestamp_delta >= 0  # no default timestamps in the future!
+
+    # the time in seconds between DatasetProfile creation and t1 assignment should be relatively small
+    assert timestamp_delta < 30

--- a/python/whylogs/api/fugue/profiler.py
+++ b/python/whylogs/api/fugue/profiler.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import reduce
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -67,7 +67,7 @@ class _FugueProfiler:
         creation_timestamp: Optional[datetime] = None,
         profile_field: str = DF_PROFILE_FIELD,
     ):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         self._dataset_timestamp = dataset_timestamp or now
         self._creation_timestamp = creation_timestamp or now

--- a/python/whylogs/api/pyspark/experimental/profiler.py
+++ b/python/whylogs/api/pyspark/experimental/profiler.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import reduce
 from logging import getLogger
 from typing import Dict, Iterable, Optional, Tuple
@@ -65,7 +65,7 @@ def collect_column_profile_views(input_df: SparkDataFrame) -> Dict[str, ColumnPr
 def collect_dataset_profile_view(
     input_df: SparkDataFrame, dataset_timestamp: Optional[int] = None, creation_timestamp: Optional[int] = None
 ) -> DatasetProfileView:
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     _dataset_timestamp = dataset_timestamp or now
     _creation_timestamp = creation_timestamp or now

--- a/python/whylogs/api/store/local_store.py
+++ b/python/whylogs/api/store/local_store.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import reduce
 from glob import glob
 from typing import List, Optional, Union
@@ -49,8 +49,8 @@ class LocalStore(ProfileStore):
     store = LocalStore()
     query = DateQuery(
         profile_name="my_model",
-        start_date = datetime.utcnow() - timedelta(days=7),
-        end_date = datetime.utcnow()
+        start_date = datetime.now(timezone.utc) - timedelta(days=7),
+        end_date = datetime.now(timezone.utc)
     )
 
     profile_view = store.get(query=query)
@@ -82,7 +82,7 @@ class LocalStore(ProfileStore):
 
     @staticmethod
     def _get_profile_filename() -> str:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         return f"profile_{now.date()}_{now.hour}:{now.minute}:{now.second}_{uuid.uuid4()}.bin"
 
     def list(self) -> List[str]:

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -48,7 +48,7 @@ class DatasetProfile(Writable):
     ):
         if schema is None:
             schema = DatasetSchema()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         self._dataset_timestamp = dataset_timestamp or now
         self._creation_timestamp = creation_timestamp or now
         self._schema = schema


### PR DESCRIPTION
## Description

datetime.utcnow() should not be used for default timestamps, it is a naive time (no timezone info), so later when we grab the timestamp() from it that method uses timezone info to calculate the timestamp, and if None, it uses local time (thereby reinterpreting the UTC time as being local timezone.

for some context look at implementation details here: https://github.com/python/cpython/blob/3.8/Lib/datetime.py#L1791-L1792


## Changes

- Use `datetime.now(timezone.utc)` consistently over `utcnow`

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
