### PR TITLE
Support tagging columns as outputs

### DIFF
--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -3335,7 +3335,7 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f"},
 ]
 livereload = [
-    {file = "livereload-2.6.3.tar.gz", hash = "sha256:776f2f865e59fde56490a56bcc6773b6917366bce0c267c60ee8aaf1a0959869"},
+    {file = "livereload-2.6.3-py2.py3-none-any.whl", hash = "sha256:ad4ac6f53b2d62bb6ce1a5e6e96f1f00976a32348afedcb4b6d68df2a1d346e4"},
 ]
 markdown-it-py = [
     {file = "markdown-it-py-2.1.0.tar.gz", hash = "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"},

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -498,7 +498,6 @@ class WhyLabsWriter(Writer):
             raise e
 
     def _get_existing_column_schema(self, model_api_instance, column_name) -> Optional[ColumnSchema]:
-
         try:
             # TODO: remove when whylabs supports merge writes.
             existing_schema = model_api_instance.get_entity_schema_column(


### PR DESCRIPTION
## Description

After uploading whylogs profiles or performance metrics, we often want to have the columns classified as input or outputs for monitoring and analysis. This change adds a method that lets practioners tag columns from previously uploaded profiles as being outputs. 

## Changes

- Add new method to WhyLabsWriter to tag columns
- convenience method for tagging output columns

## Example

If you previously ran an example notebook such as: https://github.com/whylabs/whylogs/blob/mainline/python/examples/integrations/writers/Writing_Classification_Performance_Metrics_to_WhyLabs.ipynb

Then you have profiles already uploaded to Whylabs, then you can simply run the following to set the "rating" field as an output.

```python
from whylogs.api.writer.whylabs import WhyLabsWriter
whylabs_writer = WhyLabsWriter() 
whylabs_writer.tag_output_columns(["rating", "output_discount"])
```

In this example the "output_discount" column is already treated as an output and so the schema is not updated. The returned status for this method call above would be:

```
(True,
 "{'rating': 'rating updated from input to output', 'output_discount': 'column output_discount was already classified output.'}")
```


- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
