### PR TITLE
Fix conversion of counters between v0 and v1 format

### DIFF
--- a/python/whylogs/migration/converters.py
+++ b/python/whylogs/migration/converters.py
@@ -202,16 +202,21 @@ def _extract_cardinality_metric(msg: ColumnMessageV0) -> CardinalityMetric:
 
 
 def _extract_schema_message_v0(col_prof: ColumnProfileView) -> SchemaMessageV0:
-    metric: TypeCountersMetric = col_prof.get_metric(TypeCountersMetric.get_namespace())
-    if metric is None:
-        return SchemaMessageV0()
+    types: TypeCountersMetric = col_prof.get_metric(TypeCountersMetric.get_namespace())
+    counts: ColumnCountsMetric = col_prof.get_metric(ColumnCountsMetric.get_namespace())
+    if types is None:
+        types = TypeCountersMetric.zero()
+
+    if counts is None:
+        counts = ColumnCountsMetric.zero()
 
     type_counts: Dict[int, int] = {}
-    type_counts[InferredType.INTEGRAL] = metric.integral.value
-    type_counts[InferredType.BOOLEAN] = metric.boolean.value
-    type_counts[InferredType.FRACTIONAL] = metric.fractional.value
-    type_counts[InferredType.STRING] = metric.string.value
-    type_counts[InferredType.UNKNOWN] = metric.object.value
+    type_counts[InferredType.INTEGRAL] = types.integral.value
+    type_counts[InferredType.BOOLEAN] = types.boolean.value
+    type_counts[InferredType.FRACTIONAL] = types.fractional.value
+    type_counts[InferredType.STRING] = types.string.value
+    type_counts[InferredType.UNKNOWN] = types.object.value
+    type_counts[InferredType.NULL] = counts.null.value
 
     msg_v0 = SchemaMessageV0(
         typeCounts=type_counts,


### PR DESCRIPTION
## Description

This fixes missing null counts when converting from v1 profiles to v0 which is currently the case when profiling within segments before uploading to WhyLabs.

The result of this bug is that missing value ratios would be incorrect with segmented profiles.

## Changes

- Correctly pull the null count from the columns counts metric and set the corresponding value in the v0 schema message's counts.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
