### PR TITLE
[fix] make dataset_id param default on ProfileStore

### DIFF
--- a/python/whylogs/api/store/profile_store.py
+++ b/python/whylogs/api/store/profile_store.py
@@ -16,7 +16,7 @@ class ProfileStore(ABC):
         pass
 
     @abstractmethod
-    def write(self, profile_view: DatasetProfileView, profile_name: str) -> None:
+    def write(self, profile_view: DatasetProfileView, dataset_id: str) -> None:
         pass
 
     @staticmethod


### PR DESCRIPTION
## Description

Quick fix for correct parameter naming on ProfileStore

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
