### PR TITLE
Register non-standard metrics for deserialization 

### DIFF
--- a/python/tests/core/metrics/test_custom_deserialization.py
+++ b/python/tests/core/metrics/test_custom_deserialization.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from whylogs.core.configs import SummaryConfig
 from whylogs.core.dataset_profile import DatasetProfile
 from whylogs.core.datatypes import DataType
 from whylogs.core.metrics.metric_components import MaxIntegralComponent
-from whylogs.core.metrics.metrics import Metric, OperationResult
+from whylogs.core.metrics.metrics import Metric, OperationResult, custom_metric
 from whylogs.core.preprocessing import PreprocessedColumn
 from whylogs.core.resolvers import Resolver
 from whylogs.core.schema import ColumnSchema, DatasetSchema
@@ -42,8 +42,11 @@ class TestMetric(Metric):
         return OperationResult.ok(successes)
 
     @classmethod
-    def zero(cls, schema: ColumnSchema) -> "TestMetric":
+    def zero(cls, schema: Optional[ColumnSchema] = None) -> "TestMetric":
         return cls(max=MaxIntegralComponent(0))
+
+
+custom_metric(TestMetric)
 
 
 class TestResolver(Resolver):

--- a/python/tests/core/metrics/test_custom_deserialization.py
+++ b/python/tests/core/metrics/test_custom_deserialization.py
@@ -11,6 +11,7 @@ from whylogs.core.resolvers import Resolver
 from whylogs.core.schema import ColumnSchema, DatasetSchema
 
 
+@custom_metric
 @dataclass(frozen=True)
 class TestMetric(Metric):
     max: MaxIntegralComponent
@@ -44,9 +45,6 @@ class TestMetric(Metric):
     @classmethod
     def zero(cls, schema: Optional[ColumnSchema] = None) -> "TestMetric":
         return cls(max=MaxIntegralComponent(0))
-
-
-custom_metric(TestMetric)
 
 
 class TestResolver(Resolver):

--- a/python/tests/core/metrics/test_multimetric.py
+++ b/python/tests/core/metrics/test_multimetric.py
@@ -3,8 +3,12 @@ from typing import Optional
 import numpy as np
 import pytest
 
+import whylogs.core.metrics  # noqa: F401
+import whylogs.extras.image_metric  # noqa: F401
 from whylogs.core.metrics.column_metrics import ColumnCountsMetric, TypeCountersMetric
+from whylogs.core.metrics.metrics import Metric  # noqa: F401
 from whylogs.core.metrics.metrics import (
+    _METRIC_DESERIALIZER_REGISTRY,
     CardinalityMetric,
     DistributionMetric,
     FrequentItemsMetric,
@@ -265,3 +269,21 @@ def test_compound_metric_merge() -> None:
     assert merged.submetrics["Metric2"]["distribution"].kll.value.get_n() == d_merged.kll.value.get_n()
     assert merged.submetrics["Metric2"]["distribution"].mean.value == d_merged.mean.value
     assert merged.submetrics["Metric2"]["distribution"].stddev == d_merged.stddev
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [
+        ("condition_count"),
+        ("unicode_range"),
+        ("cardinality"),
+        ("counts"),
+        ("distribution"),
+        ("ints"),
+        ("types"),
+        ("image"),
+        ("frequent_items"),
+    ],
+)
+def test_complex_metric_registration(metric: str) -> None:
+    assert metric in _METRIC_DESERIALIZER_REGISTRY

--- a/python/tests/extras/test_image_metric.py
+++ b/python/tests/extras/test_image_metric.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 import whylogs as why
 from whylogs.api.writer.whylabs import _uncompound_dataset_profile
+from whylogs.core import DatasetProfileView
 from whylogs.core.configs import SummaryConfig
 from whylogs.core.datatypes import DataType
 from whylogs.core.metrics import Metric
