### PR TITLE
add_resolver to DeclarativeResolver and DeclarativeSchema

### DIFF
--- a/python/whylogs/core/resolvers.py
+++ b/python/whylogs/core/resolvers.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, TypeVar
 
 from typing_extensions import TypeAlias
 
-from whylogs.core.datatypes import DataType, Fractional, Integral, String
+from whylogs.core.datatypes import AnyType, DataType, Fractional, Integral, String
 from whylogs.core.metrics import StandardMetric
 from whylogs.core.metrics.metrics import Metric, MetricConfig
 
@@ -95,6 +95,10 @@ class MetricSpec:
     metric: Any  # Should be a subclass of Metric, it should be the class, not an instance
     config: Optional[MetricConfig] = None  # omit to use default MetricConfig
 
+    def __post_init__(self):
+        if not issubclass(self.metric, Metric):
+            raise ValueError("MetricSpec: must supply a Metric subclass to MetricSpec")
+
 
 @dataclass
 class ResolverSpec:
@@ -108,6 +112,15 @@ class ResolverSpec:
     column_name: Optional[str] = None  # TODO: maybe make this a regex
     column_type: Optional[Any] = None
     metrics: List[MetricSpec] = field(default_factory=list)
+
+    def __post_init__(self):
+        if self.column_name and self.column_type:
+            logger.warning(f"ResolverSpec: column {self.column_name} also specified type, name takes precedence")
+        if not (self.column_name or self.column_type):
+            raise ValueError("ResolverSpec: resolver specification must supply name or type")
+
+        if self.column_type and not issubclass(self.column_type, DataType):
+            raise ValueError("ResolverSpec: resolver specification column type must be a DataType")
 
 
 # whylabs expects COLUMN_METRICS to be present for every column.
@@ -131,24 +144,12 @@ class DeclarativeResolver(Resolver):
     of ResolverSpecs
     """
 
+    def add_resolver(self, resolver_spec: ResolverSpec):
+        self._resolvers.append(resolver_spec)
+
     def __init__(self, resolvers: List[ResolverSpec], default_config: Optional[MetricConfig] = None) -> None:
-        # Validate resolvers -- must have name xor type, MetricSpec metrcis must <: Metric
-        for spec in resolvers:
-            if spec.column_name and spec.column_type:
-                logger.warning(
-                    f"DeclarativeSchema: column {spec.column_name} also specified type, name takes precedence"
-                )
-            if not (spec.column_name or spec.column_type):
-                raise ValueError("DeclarativeSchema: resolver specification must supply name or type")
-
-            if spec.column_type and not issubclass(spec.column_type, DataType):
-                raise ValueError("DeclarativeSchema: resolver specification column type must be a DataType")
-
-            for metric_spec in spec.metrics:
-                if not issubclass(metric_spec.metric, Metric):
-                    raise ValueError("DeclarativeSchema: must supply a Metric subclass to MetricSpec")
-
-        self._resolvers = resolvers
+        # Validate resolvers -- must have name xor type, MetricSpec metrics must <: Metric
+        self._resolvers = resolvers.copy()
 
     def resolve(self, name: str, why_type: DataType, column_schema: ColumnSchema) -> Dict[str, Metric]:
         result: Dict[str, Metric] = {}
@@ -161,3 +162,65 @@ class DeclarativeResolver(Resolver):
                         result[spec.metric.get_namespace()] = spec.metric.zero(config)
 
         return result
+
+
+# STANDARD_RESOLVER matches the default DatasetSchema/StandardResolver behavior
+STANDARD_RESOLVER = [
+    ResolverSpec(
+        column_type=Integral,
+        metrics=COLUMN_METRICS
+        + [
+            MetricSpec(StandardMetric.distribution.value),
+            MetricSpec(StandardMetric.ints.value),
+            MetricSpec(StandardMetric.cardinality.value),
+            MetricSpec(StandardMetric.frequent_items.value),
+        ],
+    ),
+    ResolverSpec(
+        column_type=Fractional,
+        metrics=COLUMN_METRICS
+        + [
+            MetricSpec(StandardMetric.distribution.value),
+            MetricSpec(StandardMetric.cardinality.value),
+        ],
+    ),
+    ResolverSpec(
+        column_type=String,
+        metrics=COLUMN_METRICS
+        + [
+            MetricSpec(StandardMetric.unicode_range.value),
+            MetricSpec(StandardMetric.distribution.value),
+            MetricSpec(StandardMetric.cardinality.value),
+            MetricSpec(StandardMetric.frequent_items.value),
+        ],
+    ),
+    ResolverSpec(column_type=AnyType, metrics=COLUMN_METRICS),
+]
+
+LIMITED_TRACKING_RESOLVER = [
+    ResolverSpec(
+        column_type=Integral,
+        metrics=COLUMN_METRICS
+        + [
+            MetricSpec(StandardMetric.distribution.value),
+            MetricSpec(StandardMetric.ints.value),
+        ],
+    ),
+    ResolverSpec(
+        column_type=Fractional,
+        metrics=COLUMN_METRICS
+        + [
+            MetricSpec(StandardMetric.distribution.value),
+        ],
+    ),
+    ResolverSpec(column_type=String, metrics=COLUMN_METRICS),
+    ResolverSpec(column_type=AnyType, metrics=COLUMN_METRICS),
+]
+
+
+HISTOGRAM_COUNTING_TRACKING_RESOLVER = [
+    ResolverSpec(column_type=Integral, metrics=[MetricSpec(StandardMetric.distribution.value)]),
+    ResolverSpec(column_type=Fractional, metrics=[MetricSpec(StandardMetric.distribution.value)]),
+    ResolverSpec(column_type=String, metrics=[MetricSpec(StandardMetric.distribution.value)]),
+    ResolverSpec(column_type=AnyType, metrics=[MetricSpec(StandardMetric.distribution.value)]),
+]

--- a/python/whylogs/core/schema.py
+++ b/python/whylogs/core/schema.py
@@ -208,6 +208,9 @@ class DeclarativeSchema(DatasetSchema):
     in whylogs/python/tests/core/test_declarative_schema.py
     """
 
+    def add_resolver(self, resolver_spec: ResolverSpec):
+        self.resolvers.add_resolver(resolver_spec)
+
     def __init__(
         self,
         resolvers: List[ResolverSpec],


### PR DESCRIPTION
also:
- changed validation from DeclarativeResolver to ResolverSpec and MetricSpec
- changed Declarative Standard Resolvers from test to resolvers.py
- copy() list of resolvers to prevent original list being changed by add_resolver()
