### PR TITLE
Update path to EmbeddingMetric

### DIFF
--- a/python/examples/experimental/embeddings/Embeddings_Distance_Logging.ipynb
+++ b/python/examples/experimental/embeddings/Embeddings_Distance_Logging.ipynb
@@ -179,7 +179,7 @@
     "import whylogs as why\n",
     "from whylogs.core.resolvers import MetricSpec, ResolverSpec\n",
     "from whylogs.core.schema import DeclarativeSchema\n",
-    "from whylogs.experimental.core.metrics.embedding_metric import (\n",
+    "from whylogs.experimental.extras.embedding_metric import (\n",
     "    DistanceFunction,\n",
     "    EmbeddingConfig,\n",
     "    EmbeddingMetric,\n",


### PR DESCRIPTION
Fixes whylabs/whylogs#1092

## Description

Use correct import for `EmbeddingMetric`


## Related

Relates to whylabs/whylogs#1092

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes whylabs/whylogs#1092

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
