### PR TITLE
Adding warning for vector dictionary on why.log

### DIFF
--- a/python/tests/api/logger/test_logger.py
+++ b/python/tests/api/logger/test_logger.py
@@ -281,8 +281,7 @@ def test_warning_when_logging_a_vector(caplog):
     with caplog.at_level(logging.WARNING):
         why.log({"a": 1.2, "b": [2.2]})
         assert (
-            """It looks like you are logging a vector which isn't directly profiled in whylogs,
-            try logging as a dataframe to get batch logging of individual rows or log the rows individually
-            """
+            "It looks like you are logging a vector which isn't directly profiled in whylogs,"
+            "try logging as a dataframe to get batch logging of individual rows or log the rows individually"
             in caplog.text
         )

--- a/python/tests/api/logger/test_logger.py
+++ b/python/tests/api/logger/test_logger.py
@@ -1,3 +1,4 @@
+import logging
 import os.path
 import tempfile
 from typing import Any
@@ -274,3 +275,14 @@ def test_result_set_reader(profile_view):
         results = reader.read(path=tmp_file.name)
         assert isinstance(reader, ResultSetReader)
         assert isinstance(results, ResultSet)
+
+
+def test_warning_when_logging_a_vector(caplog):
+    with caplog.at_level(logging.WARNING):
+        why.log({"a": 1.2, "b": [2.2]})
+        assert (
+            """It looks like you are logging a vector which isn't directly profiled in whylogs,
+            try logging as a dataframe to get batch logging of individual rows or log the rows individually
+            """
+            in caplog.text
+        )

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -134,9 +134,8 @@ class DatasetProfile(Writable):
         if row is not None:
             if any(isinstance(v, list) for v in row.values()):
                 logger.warn(
-                    """It looks like you are logging a vector which isn't directly profiled in whylogs,
-                    try logging as a dataframe to get batch logging of individual rows or log the rows individually
-                    """
+                    "It looks like you are logging a vector which isn't directly profiled in whylogs,"
+                    "try logging as a dataframe to get batch logging of individual rows or log the rows individually"
                 )
             for k in row.keys():
                 self._columns[k]._track_datum(row[k])

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -132,6 +132,12 @@ class DatasetProfile(Writable):
             self._initialize_new_columns(tuple(new_cols))
 
         if row is not None:
+            if any(isinstance(v, list) for v in row.values()):
+                logger.warn(
+                    """It looks like you are logging a vector which isn't directly profiled in whylogs,
+                    try logging as a dataframe to get batch logging of individual rows or log the rows individually
+                    """
+                )
             for k in row.keys():
                 self._columns[k]._track_datum(row[k])
             return


### PR DESCRIPTION
## Description

Adding a warning for when users try to `why.log` a pandas-like dictionary (with vectors), as in #1021 

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
