### PR TITLE
Fix reversed frequent item upper/lower bounds

### DIFF
--- a/python/tests/core/metrics/test_metrics.py
+++ b/python/tests/core/metrics/test_metrics.py
@@ -153,7 +153,7 @@ def test_merge_two_profiles_mean(lending_club_df: pd.DataFrame) -> None:
 
 def test_frequent_items_handling_int_as_string() -> None:
     df_gamma = pd.DataFrame({"feature1": np.random.gamma(1, 2, 1000).astype(int)})
-    df_rand =  pd.DataFrame({"feature1": np.random.randint(10000, size=9000)})
+    df_rand = pd.DataFrame({"feature1": np.random.randint(10000, size=9000)})
     df = df_gamma.append(df_rand)
 
     res = why.log(df).view().to_pandas()["frequent_items/frequent_strings"]

--- a/python/tests/core/metrics/test_metrics.py
+++ b/python/tests/core/metrics/test_metrics.py
@@ -152,7 +152,9 @@ def test_merge_two_profiles_mean(lending_club_df: pd.DataFrame) -> None:
 
 
 def test_frequent_items_handling_int_as_string() -> None:
-    df = pd.DataFrame({"int": [1, 1, 1]})
+    df_gamma = pd.DataFrame({"feature1": np.random.gamma(1, 2, 1000).astype(int)})
+    df_rand =  pd.DataFrame({"feature1": np.random.randint(10000, size=9000)})
+    df = df_gamma.append(df_rand)
 
     res = why.log(df).view().to_pandas()["frequent_items/frequent_strings"]
     fi_tuple = res.array[0][0]

--- a/python/tests/core/metrics/test_metrics.py
+++ b/python/tests/core/metrics/test_metrics.py
@@ -155,7 +155,7 @@ def test_frequent_items_handling_int_as_string() -> None:
     df = pd.DataFrame({"int": [1, 1, 1]})
 
     res = why.log(df).view().to_pandas()["frequent_items/frequent_strings"]
-    fi_tuple = res.array[0][0]
+    assert res.array[0][0].value == "1"  # type: ignore
 
 
 def test_frequent_items_bounds_order() -> None:

--- a/python/tests/core/metrics/test_metrics.py
+++ b/python/tests/core/metrics/test_metrics.py
@@ -158,7 +158,6 @@ def test_frequent_items_handling_int_as_string() -> None:
 
     res = why.log(df).view().to_pandas()["frequent_items/frequent_strings"]
     fi_tuple = res.array[0][0]
-    assert fi_tuple.value == "1"  # type: ignore
     assert fi_tuple.lower <= fi_tuple.est <= fi_tuple.upper
 
 

--- a/python/tests/core/metrics/test_metrics.py
+++ b/python/tests/core/metrics/test_metrics.py
@@ -152,6 +152,13 @@ def test_merge_two_profiles_mean(lending_club_df: pd.DataFrame) -> None:
 
 
 def test_frequent_items_handling_int_as_string() -> None:
+    df = pd.DataFrame({"int": [1, 1, 1]})
+
+    res = why.log(df).view().to_pandas()["frequent_items/frequent_strings"]
+    fi_tuple = res.array[0][0]
+
+
+def test_frequent_items_bounds_order() -> None:
     df_gamma = pd.DataFrame({"feature1": np.random.gamma(1, 2, 1000).astype(int)})
     df_rand = pd.DataFrame({"feature1": np.random.randint(10000, size=9000)})
     df = df_gamma.append(df_rand)

--- a/python/tests/core/metrics/test_metrics.py
+++ b/python/tests/core/metrics/test_metrics.py
@@ -155,7 +155,9 @@ def test_frequent_items_handling_int_as_string() -> None:
     df = pd.DataFrame({"int": [1, 1, 1]})
 
     res = why.log(df).view().to_pandas()["frequent_items/frequent_strings"]
-    assert res.array[0][0].value == "1"  # type: ignore
+    fi_tuple = res.array[0][0]
+    assert fi_tuple.value == "1"  # type: ignore
+    assert fi_tuple.lower <= fi_tuple.est <= fi_tuple.upper
 
 
 def test_cardinality_metric_booleans() -> None:

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -492,7 +492,8 @@ class FrequentItemsMetric(Metric):
             limited_freq_items = all_freq_items[: cfg.frequent_items_limit]
         else:
             limited_freq_items = all_freq_items
-        items = [FrequentItem(value=x[0], est=x[1], lower=x[2], upper=x[3]) for x in limited_freq_items]
+        items = [FrequentItem(value=x[0], est=x[1], lower=x[3], upper=x[2]) for x in limited_freq_items]
+        # items = [FrequentItem(value=x[0], est=x[1], lower=x[2], upper=x[3]) for x in limited_freq_items]
         return {"frequent_strings": items}
 
     @property

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -492,7 +492,7 @@ class FrequentItemsMetric(Metric):
             limited_freq_items = all_freq_items[: cfg.frequent_items_limit]
         else:
             limited_freq_items = all_freq_items
-        items = [FrequentItem(value=x[0], est=x[1], upper=x[2], lower=x[3]) for x in limited_freq_items]
+        items = [FrequentItem(value=x[0], est=x[1], lower=x[2], upper=x[3]) for x in limited_freq_items]
         return {"frequent_strings": items}
 
     @property

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -492,8 +492,7 @@ class FrequentItemsMetric(Metric):
             limited_freq_items = all_freq_items[: cfg.frequent_items_limit]
         else:
             limited_freq_items = all_freq_items
-        items = [FrequentItem(value=x[0], est=x[1], lower=x[3], upper=x[2]) for x in limited_freq_items]
-        # items = [FrequentItem(value=x[0], est=x[1], lower=x[2], upper=x[3]) for x in limited_freq_items]
+        items = [FrequentItem(value=x[0], est=x[1], lower=x[2], upper=x[3]) for x in limited_freq_items]
         return {"frequent_strings": items}
 
     @property


### PR DESCRIPTION
## Description

It should be the case for `FrequentItem`s that lower bound <= estimate <= upper bound. It looks like we got the upper & lower bounds reversed between the pybind11 interface code and the `FrequentItemsMetric`

`items = [FrequentItem(value=x[0], est=x[1], upper=x[2], lower=x[3]) for x in limited_freq_items]`  in `metrics.py` but 
```
    py::tuple t = py::make_tuple(iter->get_item(),
                                 iter->get_estimate(),
                                 iter->get_lower_bound(),
                                 iter->get_upper_bound());
```
in `fi_wrapper.cpp` (in the `datasketches-cpp` repo).

## Changes

-Upper/lower bounds fixed

## Related



<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->


<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