@@ -161,3 +162,15 @@ def test_uncompound_profile() -> None:
 
     for metric in ["counts", "types", "cardinality", "frequent_items"]:
         assert metric in uncompounded._columns["image_column.Software"]._metrics
+
+
+def test_deserialize_profile() -> None:
+    image_path = os.path.join(TEST_DATA_PATH, "images", "flower2.jpg")
+    img = image_loader(image_path)
+    profile_view = log_image(img, "image_column").view()
+    profile_view.write(path="test.bin")
+    deserialized_view = DatasetProfileView.read("test.bin")
+    assert (
+        profile_view.get_column("image_column").to_summary_dict()
+        == deserialized_view.get_column("image_column").to_summary_dict()
+    )

--- a/python/whylogs/core/metrics/column_metrics.py
+++ b/python/whylogs/core/metrics/column_metrics.py
@@ -3,7 +3,12 @@ from typing import Any, Dict, Optional
 
 from whylogs.core.configs import SummaryConfig
 from whylogs.core.metrics.metric_components import IntegralComponent
-from whylogs.core.metrics.metrics import Metric, MetricConfig, OperationResult
+from whylogs.core.metrics.metrics import (
+    Metric,
+    MetricConfig,
+    OperationResult,
+    custom_metric,
+)
 from whylogs.core.preprocessing import PreprocessedColumn
 
 
@@ -88,6 +93,9 @@ class TypeCountersMetric(Metric):
         )
 
 
+custom_metric(TypeCountersMetric)
+
+
 @dataclass(frozen=True)
 class ColumnCountsMetric(Metric):
     n: IntegralComponent
@@ -129,3 +137,6 @@ class ColumnCountsMetric(Metric):
         return ColumnCountsMetric(
             n=IntegralComponent(0), null=IntegralComponent(0), nan=IntegralComponent(0), inf=IntegralComponent(0)
         )
+
+
+custom_metric(ColumnCountsMetric)

--- a/python/whylogs/core/metrics/column_metrics.py
+++ b/python/whylogs/core/metrics/column_metrics.py
@@ -7,7 +7,7 @@ from whylogs.core.metrics.metrics import (
     Metric,
     MetricConfig,
     OperationResult,
-    custom_metric,
+    register_metric,
 )
 from whylogs.core.preprocessing import PreprocessedColumn
 
@@ -93,9 +93,6 @@ class TypeCountersMetric(Metric):
         )
 
 
-custom_metric(TypeCountersMetric)
-
-
 @dataclass(frozen=True)
 class ColumnCountsMetric(Metric):
     n: IntegralComponent
@@ -139,4 +136,4 @@ class ColumnCountsMetric(Metric):
         )
 
 
-custom_metric(ColumnCountsMetric)
+register_metric([TypeCountersMetric, ColumnCountsMetric])

--- a/python/whylogs/core/metrics/compound_metric.py
+++ b/python/whylogs/core/metrics/compound_metric.py
@@ -18,8 +18,8 @@ class CompoundMetric(Metric, ABC):
     of one or more metrics. It is handy when you need to do some
     processing of the logged values and track serveral metrics on
     the results. The sub-metrics must either be a StandardMetric, or tagged
-    as a @custom_metric or @dataclass. Note that CompoundMetric is neither, so it
-    cannot be nested.
+    as a @custom_metric or registered via register_metric(). Note that
+    CompoundMetric is neither, so it cannot be nested.
 
     Typically you will need to override namespace(); columnar_update(), calling
     it on the submetrics as needed; and the zero() method to return an

--- a/python/whylogs/core/metrics/condition_count_metric.py
+++ b/python/whylogs/core/metrics/condition_count_metric.py
@@ -12,7 +12,7 @@ from whylogs.core.metrics.metrics import (
     Metric,
     MetricConfig,
     OperationResult,
-    custom_metric,
+    register_metric,
 )
 from whylogs.core.preprocessing import PreprocessedColumn
 from whylogs.core.proto import MetricMessage
