### PR TITLE
pyspark segments support

### DIFF
--- a/python/tests/api/pyspark/experimental/test_profiler_function.py
+++ b/python/tests/api/pyspark/experimental/test_profiler_function.py
@@ -37,8 +37,6 @@ def _assert_segmented_result_sets_are_equal(results_a: SegmentedResultSet, resul
         if isinstance(segmented_view_b, DatasetProfile):
             segmented_view_b = segmented_view_b.view()
         assert isinstance(segmented_view_b, DatasetProfileView)
-        if segmented_view_a is None and segmented_view_b is None:
-            return
         if segmented_view_a is None or segmented_view_b is None:
             assert segmented_view_a == segmented_view_b
 

--- a/python/tests/api/pyspark/experimental/test_profiler_function.py
+++ b/python/tests/api/pyspark/experimental/test_profiler_function.py
@@ -4,24 +4,65 @@ from typing import Dict
 
 import pytest
 
+import whylogs as why
+from whylogs.api.logger.result_set import SegmentedResultSet
 from whylogs.api.pyspark.experimental import (
     collect_column_profile_views,
     collect_dataset_profile_view,
     column_profile_bytes_aggregator,
     whylogs_pandas_map_profiler,
+    collect_segmented_results,
 )
-from whylogs.core import ColumnProfileView, DatasetSchema, Resolver
+from whylogs.core import ColumnProfileView, DatasetProfile, DatasetSchema, Resolver
 from whylogs.core.metrics import StandardMetric
+from whylogs.core.segmentation_partition import SegmentFilter, segment_on_column
 from whylogs.core.stubs import pd as pd
 from whylogs.core.view.dataset_profile_view import DatasetProfileView
+from whylogs.core.view.segmented_dataset_profile_view import SegmentedDatasetProfileView
 
 TEST_LOGGER = getLogger(__name__)
 
+def _assert_segmented_result_sets_are_equal(results_a: SegmentedResultSet, results_b: SegmentedResultSet) -> None:
+    assert type(results_a) == type(results_b)
+
+    profiles_a = results_a.get_writables()
+    profiles_b = results_b.get_writables()
+    assert len(profiles_a) == len(profiles_b)
+    for profile_a in profiles_a:
+        assert isinstance(profile_a, SegmentedDatasetProfileView)
+        segment = profile_a.segment
+        segmented_view_a = profile_a.profile_view
+        segmented_view_b = results_b.profile(segment)
+        if isinstance(segmented_view_b, DatasetProfile):
+            segmented_view_b = segmented_view_b.view()
+        assert isinstance(segmented_view_b, DatasetProfileView)
+        if segmented_view_a is None and segmented_view_b is None:
+            return
+        if segmented_view_a is None or segmented_view_b is None:
+            assert segmented_view_a == segmented_view_b
+
+        columns_in_a = segmented_view_a.get_columns()
+        columns_in_b = segmented_view_b.get_columns()
+        if not columns_in_b:
+            assert columns_in_a == columns_in_b
+
+        assert columns_in_a.keys() == columns_in_b.keys()
+
+        for col_name in columns_in_a:
+            assert col_name in columns_in_b
+            assert (col_name, columns_in_a[col_name].to_protobuf()) == (col_name, columns_in_b[col_name].to_protobuf())
+
+        assert segmented_view_a.creation_timestamp.timestamp() == pytest.approx(segmented_view_b.creation_timestamp.timestamp())
+        assert segmented_view_a.dataset_timestamp.timestamp() == pytest.approx(segmented_view_b.dataset_timestamp.timestamp())
 
 class TestPySpark(object):
     @pytest.fixture()
     def test_columns(self):
         return ["0", "1", "2", "3"]
+
+    @pytest.fixture()
+    def segment_columns(self):
+        return ["A", "B", "C", "D"]
 
     @pytest.fixture()
     def input_df(self, test_columns, spark_session):
@@ -34,6 +75,19 @@ class TestPySpark(object):
             schema=test_columns,
         )
         return input_df
