### PR TITLE
fix make format-fix

### DIFF
--- a/.github/workflows/whylogs-ci.yml
+++ b/.github/workflows/whylogs-ci.yml
@@ -82,9 +82,6 @@ jobs:
           *) echo "Incorrect Poetry virtualenv." && exit 1 ;;
           esac
 
-      - name: Run pre-commit hooks
-        run: make pre-commit
-
       - name: Run build, style, and lint checks
         run: make release
 

--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ minimum_pre_commit_version: 2.8.0
 default_stages: [commit, push, manual]
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1a1
     hooks:
       - id: black
         exclude: python/whylogs/core/proto/|python/docs/|python/whylogs/viz/html/|java

--- a/python/Makefile
+++ b/python/Makefile
@@ -19,7 +19,7 @@ build.proto.v0.dir := whylogs/core/proto/v0
 build.proto.v0 := $(patsubst $(src.proto.v0.dir)/%.proto,$(build.proto.v0.dir)/%_pb2.py,$(src.proto.v0))
 default: dist
 
-release: format lint test dist ## Compile distribution files and run all tests and checks.
+release: pre-commit test dist ## Compile distribution files and run all tests and checks.
 
 pre-commit: proto
 	@$(call i, Running pre-commit checks)
@@ -135,16 +135,12 @@ lint-fix: ## Automatically fix linting issues.
 	poetry run autoflake --in-place --remove-all-unused-imports --remove-unused-variables $(src.python) $(tst.python)
 
 format: ## Check style formatting.
-	@$(call i, Checking import formatting)
-	poetry run isort --check-only .
-	@$(call i, Checking code formatting)
-	poetry run black --check .
+	@$(call w, format is deprecated running pre-commit instead)
+	poetry run pre-commit run --all-files
 
-format-fix: ## Fix formatting with black. This updates files.
-	@$(call i, Formatting imports)
-	poetry run isort .
-	@$(call i, Formatting code)
-	poetry run black .
+format-fix: ## Fix formatting with pre-commit (black, isort, flake, + configured hooks).
+	@$(call w, format-fix is deprecated running pre-commit instead)
+	poetry run pre-commit run --all-files
 
 test: dist ## Run unit tests.
 	@$(call i, Running tests)

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -3335,7 +3335,7 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f"},
 ]
 livereload = [
-    {file = "livereload-2.6.3.tar.gz", hash = "sha256:776f2f865e59fde56490a56bcc6773b6917366bce0c267c60ee8aaf1a0959869"},
+    {file = "livereload-2.6.3-py2.py3-none-any.whl", hash = "sha256:ad4ac6f53b2d62bb6ce1a5e6e96f1f00976a32348afedcb4b6d68df2a1d346e4"},
 ]
 markdown-it-py = [
     {file = "markdown-it-py-2.1.0.tar.gz", hash = "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"},

--- a/python/tests/core/constraints/factories/test_cardinality_metrics.py
+++ b/python/tests/core/constraints/factories/test_cardinality_metrics.py
@@ -11,7 +11,7 @@ def test_distinct_number_in_range(builder):
         ("legs distinct values estimate between 0.0 and 4.0 (inclusive)", 1, 0, None),
         ("legs distinct values estimate between 0.1 and 2.0 (inclusive)", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])
 
 
@@ -25,5 +25,5 @@ def test_distinct_number_in_range_with_nans(nan_builder):
         ("a distinct values estimate between 0 and 5.0 (inclusive)", 1, 0, None),
         ("a distinct values estimate between 2.2 and 5.0 (inclusive)", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])

--- a/python/tests/core/constraints/factories/test_count_metrics.py
+++ b/python/tests/core/constraints/factories/test_count_metrics.py
@@ -35,7 +35,7 @@ def test_count_below_number(builder, nan_builder):
         ("count of a lower than 10", 1, 0, None),
         ("count of a lower than 1", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])
 
 
@@ -49,7 +49,7 @@ def test_null_values_below_number(builder, nan_builder):
         ("null values of legs lower than 1", 1, 0, None),
         ("null values of weight lower than 1", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])
 
     nan_builder.add_constraint(null_values_below_number(column_name="a", number=10))