@@ -194,4 +194,4 @@ class ConditionCountMetric(Metric):
 
 
 # Register it so Multimetric and ProfileView can deserialize
-custom_metric(ConditionCountMetric)
+register_metric(ConditionCountMetric)

--- a/python/whylogs/core/metrics/condition_count_metric.py
+++ b/python/whylogs/core/metrics/condition_count_metric.py
@@ -87,7 +87,6 @@ class ConditionCountMetric(Metric):
         return "condition_count"
 
     def __post_init__(self) -> None:
-        super(type(self), self).__post_init__()
         if "total" in self.conditions.keys():
             raise ValueError("Condition cannot be named 'total'")
 

--- a/python/whylogs/core/metrics/condition_count_metric.py
+++ b/python/whylogs/core/metrics/condition_count_metric.py
@@ -8,7 +8,12 @@ from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 from whylogs.core.configs import SummaryConfig
 from whylogs.core.metrics.metric_components import IntegralComponent, MetricComponent
-from whylogs.core.metrics.metrics import Metric, MetricConfig, OperationResult
+from whylogs.core.metrics.metrics import (
+    Metric,
+    MetricConfig,
+    OperationResult,
+    custom_metric,
+)
 from whylogs.core.preprocessing import PreprocessedColumn
 from whylogs.core.proto import MetricMessage
 
@@ -187,3 +192,7 @@ class ConditionCountMetric(Metric):
             total,
             matches,
         )
+
+
+# Register it so Multimetric and ProfileView can deserialize
+custom_metric(ConditionCountMetric)

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -154,6 +154,15 @@ class Metric(ABC):
         return cls(**components)
 
 
+def register_metric(metrics: Union[Metric, Type[METRIC], List[Metric], List[Type[METRIC]]]) -> None:
+    global _METRIC_DESERIALIZER_REGISTRY
+    if not isinstance(metrics, list):
+        metrics = [metrics]  # type: ignore
+
+    for metric in metrics:  # type: ignore
+        _METRIC_DESERIALIZER_REGISTRY[metric.get_namespace()] = metric  # type: ignore
+
+
 @dataclass(frozen=True)
 class IntsMetric(Metric):
     max: MaxIntegralComponent
@@ -203,7 +212,7 @@ class IntsMetric(Metric):
         return self.min.value
 
 
-custom_metric(IntsMetric)
+register_metric(IntsMetric)
 
 
 @dataclass(frozen=True)
@@ -423,7 +432,7 @@ class DistributionMetric(Metric):
         )
 
 
-custom_metric(DistributionMetric)
+register_metric(DistributionMetric)
 
 
 @dataclass(frozen=True)
@@ -500,7 +509,7 @@ class FrequentItemsMetric(Metric):
         return FrequentItemsMetric(frequent_strings=FrequentStringsComponent(sk))
 
 
-custom_metric(FrequentItemsMetric)
+register_metric(FrequentItemsMetric)
 
 
 @dataclass(frozen=True)
@@ -589,7 +598,7 @@ class CardinalityMetric(Metric):
         return CardinalityMetric(hll=HllComponent(sk))
 
 
-custom_metric(CardinalityMetric)
+register_metric(CardinalityMetric)
 
 
 def _drop_private_fields(data: List[Tuple[str, Any]]) -> Dict[str, Any]:
@@ -606,7 +615,7 @@ class CustomMetricBase(Metric, ABC):
     @dataclass. All fields not prefixed with an underscore will be included
     in the summary and will be [de]serialized. Such subclasses will need to
     implement the namespace, merge, and zero methods. They should be registered
