### PR TITLE
Fix lack of site.getsitepackages in virtualenv

### DIFF
--- a/python/whylogs/api/usage_stats/__init__.py
+++ b/python/whylogs/api/usage_stats/__init__.py
@@ -10,7 +10,7 @@ import sys
 import uuid
 from datetime import datetime
 from threading import Thread
-from typing import Any, Dict
+from typing import Any, Dict, List
 from urllib import request
 
 import whylogs
@@ -26,8 +26,18 @@ ANALYTICS_OPT_OUT = "WHYLOGS_NO_ANALYTICS"
 # Flag to disable it internally
 _TELEMETRY_DISABLED = False
 _TRACKED_EVENTS: Dict[str, bool] = {}
+_SITE_PACKAGES: List[str] = []
 
-_SITE_PACKAGES = site.getsitepackages()
+try:
+    # fix for virtualenv lack of definition for getsitepackages
+    if hasattr(site, "getsitepackages"):
+        _SITE_PACKAGES = site.getsitepackages()
+    else:
+        from distutils.sysconfig import get_python_lib
+
+        _SITE_PACKAGES = [get_python_lib()]
+except:  # noqa
+    logger.debug("Encountered exception when checking site packages")
 
 if os.getenv(ANALYTICS_OPT_OUT) is not None:
     logger.debug("Opted out of usage statistics. Skipping.")


### PR DESCRIPTION
## Description

Inside virtualenv environments the site module can be missing `getsitepackages` so we should check and use the single python library in this case. The calls to check for existence of libraries on a system should be restricted to the active environment so this leads to a better representation.

Also wrapped the calls in try/except as we don't want to block usage if the usage stats calls fail.

## Changes

- check site has getsitepackages before calling it
- fallback to get_python_lib
- try/except and log if anything fails.

## Related

Closes #1041 

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
