### PR TITLE
Fix UnicodeRangeMetric submetric updates

### DIFF
--- a/python/tests/core/metrics/test_unicode_range.py
+++ b/python/tests/core/metrics/test_unicode_range.py
@@ -2,8 +2,10 @@ import math
 from typing import Any, Dict
 
 import numpy as np
+import pandas as pd
 import pytest
 
+import whylogs as why
 from whylogs.core.configs import SummaryConfig
 from whylogs.core.dataset_profile import DatasetProfile
 from whylogs.core.datatypes import DataType
@@ -172,3 +174,14 @@ def test_unicode_range_metric_in_profile() -> None:
         if col1_prof:
             assert col1_prof._metrics.keys() == col2_prof._metrics.keys()
             assert _NaNfully_equal(col1_prof.to_summary_dict(), col2_prof.to_summary_dict())
+
+
+def test_correct_in_column_view() -> None:
+    d = {"col_a": [1, 2], "col_b": [3.0, 4.0], "col_c": ["a", "b"]}
+    results = why.log(pd.DataFrame(d), schema=_UNICODE_SCHEMA)
+    view = results.view()
+    col_view = view.get_column("col_c")
+    summary = col_view.to_summary_dict()
+    assert summary["unicode_range/string_length:ints/min"] == 1
+    assert summary["unicode_range/alpha:distribution/mean"] == 1
+    assert summary["unicode_range/alpha:ints/min"] == 1

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -49,8 +49,8 @@ class MetricConfig:
             "emoticon": (0x1F600, 0x1F64F),
             "control": (0x00, 0x1F),
             "digits": (0x30, 0x39),
-            "latin-lower": (0x41, 0x5A),
-            "latin-upper": (0x61, 0x7A),
+            "latin-upper": (0x41, 0x5A),
+            "latin-lower": (0x61, 0x7A),
             "basic-latin": (0x00, 0x7F),
             "extended-latin": (0x0080, 0x02AF),
         }

--- a/python/whylogs/core/metrics/unicode_range.py
+++ b/python/whylogs/core/metrics/unicode_range.py
@@ -99,13 +99,12 @@ class UnicodeRangeMetric(MultiMetric):
             for range_name, range_count in range_counter.items():
                 range_data[range_name].append(range_count)
 
-        submetric_col = PreprocessedColumn()
-        submetric_col.list.ints = lengths
+        submetric_col = PreprocessedColumn.apply(lengths)
         for metric in self.submetrics[_STRING_LENGTH].values():
             metric.columnar_update(submetric_col)
 
         for range_name, range_list in range_data.items():
-            submetric_col.list.ints = range_list
+            submetric_col = PreprocessedColumn.apply(range_list)
             for metric in self.submetrics[range_name].values():
                 metric.columnar_update(submetric_col)
 


### PR DESCRIPTION
## Description

This fixes how `UnicodeRangeMetric` passes data to its submetrics.  Some submetrics required data computed in `PreprocessedColumn.apply()`, so they were upset with the manually constructed preprocessed columns.

Also corrects the upper/lower case Unicode range definitions.

## Changes

- Pass data to submetrics with `PreprocessedColumn::apply()`
- Reverses the upper/lower case Unicode range definitions