-    by calling custmom_metric()
+    by calling register_metric()
     """
 
     def get_component_paths(self) -> List[str]:

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -62,9 +62,10 @@ class MetricConfig:
 _METRIC_DESERIALIZER_REGISTRY: Dict[str, Type[METRIC]] = {}  # type: ignore
 
 
-def custom_metric(metric: Type[METRIC], config: MetricConfig = MetricConfig()) -> Type[METRIC]:  # type: ignore
+def custom_metric(metric: Type[METRIC]) -> Type[METRIC]:  # type: ignore
     global _METRIC_DESERIALIZER_REGISTRY
-    _METRIC_DESERIALIZER_REGISTRY[metric.get_namespace(config)] = metric
+    _METRIC_DESERIALIZER_REGISTRY[metric.get_namespace()] = metric
+    print(f"REGISTERED {metric.get_namespace()}")
     return metric
 
 

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -100,10 +100,6 @@ class Metric(ABC):
     def namespace(self) -> str:
         raise NotImplementedError
 
-    def __post_init__(self):
-        global _METRIC_DESERIALIZER_REGISTRY
-        _METRIC_DESERIALIZER_REGISTRY[self.namespace] = self.__class__
-
     def __add__(self: METRIC, other: METRIC) -> METRIC:
         return self.merge(other)
 
@@ -206,6 +202,9 @@ class IntsMetric(Metric):
     @property
     def minimum(self) -> float:
         return self.min.value
+
+
+custom_metric(IntsMetric)
 
 
 @dataclass(frozen=True)
@@ -425,6 +424,9 @@ class DistributionMetric(Metric):
         )
 
 
+custom_metric(DistributionMetric)
+
+
 @dataclass(frozen=True)
 class FrequentItem:
     value: str
@@ -497,6 +499,9 @@ class FrequentItemsMetric(Metric):
         config = config or MetricConfig()
         sk = ds.frequent_strings_sketch(lg_max_k=config.fi_lg_max_k)
         return FrequentItemsMetric(frequent_strings=FrequentStringsComponent(sk))
+
+
+custom_metric(FrequentItemsMetric)
 
 
 @dataclass(frozen=True)
@@ -585,6 +590,9 @@ class CardinalityMetric(Metric):
         return CardinalityMetric(hll=HllComponent(sk))
 
 
+custom_metric(CardinalityMetric)
+
+
 def _drop_private_fields(data: List[Tuple[str, Any]]) -> Dict[str, Any]:
     return {k: v for k, v in data if not k.startswith("_")}
 
@@ -598,7 +606,8 @@ class CustomMetricBase(Metric, ABC):
     the supplied or custom MetricComponents. Subclasses must be decorated with
     @dataclass. All fields not prefixed with an underscore will be included
     in the summary and will be [de]serialized. Such subclasses will need to
-    implement the namespace, merge, and zero methods.
+    implement the namespace, merge, and zero methods. They should be registered
+    by calling custmom_metric()
     """
 
     def get_component_paths(self) -> List[str]:

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -65,7 +65,6 @@ _METRIC_DESERIALIZER_REGISTRY: Dict[str, Type[METRIC]] = {}  # type: ignore
 def custom_metric(metric: Type[METRIC]) -> Type[METRIC]:  # type: ignore
     global _METRIC_DESERIALIZER_REGISTRY
     _METRIC_DESERIALIZER_REGISTRY[metric.get_namespace()] = metric
-    print(f"REGISTERED {metric.get_namespace()}")
     return metric
 
 

--- a/python/whylogs/core/metrics/multimetric.py
+++ b/python/whylogs/core/metrics/multimetric.py
@@ -37,8 +37,8 @@ class MultiMetric(Metric, ABC):
     of one or more metrics. It is handy when you need to do some
     processing of the logged values and track several metrics on
     the results. The sub-metrics must either be a StandardMetric, or tagged
-    as a @custom_metric or @dataclass. Note that MultiMetric is neither, so it
-    cannot be nested.
+    as a @custom_metric or registered via register_metric(). Note that
+    MultiMetric is neither, so it cannot be nested.
 
     Typically you will need to override namespace(); columnar_update(), calling
     it on the submetrics as needed; and the zero() method to return an

