### PR TITLE
Fix error logging categorical dtype integer values

### DIFF
--- a/python/tests/api/logger/test_logger.py
+++ b/python/tests/api/logger/test_logger.py
@@ -99,6 +99,19 @@ def test_lending_club(lending_club_df: pd.DataFrame) -> None:
     assert len(df) == 151
 
 
+def test_categorical_dtype() -> None:
+    data = {"can_fly": [0, 1, 0, 0], "habitat": ["forest", "forest", "river", "river"]}
+
+    df = pd.DataFrame(data)
+    df["can_fly"] = df["can_fly"].astype("category")
+    df["habitat"] = df["habitat"].astype("category")
+
+    results = why.log(df)
+    view = results.view()
+    metrics = view.get_column("can_fly").get_metric("counts").to_summary_dict()
+    assert metrics["n"] == 4
+
+
 def test_roundtrip_resultset(tmp_path: Any) -> None:
     d = {"col1": [1, 2], "col2": [3.0, 4.0], "col3": ["a", "b"]}
     df = pd.DataFrame(data=d)

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -161,7 +161,7 @@ class PreprocessedColumn:
         str_mask = non_null_series.apply(lambda x: isinstance(x, str))
 
         floats = non_null_series[float_mask]
-        ints = non_null_series[int_mask]
+        ints = non_null_series[int_mask].astype(int)
         bool_count = non_null_series[bool_mask].count()
         bool_count_where_true = non_null_series[bool_mask_where_true].count()
         strings = non_null_series[str_mask]
@@ -173,6 +173,7 @@ class PreprocessedColumn:
             floats = floats.astype(float)
             inf_mask = floats.apply(lambda x: np.isinf(x))
             self.inf_count = len(floats[inf_mask])
+
         self.numpy = NumpyView(floats=floats, ints=ints)
         self.pandas.strings = strings
         self.pandas.objs = objs


### PR DESCRIPTION
## Description

pandas dataframes containing integer values with a dtype categorical hit error because the values were not converted to int types before passing to distribution metric.

## Changes

We already call astype(float) for the float numerics and to avoid this kind of processing error we need to do the same for integral types in preprocessing.
Added a test that repros the issue and shows string categorical values are already ok.

## Related

Closes #1093 

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
