### PR TITLE
Stop writing local segmented profiles as v0

### DIFF
--- a/python/tests/api/logger/test_segments.py
+++ b/python/tests/api/logger/test_segments.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
+import pytest
 
 import whylogs as why
 from whylogs.api.logger.result_set import SegmentedResultSet
@@ -156,7 +157,8 @@ def test_filtered_single_column_segment() -> None:
     assert count == 10
 
 
-def test_segment_write(tmp_path: Any) -> None:
+@pytest.mark.parametrize("v0", [True, False])
+def test_segment_write_roundtrip_versions(tmp_path: Any, v0) -> None:
     input_rows = 10
     segment_column = "col3"
     number_of_segments = 2
@@ -192,12 +194,15 @@ def test_segment_write(tmp_path: Any) -> None:
     assert count is not None
     assert count == values_per_segment
 
-    results.writer().option(base_dir=tmp_path).write()
+    results.writer().option(base_dir=tmp_path).write(use_v0=v0)
     paths = glob(os.path.join(tmp_path) + "/*x0.bin")
     assert len(paths) == 1
     roundtrip_profiles = []
     for file_path in paths:
-        roundtrip_profiles.append(read_v0_to_view(file_path))
+        if v0:
+            roundtrip_profiles.append(read_v0_to_view(path=file_path))
+        else:
+            roundtrip_profiles.append(why.read(path=file_path).view())
     assert len(roundtrip_profiles) == 1
     post_deserialization_first_view = roundtrip_profiles[0]
     assert post_deserialization_first_view is not None
@@ -252,7 +257,7 @@ def test_multi_column_segment() -> None:
     assert count == 1
 
 
-def test_multi_column_segment_serialization_roundtrip(tmp_path: Any) -> None:
+def test_multi_column_segment_serialization_roundtrip_v0(tmp_path: Any) -> None:
     input_rows = 35
     d = {
         "A": [i % 7 for i in range(input_rows)],
@@ -263,7 +268,7 @@ def test_multi_column_segment_serialization_roundtrip(tmp_path: Any) -> None:
     segmentation_partition = SegmentationPartition(name="A,B", mapper=ColumnMapperFunction(col_names=["A", "B"]))
     test_segments = {segmentation_partition.name: segmentation_partition}
     results: SegmentedResultSet = why.log(df, schema=DatasetSchema(segments=test_segments))
-    results.writer().option(base_dir=tmp_path).write()
+    results.writer().option(base_dir=tmp_path).write(use_v0=True)
 
     paths = glob(os.path.join(tmp_path) + "/*.bin")
     assert len(paths) == input_rows

--- a/python/whylogs/api/writer/local.py
+++ b/python/whylogs/api/writer/local.py
@@ -25,7 +25,7 @@ class LocalWriter(Writer):
     ) -> Tuple[bool, str]:
         dest = dest or self._base_name or file.get_default_path()  # type: ignore
         full_path = os.path.join(self._base_dir, dest)
-        file.write(full_path)
+        file.write(full_path, **kwargs)
         return True, full_path
 
     def option(self, base_dir: Optional[str] = None, base_name: Optional[str] = None) -> "LocalWriter":  # type: ignore

--- a/python/whylogs/api/writer/local.py
+++ b/python/whylogs/api/writer/local.py
@@ -5,7 +5,6 @@ from typing import Any, Optional, Tuple
 from whylogs.api.writer import Writer
 from whylogs.api.writer.writer import Writable
 from whylogs.core.utils import deprecated_alias
-from whylogs.core.view.segmented_dataset_profile_view import SegmentedDatasetProfileView
 
 logger = logging.getLogger(__name__)
 
@@ -26,11 +25,7 @@ class LocalWriter(Writer):
     ) -> Tuple[bool, str]:
         dest = dest or self._base_name or file.get_default_path()  # type: ignore
         full_path = os.path.join(self._base_dir, dest)
-        has_segments = isinstance(file, SegmentedDatasetProfileView)
-        if has_segments:
-            file.write(full_path, use_v0=True)
-        else:
-            file.write(full_path)  # type: ignore
+        file.write(full_path)
         return True, full_path
 
     def option(self, base_dir: Optional[str] = None, base_name: Optional[str] = None) -> "LocalWriter":  # type: ignore


### PR DESCRIPTION
## Description

Remove use of v0 format in local writer so that reading as v1 format works after serializing segmented profiles.

## Related

fixes #966 

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