+
+    @pytest.fixture()
+    def segment_df(self, segment_columns, spark_session):
+        segment_df = spark_session.createDataFrame(
+            data=[
+                [0, 'test', 2.0, 3.0],
+                [1, 'test', 2.1, 3.1],
+                [0, 'eval', 2.3, 3.3],
+                [1, 'reserved', 2.4, 3.4],
+            ],
+            schema=segment_columns,
+        )
+        return segment_df
 
     def test_profile_mapper_function(self, input_df):
         # TODO: consider a constant for this, or better encapsulation.
@@ -82,6 +136,31 @@ class TestPySpark(object):
         assert profile_view.get_column("1").get_metric_names() == []
         assert profile_view.get_column("2").get_metric_names() == []
         assert profile_view.get_column("3").get_metric_names() == []
+
+    def test_profile_segments_same_in_pyspark_and_local_python_log(self, segment_df):
+        segment_column = "B"
+ 
+        d = {
+            "A" : [0,1,0,1],
+            "B" : ['test','test','eval','reserved'],
+            "C" : [2.0,2.1,2.3,2.4],
+            "D" : [3.0,3.1,3.3,3.4],
+        }
+
+        df = pd.DataFrame(data=d)
+        test_segments = segment_on_column(segment_column)
+        test_segments[segment_column].filter = SegmentFilter(filter_function=lambda df: df.C > 2.0)
+        segmented_schema = DatasetSchema(segments=test_segments)
+
+        local_results = why.log(df, schema=segmented_schema)
+        pyspark_results = collect_segmented_results(input_df=segment_df, schema=segmented_schema)
+
+        assert pyspark_results is not None
+        assert local_results is not None
+        assert pyspark_results.count == local_results.count
+        _assert_segmented_result_sets_are_equal(pyspark_results, local_results)
+
+
 
     def test_collect_dataset_profile_view(self, input_df):
         profile_view = collect_dataset_profile_view(input_df=input_df)

--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -383,7 +383,9 @@ class SegmentedResultSet(ResultSet):
                 if hasattr(profile, "view"):
                     view = profile.view()
                 else:
-                    logger.error(f"Unexpected type: {type(profile)} -> {profile}, cannot check for model performance metrics.")
+                    logger.error(
+                        f"Unexpected type: {type(profile)} -> {profile}, cannot check for model performance metrics."
+                    )
                     return None
             return view.model_performance_metrics
         return None

--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
 from logging import getLogger
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from whylogs.api.reader import Reader, Readers
 from whylogs.api.writer import Writer, Writers
@@ -11,9 +11,105 @@ from whylogs.core.metrics.metrics import Metric
 from whylogs.core.model_performance_metrics import ModelPerformanceMetrics
 from whylogs.core.segmentation_partition import SegmentationPartition
 from whylogs.core.utils import ensure_timezone
+from whylogs.core.view.dataset_profile_view import _MODEL_PERFORMANCE
 from whylogs.core.view.segmented_dataset_profile_view import SegmentedDatasetProfileView
 
 logger = getLogger(__name__)