@@ -60,7 +60,7 @@ def test_null_values_below_number(builder, nan_builder):
         ("null values of a lower than 10", 1, 0, None),
         ("null values of a lower than 3", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])
 
 
@@ -74,7 +74,7 @@ def test_null_percentage_below_number(builder, nan_builder):
         ("null percentage of weight lower than 1.0", 1, 0, None),
         ("null percentage of weight lower than 0.1", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])
 
     nan_builder.add_constraint(null_percentage_below_number(column_name="a", number=1.0))
@@ -85,5 +85,5 @@ def test_null_percentage_below_number(builder, nan_builder):
         ("null percentage of a lower than 1.0", 1, 0, None),
         ("null percentage of a lower than 0.1", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])

--- a/python/tests/core/constraints/factories/test_distribution_metrics.py
+++ b/python/tests/core/constraints/factories/test_distribution_metrics.py
@@ -89,7 +89,7 @@ def test_greater_than_number(builder, nan_builder, empty_builder):
         ("animal greater than number 0.0", 1, 0, None),
         ("animal greater than number 0.5", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])
 
     nan_builder.add_constraint(greater_than_number(column_name="a", number=2.2, skip_missing=False))
@@ -113,7 +113,7 @@ def test_smaller_than_number(builder, nan_builder, empty_builder):
         ("animal smaller than number 0.0", 1, 0, None),
         ("animal smaller than number 0.5", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])
 
     nan_builder.add_constraint(smaller_than_number(column_name="a", number=2.2, skip_missing=False))
@@ -137,7 +137,7 @@ def test_mean_between_range(builder, nan_builder):
         ("animal mean between 0.0 and 1.0 (inclusive)", 1, 0, None),
         ("animal mean between 0.0 and 1.3 (inclusive)", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])
 
     nan_builder.add_constraint(mean_between_range(column_name="a", lower=0.0, upper=1.3, skip_missing=False))
@@ -159,7 +159,7 @@ def test_stddev_between_range(builder, nan_builder):
         ("animal standard deviation between 0.0 and 1.0 (inclusive)", 1, 0, None),
         ("animal standard deviation between 0.0 and 1.3 (inclusive)", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])
 
     nan_builder.add_constraint(stddev_between_range(column_name="a", lower=0.0, upper=1.3, skip_missing=False))
@@ -189,7 +189,7 @@ def test_quantile_between_range(builder, nan_builder):
         ("animal 0.5-th quantile value between 0.0 and 5.2 (inclusive)", 1, 0, None),
         ("animal 0.5-th quantile value between 0.0 and 5.0 (inclusive)", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])
 
     nan_builder.add_constraint(

--- a/python/tests/core/constraints/factories/test_frequent_items.py
+++ b/python/tests/core/constraints/factories/test_frequent_items.py
@@ -23,7 +23,7 @@ def test_frequent_strings_in_reference_set(builder):
         (f"animal values in set {ref_set}", 1, 0, None),
         (f"animal values in set {other_set}", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])
 
 
@@ -45,5 +45,5 @@ def test_n_most_common_items_in_set(builder):
         (f"animal 1-most common items in set {ref_set}", 1, 0, None),
         (f"animal 1-most common items in set {other_set}", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])

--- a/python/tests/core/constraints/factories/test_type_metrics.py
+++ b/python/tests/core/constraints/factories/test_type_metrics.py
@@ -24,5 +24,5 @@ def test_is_nullable_type(builder):
         ("weight is nullable boolean", 0, 1, None),
         ("weight is nullable object", 0, 1, None),
     ]
-    for (x, y) in zip(constraint.report(), constraint.generate_constraints_report()):
+    for x, y in zip(constraint.report(), constraint.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])

--- a/python/tests/core/constraints/test_metric_constraints.py
+++ b/python/tests/core/constraints/test_metric_constraints.py
@@ -110,7 +110,7 @@ def test_constraints_builder(pandas_constraint_dataframe) -> None:
     assert len(report_results) == 2
     # ReportResult(name, passed, failed, summary)
     assert report_results[0] == ("legs less than 12", 1, 0, None)