--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -9,7 +9,7 @@ from whylogs.core.metrics.metrics import (
     IntsMetric,
     MetricConfig,
     OperationResult,
-    custom_metric,
+    register_metric,
 )
 from whylogs.core.metrics.multimetric import MultiMetric
 from whylogs.core.preprocessing import PreprocessedColumn
@@ -129,4 +129,4 @@ class UnicodeRangeMetric(MultiMetric):
 
 
 # Register it so Multimetric and ProfileView can deserialize
-custom_metric(UnicodeRangeMetric)
+register_metric(UnicodeRangeMetric)

--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -9,6 +9,7 @@ from whylogs.core.metrics.metrics import (
     IntsMetric,
     MetricConfig,
     OperationResult,
+    custom_metric,
 )
 from whylogs.core.metrics.multimetric import MultiMetric
 from whylogs.core.preprocessing import PreprocessedColumn
@@ -38,7 +39,7 @@ class UnicodeRangeMetric(MultiMetric):
     normalize: bool = True
 
     def __post_init__(self):
-        super(type(self), self).__post_init__()
+        super().__post_init__()
         self.range_definitions["UNKNOWN"] = (0, 0)  # catchall for characters not in a defined range
         for key, range in self.range_definitions.items():
             if range[0] > range[1]:
@@ -126,3 +127,7 @@ class UnicodeRangeMetric(MultiMetric):
         result = cls(ranges)
         result.submetrics = submetrics
         return result
+
+
+# Register it so Multimetric and ProfileView can deserialize
+custom_metric(UnicodeRangeMetric)

--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -39,7 +39,6 @@ class UnicodeRangeMetric(MultiMetric):
     normalize: bool = True
 
     def __post_init__(self):
-        super().__post_init__()
         self.range_definitions["UNKNOWN"] = (0, 0)  # catchall for characters not in a defined range
         for key, range in self.range_definitions.items():
             if range[0] > range[1]:

--- a/python/whylogs/extras/image_metric.py
+++ b/python/whylogs/extras/image_metric.py
@@ -16,7 +16,12 @@ from whylogs.core.datatypes import (
     TypeMapper,
 )
 from whylogs.core.metrics import StandardMetric
-from whylogs.core.metrics.metrics import Metric, MetricConfig, OperationResult
+from whylogs.core.metrics.metrics import (
+    Metric,
+    MetricConfig,
+    OperationResult,
+    custom_metric,
+)
 from whylogs.core.metrics.multimetric import MultiMetric
 from whylogs.core.preprocessing import PreprocessedColumn
 from whylogs.core.resolvers import Resolver
@@ -276,3 +281,7 @@ def log_image(
         raise ValueError("log_image requires DatasetSchema with an ImageMetricConfig as default_configs")
 
     return why.log(row=images, schema=schema)
+
+
+# Register it so Multimetric and ProfileView can deserialize
+custom_metric(ImageMetric)

--- a/python/whylogs/extras/image_metric.py
+++ b/python/whylogs/extras/image_metric.py
@@ -20,7 +20,7 @@ from whylogs.core.metrics.metrics import (
     Metric,
     MetricConfig,
     OperationResult,
-    custom_metric,
+    register_metric,
 )
 from whylogs.core.metrics.multimetric import MultiMetric
 from whylogs.core.preprocessing import PreprocessedColumn
@@ -284,4 +284,4 @@ def log_image(
 
 
 # Register it so Multimetric and ProfileView can deserialize
-custom_metric(ImageMetric)
+register_metric(ImageMetric)


### PR DESCRIPTION
## Description

Register non-standard metrics for custom deserialization.

`MultiMetric` subclasses (`ImageMetric` and `UnicodeRangeMetric`) are not dataclasses, so they were not registering for deserialization. `ConditionCountMetric` is, but for all of these metrics registration happened in the constructor so they couldn't be deserialized unless one had been instantiated.

## Changes

- Register non-standard metrics on `import`

## Related

Relates to #1009 