+
+
+def _merge_metrics(
+    lhs_metrics: Optional[Dict[str, Any]], rhs_metrics: Optional[Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    if not rhs_metrics:
+        return lhs_metrics
+    if not lhs_metrics:
+        return rhs_metrics
+    lhs_keys = lhs_metrics.keys()
+    rhs_keys = rhs_metrics.keys()
+    merged_metrics: Dict[str, Any] = dict()
+    lhs_only = lhs_keys - rhs_keys
+    rhs_only = rhs_keys - lhs_keys
+    intersection_keys = lhs_keys & rhs_keys
+    for key in lhs_only:
+        merged_metrics[key] = lhs_metrics[key]
+
+    for key in rhs_only:
+        merged_metrics[key] = rhs_metrics[key]
+
+    for key in intersection_keys:
+        merged_metrics[key] = lhs_metrics[key].merge(rhs_metrics[key])
+
+    return merged_metrics
+
+
+def _accumulate_properties(acc: Optional[Dict[str, Any]], props: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if not props:
+        return acc
+    if acc is None:
+        acc = dict()
+    intersection_keys = acc.keys() & props.keys()
+    for key in intersection_keys:
+        if acc[key] != props[key]:
+            logger.warning(f"Merging result properties collision, using {key}:{acc[key]} and dropping {props[key]}.")
+    acc.update(props)
+    return acc
+
+
+def _merge_segments(
+    lhs_segments: Dict[Segment, Union[DatasetProfile, DatasetProfileView]],
+    rhs_segments: Dict[Segment, Union[DatasetProfile, DatasetProfileView]],
+) -> Dict[Segment, DatasetProfileView]:
+    lhs_keys = lhs_segments.keys()
+    rhs_keys = rhs_segments.keys()
+    merged_segments: Dict[Segment, DatasetProfileView] = dict()
+    lhs_only = lhs_keys - rhs_keys
+    rhs_only = rhs_keys - lhs_keys
+    intersection_keys = lhs_keys & rhs_keys
+    for key in lhs_only:
+        left_value = lhs_segments[key]
+        left_view = left_value if isinstance(left_value, DatasetProfileView) else left_value.view()
+        merged_segments[key] = left_view
+
+    for key in rhs_only:
+        right_value = rhs_segments[key]
+        right_view = right_value if isinstance(right_value, DatasetProfileView) else right_value.view()
+        merged_segments[key] = right_view
+
+    for key in intersection_keys:
+        left_value = lhs_segments[key]
+        left_view = left_value if isinstance(left_value, DatasetProfileView) else left_value.view()
+        right_value = lhs_segments[key]
+        right_view = right_value if isinstance(right_value, DatasetProfileView) else right_value.view()
+        merged_segments[key] = left_view.merge(right_view)
+
+    return merged_segments
+
+
+def _merge_partitioned_segments(
+    lhs_segments: Dict[str, Dict[Segment, DatasetProfile]], rhs_segments: Dict[str, Dict[Segment, DatasetProfile]]
+) -> Dict[str, Dict[Segment, DatasetProfile]]:
+    lhs_partitions = lhs_segments.keys()
+    rhs_partitions = rhs_segments.keys()
+    merged_partitions: Dict[str, Dict[Segment, DatasetProfile]] = dict()
+    lhs_only = lhs_partitions - rhs_partitions
+    rhs_only = rhs_partitions - lhs_partitions
+    intersection_keys = lhs_partitions & rhs_partitions
+    for key in lhs_only:
+        merged_partitions[key] = lhs_segments[key]
+
+    for key in rhs_only:
+        merged_partitions[key] = rhs_segments[key]
+
+    for key in intersection_keys:
+        merged_partitions[key] = _merge_segments(lhs_segments[key], rhs_segments[key])
+
+    return merged_partitions
+
+
+def _merge_partitions(
+    lhs_partitions: List[SegmentationPartition], rhs_partitions: List[SegmentationPartition]
+) -> List[SegmentationPartition]:
+    return list(set(lhs_partitions).union(set(rhs_partitions)))
 
 
 class ResultSetWriter:
@@ -128,6 +224,9 @@ class ResultSet(ABC):
         else:
             raise ValueError(f"Cannot add {name} metric {metric} to a result set with no profile!")
 
+    def merge(self, other: "ResultSet") -> "ResultSet":
+        raise NotImplementedError("This result set did not define merge, see ProfileResultSet or SegmentedResulSet.")
+
 
 class ViewResultSet(ResultSet):
     def __init__(self, view: DatasetProfileView) -> None:
@@ -142,6 +241,15 @@ class ViewResultSet(ResultSet):
     @staticmethod
     def zero() -> "ViewResultSet":
         return ViewResultSet(DatasetProfileView.zero())
+
+    def merge(self, other: "ResultSet") -> "ViewResultSet":
+        if other is None:
+            return self
+
+        lhs_view = self._view or DatasetProfileView.zero()
+        if not isinstance(other, (ViewResultSet, ProfileResultSet)):
+            logger.warning(f"Merging potentially incompatible ViewResultSet and {type(other)}")
+        return ViewResultSet(lhs_view.merge(other.view()))
 
 
 class ProfileResultSet(ResultSet):
@@ -158,18 +266,30 @@ class ProfileResultSet(ResultSet):
     def zero() -> "ProfileResultSet":
         return ProfileResultSet(DatasetProfile())
 
+    def merge(self, other: "ResultSet") -> ViewResultSet:
+        if other is None:
+            return self
+
+        lhs_profile = self.view() or DatasetProfileView()
+        if not isinstance(other, (ProfileResultSet, ViewResultSet)):
+            logger.error(f"Merging potentially incompatible ProfileResultSet and {type(other)}")
+        return ViewResultSet(lhs_profile.merge(other.view()))
+
 
 class SegmentedResultSet(ResultSet):
     def __init__(
         self,
-        segments: Dict[str, Dict[Segment, DatasetProfile]],
+        segments: Dict[str, Dict[Segment, Union[DatasetProfile, DatasetProfileView]]],
         partitions: Optional[List[SegmentationPartition]] = None,
+        metrics: Optional[Dict[str, Any]] = None,
+        properties: Optional[Dict[str, Any]] = None,
     ) -> None:
         self._segments = segments
         self._partitions = partitions
-        self.model_performance_metric: Optional[ModelPerformanceMetrics] = None
+        self._metrics = metrics or dict()
+        self._dataset_properties = properties or dict()
 
-    def profile(self, segment: Optional[Segment] = None) -> Optional[DatasetProfile]:
+    def profile(self, segment: Optional[Segment] = None) -> Optional[Union[DatasetProfile, DatasetProfileView]]:
         if not self._segments:
             return None
         elif segment:
@@ -181,13 +301,23 @@ class SegmentedResultSet(ResultSet):
                 segments = self._segments.get(partition_id)
                 number_of_segments = len(segments) if segments else 0
                 if number_of_segments == 1:
-                    single_dictionary: Dict[Segment, DatasetProfile] = segments if segments else dict()
+                    single_dictionary: Dict[Segment, Union[DatasetProfile, DatasetProfileView]] = (
+                        segments if segments else dict()
+                    )
                     for key in single_dictionary:
                         return single_dictionary[key]
 
         raise ValueError(
             f"A profile was requested from a segmented result set without specifying which segment to return: {self._segments}"
         )
+
+    @property
+    def dataset_properties(self) -> Optional[Dict[str, Any]]:
+        return self._dataset_properties
+
+    @property
+    def dataset_metrics(self) -> Optional[Dict[str, Any]]:
+        return self._metrics
 
     @property
     def partitions(self) -> Optional[List[SegmentationPartition]]:
@@ -228,12 +358,15 @@ class SegmentedResultSet(ResultSet):
                 result += len(profiles)
         return result
 
-    def segments_in_partition(self, partition: SegmentationPartition) -> Optional[Dict[Segment, DatasetProfile]]:
+    def segments_in_partition(
+        self, partition: SegmentationPartition
+    ) -> Optional[Dict[Segment, Union[DatasetProfile, DatasetProfileView]]]:
         return self._segments.get(partition.id)
 
     def view(self, segment: Optional[Segment] = None) -> Optional[DatasetProfileView]:
         result = self.profile(segment)
-        return result.view() if result else None
+        view = result.view() if isinstance(result, DatasetProfile) else result
+        return view
 
     def get_model_performance_metrics_for_segment(self, segment: Segment) -> Optional[ModelPerformanceMetrics]:
         if segment.parent_id in self._segments:
@@ -243,7 +376,15 @@ class SegmentedResultSet(ResultSet):
                     f"No profile found for segment {segment} when requesting model performance metrics, returning None!"
                 )
                 return None
-            view = profile.view()
+
+            if isinstance(profile, DatasetProfileView):
+                view = profile
+            else:
+                if hasattr(profile, "view"):
+                    view = profile.view()
+                else:
+                    logger.error(f"Unexpected type: {type(profile)} -> {profile}, cannot check for model performance metrics.")
+                    return None
             return view.model_performance_metrics
         return None
 
@@ -273,9 +414,9 @@ class SegmentedResultSet(ResultSet):
                         logger.debug(
                             f"Found model performance metrics: {metric}, adding to segmented profile: {segment_key}."
                         )
-
+                    view = profile.view() if isinstance(profile, DatasetProfile) else profile
                     segmented_profile = SegmentedDatasetProfileView(
-                        profile_view=profile.view(), segment=segment_key, partition=first_partition
+                        profile_view=view, segment=segment_key, partition=first_partition
                     )
                     results.append(segmented_profile)
             else:
@@ -297,3 +438,40 @@ class SegmentedResultSet(ResultSet):
     @staticmethod
     def zero() -> "SegmentedResultSet":
         return SegmentedResultSet(segments=dict())
+
+    @property
+    def model_performance_metric(self) -> Optional[ModelPerformanceMetrics]:
+        if self._metrics:
+            return self._metrics.get(_MODEL_PERFORMANCE)
+        return None
+
+    def add_model_performance_metrics(self, metrics: ModelPerformanceMetrics) -> None:
+        if self._metrics:
+            self._metrics[_MODEL_PERFORMANCE] = metrics
+        else:
+            self._metrics = {_MODEL_PERFORMANCE: metrics}
+
+    def add_metric(self, name: str, metric: Metric) -> None:
+        if not self._metrics:
+            self._metrics = dict()
+        self._metrics[name] = metric
+
+    def merge(self, other: "ResultSet") -> "SegmentedResultSet":
+        if other is None:
+            return self
+
+        if isinstance(other, SegmentedResultSet):
+            lhs_partitions: List[SegmentationPartition] = self.partitions or list()
+            rhs_partitions: List[SegmentationPartition] = other.partitions or list()
+
+            lhs_segments: Dict[str, Dict[Segment, DatasetProfile]] = self._segments or dict()
+            rhs_segments: Dict[str, Dict[Segment, DatasetProfile]] = other._segments or dict()
+
+            merged_segments = _merge_partitioned_segments(lhs_segments, rhs_segments)
+            merged_metrics = _merge_metrics(self.dataset_metrics, other.dataset_metrics)
+            merged_partitions = _merge_partitions(lhs_partitions, rhs_partitions)
+            properties = _accumulate_properties(self._dataset_properties, other.dataset_properties)
+
+            return SegmentedResultSet(merged_segments, merged_partitions, metrics=merged_metrics, properties=properties)
+        else:
+            raise ValueError(f"Cannot merge incompatible SegmentedResultSet and {type(other)}")

--- a/python/whylogs/api/pyspark/experimental/__init__.py
+++ b/python/whylogs/api/pyspark/experimental/__init__.py
@@ -1,10 +1,10 @@
-from .segmented_profiler import collect_segmented_results
 from .profiler import (
     collect_column_profile_views,
     collect_dataset_profile_view,
     column_profile_bytes_aggregator,
     whylogs_pandas_map_profiler,
 )
+from .segmented_profiler import collect_segmented_results
 
 __ALL__ = [
     whylogs_pandas_map_profiler,

--- a/python/whylogs/api/pyspark/experimental/__init__.py
+++ b/python/whylogs/api/pyspark/experimental/__init__.py
@@ -1,3 +1,4 @@
+from .segmented_profiler import collect_segmented_results
 from .profiler import (
     collect_column_profile_views,
     collect_dataset_profile_view,
@@ -10,4 +11,5 @@ __ALL__ = [
     column_profile_bytes_aggregator,
     collect_column_profile_views,
     collect_dataset_profile_view,
+    collect_segmented_results,
 ]

--- a/python/whylogs/api/pyspark/experimental/profiler.py
+++ b/python/whylogs/api/pyspark/experimental/profiler.py
@@ -20,7 +20,6 @@ except ImportError:  # noqa
     SparkDataFrame = None  # type: ignore
 
 COL_NAME_FIELD = "col_name"
-
 COL_PROFILE_FIELD = "col_profile"
 
 
@@ -78,6 +77,12 @@ def collect_dataset_profile_view(
 
     _dataset_timestamp = dataset_timestamp or now
     _creation_timestamp = creation_timestamp or now
+    if schema and schema.segments:
+        raise ValueError(
+            "collect_dataset_profile_view returns a single DatasetProfileView but segmentation was defined, "
+            f": {schema.segments} may return multiple segmented profiles. Please use `collect_segmented_results` if you want to profile"
+            " in spark with segments defined."
+        )
 
     column_views_dict = collect_column_profile_views(input_df=input_df, schema=schema)
 

--- a/python/whylogs/api/pyspark/experimental/segmented_profiler.py
+++ b/python/whylogs/api/pyspark/experimental/segmented_profiler.py
@@ -1,0 +1,147 @@
+import dataclasses
+from datetime import datetime, timezone
+from functools import partial, reduce
+import json
+from logging import getLogger
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import whylogs as why
+from whylogs.api.logger.result_set import ResultSet, SegmentedResultSet
+from whylogs.api.pyspark.experimental.profiler import COL_NAME_FIELD, COL_PROFILE_FIELD
+from whylogs.api.usage_stats import emit_usage
+from whylogs.core import DatasetSchema
+from whylogs.core.segment import Segment
+from whylogs.core.segmentation_partition import SegmentationPartition
+from whylogs.core.stubs import pd
+from whylogs.core.view.column_profile_view import ColumnProfileView
+from whylogs.core.view.dataset_profile_view import DatasetProfileView
+
+logger = getLogger(__name__)
+emit_usage("pyspark")
+
+try:  # type: ignore
+    from pyspark.sql import DataFrame as SparkDataFrame  # types: ignore
+except ImportError:  # noqa
+    logger.error("No pyspark available")
+    SparkDataFrame = None  # type: ignore
+
+SEGMENT_KEY_FIELD = "segment_key"
+
+def _segment_to_string(segment: Segment) -> str:
+    return json.dumps(dataclasses.asdict(segment))
+
+def _string_to_segment(segment_key: str) -> Optional[Segment]:
+    if len(segment_key) == 0:
+        return None
+    segment_params = json.loads(segment_key)
+    if 'key' not in segment_params or 'parent_id' not in segment_params:
+        raise ValueError("Segment key is missing required key values or parent_id: {segment_params}")
+    tuple_key = tuple(segment_params['key'])
+    parent_id = segment_params['parent_id']
+    return Segment(key = tuple_key, parent_id=parent_id)
+
+
+def whylogs_pandas_segmented_profiler(
+    pdf_iterator: Iterable[pd.DataFrame], schema: Optional[DatasetSchema] = None
+) -> Iterable[pd.DataFrame]:
+    if schema is None or not schema.segments:
+        raise ValueError("Cannot profile segments without segmentation defined in the specified DatasetSchema: no segments found.")
+    for input_df in pdf_iterator:
+        # TODO: optimize this so we split the dataframe by segment first rather than split in the pandas dataframe
+        segmented_results = why.log(input_df, schema=schema)
+        res_df = pd.DataFrame(columns=[SEGMENT_KEY_FIELD, COL_NAME_FIELD, COL_PROFILE_FIELD])
+        for segmented_key in segmented_results.segments():
+            spark_segment_key = _segment_to_string(segmented_key)
+            for col_name, col_profile in segmented_results.view(segmented_key).get_columns().items():
+                d = {
+                    SEGMENT_KEY_FIELD: [spark_segment_key],
+                    COL_NAME_FIELD: [col_name],
+                    COL_PROFILE_FIELD: [col_profile.to_protobuf().SerializeToString()],
+                }
+                df_temp = pd.DataFrame(data=d)
+                res_df = res_df.append(df_temp)
+        yield res_df
+
+
+def column_profile_bytes_aggregator(group_by_cols: Tuple[str], profiles_df: pd.DataFrame) -> pd.DataFrame:
+    if len(profiles_df) == 0:
+        return pd.DataFrame([group_by_cols + (bytearray(),)])
+
+    merged_profile: ColumnProfileView = reduce(
+        lambda acc, x: acc.merge(x), profiles_df[COL_PROFILE_FIELD].apply(ColumnProfileView.from_bytes)
+    )
+    return pd.DataFrame([group_by_cols + (merged_profile.serialize(),)])
+
+
+def collect_segmented_column_profile_views(
+    input_df: SparkDataFrame, schema: Optional[DatasetSchema] = None
+) -> Dict[Segment, Dict[str, ColumnProfileView]]:
+    if SparkDataFrame is None:
+        logger.warning("Unable to load pyspark; install pyspark to get whylogs profiling support in spark environment.")
+
+    cp = f"{SEGMENT_KEY_FIELD} string, {COL_NAME_FIELD} string, {COL_PROFILE_FIELD} binary"
+    whylogs_pandas_map_profiler_with_schema = partial(whylogs_pandas_segmented_profiler, schema=schema)
+    segmented_profile_bytes_df = input_df.mapInPandas(whylogs_pandas_map_profiler_with_schema, schema=cp)  # type: ignore
+    # aggregate by segment key first, then by column
+    segment_column_profiles = segmented_profile_bytes_df.groupby(SEGMENT_KEY_FIELD, COL_NAME_FIELD).applyInPandas(  # linebreak
+        column_profile_bytes_aggregator, schema=cp
+    )
+
+    collected_segment_column_profile_views: Dict[Tuple[Segment, str], ColumnProfileView] = {
+        (_string_to_segment(row.segment_key), row.col_name): ColumnProfileView.from_bytes(row.col_profile) for row in segment_column_profiles.collect()
+    }
+
+    segmented_column_profile_views: Dict[Segment, Dict[str, ColumnProfileView]] = dict()
+
+    for key_tuple in collected_segment_column_profile_views:
+        segment_key = key_tuple[0]
+        column_name = key_tuple[1]
+        if segment_key not in segmented_column_profile_views:
+            segmented_column_profile_views[segment_key] = dict()
+        segmented_column_profile_views[segment_key][column_name] = collected_segment_column_profile_views[key_tuple]
+
+    return segmented_column_profile_views
+
+def _lookup_segment_partition_by_id(schema: DatasetSchema, partition_id: str) -> Optional[SegmentationPartition]:
+    for partition_name in schema.segments:
+        partition = schema.segments[partition_name]
+        if partition_id == partition.id:
+            return partition
+    logger.warning(f"Skipping segment: could not find partition with id {partition_id} in: {schema.segments}")
+
+def collect_segmented_results(
+    input_df: SparkDataFrame,
+    schema: DatasetSchema,
+    dataset_timestamp: Optional[int] = None,
+    creation_timestamp: Optional[int] = None,
+) -> ResultSet:
+    now = datetime.now(timezone.utc)
+
+    _dataset_timestamp = dataset_timestamp or now
+    _creation_timestamp = creation_timestamp or now
+    if not schema.segments:
+        raise ValueError("Cannot collect segmented results without segments defined in the passed in DatasetSchema")
+
+    logger.info(f"Processing segmented profiling in spark with {schema.segments}")
+    segment_column_views_dict = collect_segmented_column_profile_views(input_df=input_df, schema=schema)
+    segments: Dict[str, Dict[Segment, DatasetProfileView]] = dict()
+    partitions: List[SegmentationPartition] = list(schema.segments.values())
+
+    for segment in segment_column_views_dict:
+        partition_id = segment.parent_id
+        # check that the segment's parent id has a matching partition
+        partition = _lookup_segment_partition_by_id(schema, partition_id)
+        if partition is None:
+            logger.error(f"Skipping segment: could not collect profiles for segment {segment} because the schema has no matching partition ids: {schema.segments.keys()}")
+            continue
+        if not partition_id in segments:
+            segments[partition_id] = dict()
+        if segment not in segments[partition_id]:
+            column_views_dict = segment_column_views_dict[segment]
+            segments[partition_id][segment] = DatasetProfileView(
+                columns=column_views_dict, dataset_timestamp=_dataset_timestamp, creation_timestamp=_creation_timestamp
+            )
+        else:
+            raise ValueError(f"Collision when collecting profiles for segment {segment}!")
+
+    return SegmentedResultSet(segments=segments, partitions=partitions)


### PR DESCRIPTION
## Description

Added new method to support profiling segmented results. As this is still in experimental namespace, this change adds a parallel method to the previous `collect_dataset_profile_view` with `collect_segmented_results`: 

```python
from whylogs.api.pyspark.experimental import collect_dataset_profile_view, collect_segmented_results
from whylogs.core.segmentation_partition import segment_on_column
from whylogs.core import DatasetSchema

segmented_results = collect_segmented_results(input_df=df, schema=DatasetSchema(segments=segment_on_column("column_A")))
```

## Changes

- Updates to SegmentedResultSet: supports merging and result set scoped metrics
- Added merge for metadata and metrics
- Added new pyspark grouped profiling using segment columns.
- pyspark schema udf is keyed on column name, and segment key

## Related


- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