-    for (x, y) in zip(constraints.report(), constraints.generate_constraints_report()):
+    for x, y in zip(constraints.report(), constraints.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])
 
 
@@ -198,7 +198,7 @@ def test_same_constraint_on_multiple_columns(profile_view):
             ("greater_than_zero", 0, 1, None),
         ]
     )
-    for (x, y) in zip(constraints.report(), constraints.generate_constraints_report()):
+    for x, y in zip(constraints.report(), constraints.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])
 
 
@@ -217,5 +217,5 @@ def test_constraints_report(pandas_constraint_dataframe) -> None:
     assert report[0].failed == 1
     assert report[0].summary["metric"] == "distribution"
     assert report[0].summary["min"] == 0
-    for (x, y) in zip(constraints.report(), constraints.generate_constraints_report()):
+    for x, y in zip(constraints.report(), constraints.generate_constraints_report()):
         assert (x[0], x[1], x[2]) == (y[0], y[1], y[2])

--- a/python/tests/core/test_declarative_schema.py
+++ b/python/tests/core/test_declarative_schema.py
@@ -173,7 +173,7 @@ def test_resolvers() -> None:
         pass
 
     data = {"column_1": 3.14, "column_2": "lmno", "column_3": 42, "column_4": UnknownType()}
-    for (reference_resolver, declarative_resolver) in params:
+    for reference_resolver, declarative_resolver in params:
         reference_results = why.log(row=data, schema=DatasetSchema(resolvers=reference_resolver)).view()
         declarative_standard_schema = DeclarativeSchema(declarative_resolver)
         declarative_results = why.log(row=data, schema=declarative_standard_schema).view()

--- a/python/tests/core/validators/test_condition_validator.py
+++ b/python/tests/core/validators/test_condition_validator.py
@@ -99,7 +99,6 @@ def test_condition_validator(credit_card_validator, transcriptions) -> None:
 
 
 def test_condition_validator_dataframe(credit_card_validator, transcriptions):
-
     df = pd.DataFrame(data=transcriptions, columns=["transcriptions"])
     validators = {"transcriptions": [credit_card_validator]}
 

--- a/python/tests/viz/test_profile_visualizer.py
+++ b/python/tests/viz/test_profile_visualizer.py
@@ -140,7 +140,6 @@ def test_viz_constraints_report(
     max_less_than_equal_constraints: Constraints,
     tmp_path: str,
 ) -> None:
-
     test_output = os.path.join(tmp_path, "b18")
     visualization.write(
         rendered_html=visualization.constraints_report(max_less_than_equal_constraints),

--- a/python/tests/viz/utils/test_drift_calculations.py
+++ b/python/tests/viz/utils/test_drift_calculations.py
@@ -90,7 +90,6 @@ def test_hellinger_on_empty_sketch():
 
 @pytest.mark.parametrize("target_col,reference_col,result", [([0], [5], 1.0), ([5], [5], 0.0), ([0], [0], 0.0)])
 def test_hellinger_single_value(target_col, reference_col, result):
-
     target = pd.DataFrame(data={"col": target_col})
     ref = pd.DataFrame(data={"col": reference_col})
 


### PR DESCRIPTION
## Description

We have both make format and pre-commit, but the pre-commit checks perform a larger scope of checks and used different versions of some of the tools (such as black) in the .pre-commit-config.yaml file vs poetry.lock file leading to inconsistent lint and formatting checks.

whylogs will deprecate the make format target in favor of make pre-commit, and align the versions of the hooks used with those installed in developer environments via poetry.

## Changes

- Deprecate make format and make format fix with warning and call make pre-commit for both of these.
- Add pre-commit as a precondition of make release (replacing make format and lint).
- Remove redundant format and lint step in the ci since these are run again as part of make release
- update version of black in .pre-commit-config.yaml to match what we run in poetry environment.
- formatting fixes so the repo complies with updated black and ci.

## Related

fixes #1036 

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
