### PR TITLE
Explicitly test do_rollover creates a new profile

### DIFF
--- a/python/tests/api/logger/test_rolling.py
+++ b/python/tests/api/logger/test_rolling.py
@@ -1,6 +1,7 @@
 import math
 import os
 import time
+from datetime import datetime, timezone
 from os import listdir
 from os.path import isfile
 from typing import Any
@@ -169,10 +170,15 @@ def test_rolling_do_rollover():
     df = pd.DataFrame(data={"col1": [1, 2], "col2": [3.0, 4.0], "col3": ["a", "b"]})
     rolling_logger = why.logger(mode="rolling", interval=5, when="M", base_name="profile_")
     rolling_logger.append_writer("local")
-
     rolling_logger.log(df)
+    now = datetime.now(timezone.utc)
     initial_profile_id = id(rolling_logger._current_profile)
+    profile_timestamp = rolling_logger._current_profile.dataset_timestamp
     rolling_logger._do_rollover()
     post_rollover_profile_id = id(rolling_logger._current_profile)
     rolling_logger.close()
     assert initial_profile_id != post_rollover_profile_id
+    assert now.timestamp() == pytest.approx(profile_timestamp.timestamp())
+    # these lines below fail as a comparison
+    # now_plus_1h = now + datetime.timedelta(hours=1)
+    # assert now.timestamp() == pytest.approx(now_plus_1h.timestamp())

--- a/python/tests/api/logger/test_rolling.py
+++ b/python/tests/api/logger/test_rolling.py
@@ -161,3 +161,18 @@ def test_rolling_row_messages_with_segments(tmp_path: Any) -> None:
     # after explicitly calling close on the logger, we trigger one more flush which has two segments and expect two callbacks
     rolling_logger.close()
     assert rolling_callback.call_count == 2
+
+
+def test_rolling_do_rollover():
+    import pandas as pd
+
+    df = pd.DataFrame(data={"col1": [1, 2], "col2": [3.0, 4.0], "col3": ["a", "b"]})
+    rolling_logger = why.logger(mode="rolling", interval=5, when="M", base_name="profile_")
+    rolling_logger.append_writer("local")
+
+    rolling_logger.log(df)
+    initial_profile_id = id(rolling_logger._current_profile)
+    rolling_logger._do_rollover()
+    post_rollover_profile_id = id(rolling_logger._current_profile)
+    rolling_logger.close()
+    assert initial_profile_id != post_rollover_profile_id


### PR DESCRIPTION
## Description

Add a test to check that the rolling logger rotates the current profile to a new one.

## Changes

- Only test changes: new test for identity of the profile after rolling it over with rolling logger.
- 
## Related

Relates to #1083 

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
