### PR TITLE
Support computing segmented performance metrics in top level API

### DIFF
--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -3208,7 +3208,7 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
 ]
 livereload = [
-    {file = "livereload-2.6.3.tar.gz", hash = "sha256:776f2f865e59fde56490a56bcc6773b6917366bce0c267c60ee8aaf1a0959869"},
+ {file = "livereload-2.6.3-py2.py3-none-any.whl", hash = "sha256:ad4ac6f53b2d62bb6ce1a5e6e96f1f00976a32348afedcb4b6d68df2a1d346e4"},
 ]
 markdown-it-py = [
     {file = "markdown-it-py-2.1.0.tar.gz", hash = "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"},

--- a/python/tests/core/test_model_performance_metrics.py
+++ b/python/tests/core/test_model_performance_metrics.py
@@ -235,7 +235,7 @@ def test_profile_top_level_api_segmented_performance():
     d = {
         "col1": [i for i in range(input_rows)],
         "col2": [i * i * 1.1 for i in range(input_rows)],
-        segment_column: ["seg_"+str(i % number_of_segments) for i in range(input_rows)],
+        segment_column: ["seg_" + str(i % number_of_segments) for i in range(input_rows)],
         prediction_column: [f"x{str(i%number_of_classes)}" for i in range(input_rows)],
         target_column: [f"x{str((i%5)%number_of_classes)}" for i in range(input_rows)],
     }
@@ -243,7 +243,11 @@ def test_profile_top_level_api_segmented_performance():
     df = pd.DataFrame(data=d)
     segmented_schema = DatasetSchema(segments=segment_on_column(segment_column))
     segmented_classification_results = log_classification_metrics(
-        df, target_column=target_column, prediction_column=prediction_column, schema=segmented_schema, log_full_data=True
+        df,
+        target_column=target_column,
+        prediction_column=prediction_column,
+        schema=segmented_schema,
+        log_full_data=True,
     )
     segmented_regression_results = log_regression_metrics(
         df, target_column="col1", prediction_column="col2", schema=segmented_schema
@@ -260,9 +264,9 @@ def test_profile_top_level_api_segmented_performance():
     first_segment: Segment = next(iter(segments))
     first_segment_profile = segmented_classification_results.profile(first_segment)
 
-    #assert first_segment.key == ("0",)
+    # assert first_segment.key == ("0",)
     assert first_segment_profile is not None
-    
+
     metrics1: ModelPerformanceMetrics = first_segment_profile.model_performance_metrics
     assert metrics1 is not None
     assert metrics1.confusion_matrix is not None

--- a/python/whylogs/api/logger/__init__.py
+++ b/python/whylogs/api/logger/__init__.py
@@ -4,8 +4,18 @@ from typing import Any, Dict, Optional
 from typing_extensions import Literal
 
 from whylogs.api.logger.logger import Logger
-from whylogs.api.logger.result_set import ProfileResultSet, ResultSet, ResultSetReader
+from whylogs.api.logger.result_set import (
+    ProfileResultSet,
+    ResultSet,
+    ResultSetReader,
+    SegmentedResultSet,
+)
 from whylogs.api.logger.rolling import TimedRollingLogger
+from whylogs.api.logger.segment_processing import (
+    _get_segment_from_group_key,
+    _grouped_dataframe,
+    _log_segment,
+)
 from whylogs.api.logger.transient import TransientLogger
 from whylogs.core import DatasetProfile, DatasetSchema
 from whylogs.core.model_performance_metrics.model_performance_metrics import (
@@ -40,6 +50,48 @@ def _log_with_metrics(
     return results
 
 
+def _performance_metric(pandas, perf_columns, metric_name):
+    performance_values = {
+        p: pandas[perf_columns[p]].to_list() if perf_columns[p] in pandas else None for p in perf_columns
+    }
+    model_performance_metrics = ModelPerformanceMetrics()
+    metric_function = getattr(model_performance_metrics, metric_name)
+    metric_function(**performance_values)
+    return model_performance_metrics
+
+
+def _segmented_performance_metrics(log_full_data, schema, data, performance_column_mapping, performance_metric):
+    segmented_profiles = dict()
+    segment_partitions = list()
+    if log_full_data:
+        for partition_name in schema.segments:
+            partition = schema.segments.get(partition_name)
+            diagnostic_logger.info(f"Processing partition {partition_name}")
+            partition_segments = _log_segment(partition, schema, pandas=data)
+            diagnostic_logger.info(f"Partition {partition_name} had {len(partition_segments)} segments.")
+            segmented_profiles[partition.id] = partition_segments
+
+    for partition_name in schema.segments:
+        partition = schema.segments.get(partition_name)
+        grouped_data = _grouped_dataframe(partition, pandas=data)
+        partition_segments = segmented_profiles.get(partition.id) or dict()
+        for group_key in grouped_data.groups.keys():
+            pandas_segment = grouped_data.get_group(group_key)
+            segment_key = _get_segment_from_group_key(group_key, partition.id)
+            diagnostic_logger.info(f"Computing {performance_metric} for segment {partition_name}->{segment_key}")
+
+            profile = partition_segments.get(segment_key) or DatasetProfile(schema)
+            model_performance_metrics = _performance_metric(
+                pandas_segment, performance_column_mapping, performance_metric
+            )
+            profile.add_model_performance_metrics(model_performance_metrics)
+            partition_segments[segment_key] = profile
+        segmented_profiles[partition.id] = partition_segments
+        segment_partitions.append(partition)
+
+    return SegmentedResultSet(segments=segmented_profiles, partitions=segment_partitions)
+
+
 def log_classification_metrics(
     data: pd.DataFrame,
     target_column: str,
@@ -63,16 +115,19 @@ def log_classification_metrics(
         passed
     """
 
+    perf_column_mapping = {"predictions": prediction_column, "targets": target_column, "scores": score_column}
+
     if schema and schema.segments:
-        diagnostic_logger.warning(
-            "Model performance metrics do not yet support segmentation, unsegmented metrics will be computed"
+        return _segmented_performance_metrics(
+            log_full_data,
+            schema=schema,
+            data=data,
+            performance_column_mapping=perf_column_mapping,
+            performance_metric="compute_confusion_matrix",
         )
 
-    model_performance_metrics = ModelPerformanceMetrics()
-    model_performance_metrics.compute_confusion_matrix(
-        predictions=data[prediction_column].to_list(),
-        targets=data[target_column].to_list(),
-        scores=data[score_column].to_list() if score_column else None,
+    model_performance_metrics = _performance_metric(
+        pandas=data, perf_columns=perf_column_mapping, metric_name="compute_confusion_matrix"
     )
 
     return _log_with_metrics(data=data, metrics=model_performance_metrics, schema=schema, include_data=log_full_data)
@@ -99,19 +154,24 @@ def log_regression_metrics(
         assocaited scores for each inferred, all values set to 1 if not
         passed
     """
+    perf_column_mapping = {"predictions": prediction_column, "targets": target_column}
 
     if schema and schema.segments:
-        diagnostic_logger.warning(
-            "Model performance metrics do not yet support segmentation, unsegmented metrics will be computed"
+        return _segmented_performance_metrics(
+            log_full_data,
+            schema=schema,
+            data=data,
+            performance_column_mapping=perf_column_mapping,
+            performance_metric="compute_regression_metrics",
         )
 
-    model_performance_metrics = ModelPerformanceMetrics()
-    model_performance_metrics.compute_regression_metrics(
-        predictions=data[prediction_column].to_list(),
-        targets=data[target_column].to_list(),
+    model_performance_metrics = _performance_metric(
+        pandas=data, perf_columns=perf_column_mapping, metric_name="compute_regression_metrics"
     )
 
-    return _log_with_metrics(data=data, metrics=model_performance_metrics, schema=schema, include_data=log_full_data)
+    result = _log_with_metrics(data=data, metrics=model_performance_metrics, schema=schema, include_data=log_full_data)
+
+    return result
 
 
 def read(path: str) -> ResultSet:

--- a/python/whylogs/api/logger/__init__.py
+++ b/python/whylogs/api/logger/__init__.py
@@ -169,9 +169,7 @@ def log_regression_metrics(
         pandas=data, perf_columns=perf_column_mapping, metric_name="compute_regression_metrics"
     )
 
-    result = _log_with_metrics(data=data, metrics=model_performance_metrics, schema=schema, include_data=log_full_data)
-
-    return result
+    return _log_with_metrics(data=data, metrics=model_performance_metrics, schema=schema, include_data=log_full_data)
 
 
 def read(path: str) -> ResultSet:


### PR DESCRIPTION
## Description

The `log_regression_metrics` and `log_classification_metrics` methods accept a DatasetSchema but didn't support computing the performance metrics on segmentation schemes.

This change supports segmented performance metrics from these top level methods, like this:
```
results = log_classification_metrics(
        df,
        target_column=target_column,
        prediction_column=prediction_column,
        schema=DatasetSchema(segments=segment_on_column("feature_1"))
    )

```
## Changes

- minor refactor to reduce duplication between different perf metrics.
- removed error on segments defined in perf metrics
- implemented tests and segmented perf metrics calculation.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
