### PR TITLE
hellinger calculation edge cases

### DIFF
--- a/python/tests/viz/utils/test_drift_calculations.py
+++ b/python/tests/viz/utils/test_drift_calculations.py
@@ -5,6 +5,9 @@ import pandas as pd
 import pytest
 
 import whylogs as why
+from whylogs.core import ColumnProfileView
+from whylogs.core.metrics import DistributionMetric
+from whylogs.core.metrics.metrics import MetricConfig
 from whylogs.viz.utils.drift_calculations import (
     _compute_chi_squared_test_p_value,
     _compute_ks_test_p_value,
@@ -74,6 +77,31 @@ def test_get_hellinger_distance_float(view_columns):
     actual_result = _get_hellinger_distance(view_columns["weight"], view_columns["weight"])
     assert actual_result["algorithm"] == "hellinger"
     assert isinstance(actual_result["statistic"], float)
+
+
+def test_hellinger_on_empty_sketch():
+    distribution_metric = DistributionMetric.zero(MetricConfig())
+    target_col_view = ColumnProfileView({"distribution": distribution_metric})
+    ref_col_view = ColumnProfileView({"distribution": distribution_metric})
+    with pytest.warns(UserWarning, match="Distribution sketch must not be empty."):
+        _get_hellinger_distance(target_view_column=target_col_view, reference_view_column=ref_col_view)
+
+
+def test_hellinger_single_value():
+    params = [([0], [5], 1.0), ([5], [5], 0.0), ([0], [0], 0.0)]
+    for param in params:
+        target_col = param[0]
+        reference_col = param[1]
+
+        target = pd.DataFrame(data={"col": target_col})
+        ref = pd.DataFrame(data={"col": reference_col})
+
+        target_view = why.log(target).profile().view()
+        ref_view = why.log(ref).profile().view()
+
+        hel = calculate_drift_values(target_view=target_view, reference_view=ref_view, statistic=True)
+        assert hel["col"]["statistic"] == param[2]
+        assert hel["col"]["algorithm"] == "hellinger"
 
 
 def test_calculate_drift_values_result_format(profile_view):

--- a/python/tests/viz/utils/test_drift_calculations.py
+++ b/python/tests/viz/utils/test_drift_calculations.py
@@ -8,6 +8,7 @@ import whylogs as why
 from whylogs.core import ColumnProfileView
 from whylogs.core.metrics import DistributionMetric
 from whylogs.core.metrics.metrics import MetricConfig
+from whylogs.viz.configs import HellingerConfig
 from whylogs.viz.utils.drift_calculations import (
     _compute_chi_squared_test_p_value,
     _compute_ks_test_p_value,
@@ -87,21 +88,30 @@ def test_hellinger_on_empty_sketch():
         _get_hellinger_distance(target_view_column=target_col_view, reference_view_column=ref_col_view)
 
 
-def test_hellinger_single_value():
-    params = [([0], [5], 1.0), ([5], [5], 0.0), ([0], [0], 0.0)]
-    for param in params:
-        target_col = param[0]
-        reference_col = param[1]
+@pytest.mark.parametrize("target_col,reference_col,result", [([0], [5], 1.0), ([5], [5], 0.0), ([0], [0], 0.0)])
+def test_hellinger_single_value(target_col, reference_col, result):
 
-        target = pd.DataFrame(data={"col": target_col})
-        ref = pd.DataFrame(data={"col": reference_col})
+    target = pd.DataFrame(data={"col": target_col})
+    ref = pd.DataFrame(data={"col": reference_col})
 
-        target_view = why.log(target).profile().view()
-        ref_view = why.log(ref).profile().view()
+    target_view = why.log(target).profile().view()
+    ref_view = why.log(ref).profile().view()
 
-        hel = calculate_drift_values(target_view=target_view, reference_view=ref_view, statistic=True)
-        assert hel["col"]["statistic"] == param[2]
-        assert hel["col"]["algorithm"] == "hellinger"
+    hel = calculate_drift_values(target_view=target_view, reference_view=ref_view, statistic=True)
+    assert hel["col"]["statistic"] == result
+    assert hel["col"]["algorithm"] == "hellinger"
+
+
+def test_hellinger_custom_config():
+    config = HellingerConfig(min_n_buckets=1)
+    distribution_metric = DistributionMetric.zero(MetricConfig())
+    target_col_view = ColumnProfileView({"distribution": distribution_metric})
+    ref_col_view = ColumnProfileView({"distribution": distribution_metric})
+    with pytest.warns(
+        UserWarning,
+        match="MIN_N_BUCKETS < 2 might lead to erroneous results for low-sized samples. Consider setting it to >=2.",
+    ):
+        _get_hellinger_distance(target_view_column=target_col_view, reference_view_column=ref_col_view, config=config)
 
 
 def test_calculate_drift_values_result_format(profile_view):

--- a/python/whylogs/viz/configs.py
+++ b/python/whylogs/viz/configs.py
@@ -8,6 +8,7 @@ import numpy as np
 class HistogramConfig:
     max_hist_buckets: int = 30
     hist_avg_number_per_bucket: int = 4
+    min_n_buckets: int = 2
 
 
 @dataclass
@@ -19,3 +20,4 @@ class KSTestConfig:
 class HellingerConfig:
     max_hist_buckets: int = 30
     hist_avg_number_per_bucket: int = 4
+    min_n_buckets: int = 2

--- a/python/whylogs/viz/utils/drift_calculations.py
+++ b/python/whylogs/viz/utils/drift_calculations.py
@@ -229,6 +229,7 @@ def _get_hellinger_distance(
 ) -> Optional[ColumnDriftStatistic]:
     MAX_HIST_BUCKETS = HellingerConfig().max_hist_buckets
     HIST_AVG_NUMBER_PER_BUCKET = HellingerConfig().hist_avg_number_per_bucket
+    MIN_N_BUCKETS = HellingerConfig().min_n_buckets
     if not nbins:
         nbins = MAX_HIST_BUCKETS
     target_dist_metric = target_view_column.get_metric("distribution")
@@ -248,7 +249,14 @@ def _get_hellinger_distance(
     start = min([target_kll_sketch.get_min_value(), ref_kll_sketch.get_min_value()])
     end = max([target_kll_sketch.get_max_value(), ref_kll_sketch.get_max_value()])
     n = target_kll_sketch.get_n() + ref_kll_sketch.get_n()
-    bins, end = _calculate_bins(end=end, start=start, n=n, avg_per_bucket=HIST_AVG_NUMBER_PER_BUCKET, max_buckets=nbins)
+    bins, end = _calculate_bins(
+        end=end,
+        start=start,
+        n=n,
+        avg_per_bucket=HIST_AVG_NUMBER_PER_BUCKET,
+        max_buckets=nbins,
+        min_n_buckets=MIN_N_BUCKETS,
+    )
 
     target_pmf = target_kll_sketch.get_pmf(bins)
     ref_pmf = ref_kll_sketch.get_pmf(bins)

--- a/python/whylogs/viz/utils/drift_calculations.py
+++ b/python/whylogs/viz/utils/drift_calculations.py
@@ -225,11 +225,21 @@ def calculate_hellinger_distance(target_pmf: List[float], reference_pmf: List[fl
 
 
 def _get_hellinger_distance(
-    target_view_column: ColumnProfileView, reference_view_column: ColumnProfileView, nbins: Optional[int] = None
+    target_view_column: ColumnProfileView,
+    reference_view_column: ColumnProfileView,
+    nbins: Optional[int] = None,
+    config: Optional[HellingerConfig] = None,
 ) -> Optional[ColumnDriftStatistic]:
-    MAX_HIST_BUCKETS = HellingerConfig().max_hist_buckets
-    HIST_AVG_NUMBER_PER_BUCKET = HellingerConfig().hist_avg_number_per_bucket
-    MIN_N_BUCKETS = HellingerConfig().min_n_buckets
+    if config is None:
+        config = HellingerConfig()
+    MAX_HIST_BUCKETS = config.max_hist_buckets
+    HIST_AVG_NUMBER_PER_BUCKET = config.hist_avg_number_per_bucket
+    MIN_N_BUCKETS = config.min_n_buckets
+    if MIN_N_BUCKETS < 2:
+        warnings.warn(
+            "MIN_N_BUCKETS < 2 might lead to erroneous results for low-sized samples. Consider setting it to >=2."
+        )
+
     if not nbins:
         nbins = MAX_HIST_BUCKETS
     target_dist_metric = target_view_column.get_metric("distribution")


### PR DESCRIPTION
Changes to deal with some edge cases + testing for hellinger distance calculations.

- Single Values:
     Calculating hellinger for single values led to number of buckets equal to 1, which led to hellinger distance always 0. Added a min_n_buckets parameter to always have at least 2 buckets

 - min==max==0
    Calculating hellinger between single values [0] and [0] led to `math domain error`, due to trying to get the log of 0 in `get_min_intervals`. changed  `_calculate_bins` to deal with end==0

- empty sketches
   Added test to make sure an error is raised when empty sketches