### PR TITLE
performance improvement for low latency row logging

### DIFF
--- a/python/whylogs/core/column_profile.py
+++ b/python/whylogs/core/column_profile.py
@@ -49,14 +49,21 @@ class ColumnProfile(object):
         self._cache = []
         self.track_column(old_cache)
 
-    def track_column(self, series: Any) -> None:
-        ex_col = PreprocessedColumn.apply(series)
+    def _process_extracted_column(self, extracted_column: PreprocessedColumn) -> None:
         for metric in self._metrics.values():
-            res = metric.columnar_update(ex_col)
+            res = metric.columnar_update(extracted_column)
             self._failure_count += res.failures
             self._success_count += res.successes
         for validator in self._column_validators:
-            validator.columnar_validate(ex_col)
+            validator.columnar_validate(extracted_column)
+
+    def track_column(self, series: Any) -> None:
+        ex_col = PreprocessedColumn.apply(series)
+        self._process_extracted_column(ex_col)
+
+    def _track_datum(self, value: Any) -> None:
+        ex_col = PreprocessedColumn._process_scalar_value(value)
+        self._process_extracted_column(ex_col)
 
     def to_protobuf(self) -> ColumnMessage:
         self.flush()

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -131,7 +131,11 @@ class DatasetProfile(Writable):
             new_cols = (col for col in schema_col_keys if col not in self._columns)
             self._initialize_new_columns(tuple(new_cols))
 
-        if pandas is not None:
+        if row is not None:
+            for k in row.keys():
+                self._columns[k]._track_datum(row[k])
+            return
+        elif pandas is not None:
             # TODO: iterating over each column in order assumes single column metrics
             #   but if we instead iterate over a new artifact contained in dataset profile: "MetricProfiles", then
             #   each metric profile can specify which columns its tracks, and we can call like this:
@@ -147,11 +151,6 @@ class DatasetProfile(Writable):
                     )
                 else:
                     self._columns[k].track_column(column_values)
-            return
-
-        if row is not None:
-            for k in row.keys():
-                self._columns[k].track_column([row[k]])
             return
 
         raise NotImplementedError

--- a/python/whylogs/core/input_resolver.py
+++ b/python/whylogs/core/input_resolver.py
@@ -12,10 +12,10 @@ def _pandas_or_dict(
         if row is not None:
             raise ValueError("Cannot pass both obj and row params")
 
-        if pd.DataFrame is not None and isinstance(obj, pd.DataFrame):
-            pandas = obj
-        elif isinstance(obj, (dict, Dict, Mapping)):
+        if isinstance(obj, (dict, Dict, Mapping)):
             row = obj
+        elif pd.DataFrame is not None and isinstance(obj, pd.DataFrame):
+            pandas = obj
 
     if pandas is not None and row is not None:
         raise ValueError("Cannot pass both pandas and row params")

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -180,12 +180,12 @@ class IntsMetric(Metric):
 
         max_ = self.max.value
         min_ = self.min.value
-        if data.numpy.ints is not None:
+        if data.numpy.ints is not None and len(data.numpy.ints) > 0:
             max_ = max([max_, data.numpy.ints.max()])
             min_ = min([min_, data.numpy.ints.min()])
             successes += len(data.numpy.ints)
 
-        if data.list.ints is not None:
+        if data.list.ints is not None and len(data.list.ints) > 0:
             l_max = max(data.list.ints)
             l_min = min(data.list.ints)
             max_ = max([max_, l_max])


### PR DESCRIPTION
## Description

This change keeps the row based dictionary logging separate from the pandas columnar logging so that there is less overhead per call when logging messages or integrating whylogs into a service rather than batch processing scenarios.

Taken together these changes reduce latency by about an order of magnitude, but numbers are hardware and input dependent, so your mileage may vary. The included new tests are what were used to identify the pandas series preprocessing as a hot spot when logging single row messages with respect to latency and are what were used to compare the performance improvements.

There are further optimizations, tuning, and cleanup but with the significance of this improvement we are releasing this change after our initial round of testing.

These changes are the same as what exist in the pre-release of whylogs 1.1.17-dev0 (modulo version information and test changes).

## Changes

- Add scalar processing path for row logging.
- Added performance benchmark tests for latency.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
