### PR TITLE
maintenance/0.7.x spark missing columnGroups.head fix

### DIFF
--- a/java/.bumpversion.cfg
+++ b/java/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0-b1
+current_version = 0.2.1-b0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/java/spark/src/main/scala/com/whylogs/spark/WhyLogs.scala
+++ b/java/spark/src/main/scala/com/whylogs/spark/WhyLogs.scala
@@ -149,7 +149,7 @@ case class WhyProfileSession(private val dataFrame: DataFrame,
     val remainingFields = fields.filter(!groupByWithTime.contains(_)).filter(!profileMetricsFields.contains(_))
     val columnGroups = remainingFields.grouped(100).toSeq
 
-    val primaryProfiles = coalesced.select((groupByWithTime ++ profileMetricsFields ++ columnGroups.head).map(col):_*)
+    val primaryProfiles = coalesced.select((groupByWithTime ++ profileMetricsFields).map(col):_*)
       .groupBy(groupByWithTime.map(col):_*)
       .agg(DatasetProfileAggregator(name, timeInMillis, timeColumn, groupByColumns, modelProfile)
         .toColumn
@@ -159,7 +159,6 @@ case class WhyProfileSession(private val dataFrame: DataFrame,
       Seq(primaryProfiles) ++
       // adding the rest of the columns
       columnGroups
-      .tail
       .map(cols => {
         val targetFields = groupByWithTime ++ cols
         val filteredDf = coalesced.select(targetFields.head, targetFields.tail: _*)

--- a/java/spark/src/main/scala/com/whylogs/spark/WhyLogs.scala
+++ b/java/spark/src/main/scala/com/whylogs/spark/WhyLogs.scala
@@ -182,7 +182,7 @@ case class WhyProfileSession(private val dataFrame: DataFrame,
           modelId: String,
           apiKey: String,
           endpoint: String = "https://api.whylabsapp.com",
-          sslCaCertData: String = null,
+          sslCaCertData: String = null
          ): Unit = {
     val df = aggProfiles(timestamp = timestampInMs)
 
@@ -197,7 +197,7 @@ case class WhyProfileSession(private val dataFrame: DataFrame,
                         apiKey: String,
                         rows: Iterator[Row],
                         endpoint: String,
-                        sslCaCertData: String = null,
+                        sslCaCertData: String = null
                       ): Unit = {
     val client: ApiClient = new ApiClient()
     client.setBasePath(endpoint)


### PR DESCRIPTION
## Description

If you logged performance metrics and no other columns the spark profiling session in v0 would try to split up the set of non-performance metric related columns into batches of 100, and would access the first batch via the Sequence's head (which is empty and throws):

```
java.util.NoSuchElementException: head of empty stream
```

## Changes

- Instead of pulling the head into the batch here, we always process batches of the "other" columns in the second step of the sequence, which already does a map over the sequence and handles the empty case.

tested on Databricks cluster and generating performance metrics with other columns and with only the prediction, target and score columns.

Note: this is a whylogs v0 spark fix, and covers scala/java and whyspark (v0 java + python).

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
