### PR TITLE
Add a new rolling logger type that handles historical data

### DIFF
--- a/python/examples/experimental/Multi dataset logger.ipynb
+++ b/python/examples/experimental/Multi dataset logger.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d026913b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install whylogs[whylabs]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c5ac0c04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from whylogs.api.logger.experimental.multi_dataset_logger.multi_dataset_rolling_logger import MultiDatasetRollingLogger\n",
+    "from whylogs.api.logger.experimental.multi_dataset_logger.time_util import TimeGranularity, Schedule\n",
+    "from whylogs.api.writer.whylabs import WhyLabsWriter\n",
+    "\n",
+    "import os, getpass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "510d69d6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Enter your WhyLabs Org ID\n",
+      "org-123\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Enter your WhyLabs Org ID\")\n",
+    "os.environ[\"WHYLABS_DEFAULT_ORG_ID\"] = input()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "592b1f42",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Enter your WhyLabs API key\n",
+      "········\n",
+      "Using API Key ID:  xxxxxxxxxx\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Enter your WhyLabs API key\")\n",
+    "os.environ[\"WHYLABS_API_KEY\"] = getpass.getpass()\n",
+    "print(\"Using API Key ID: \", os.environ[\"WHYLABS_API_KEY\"][0:10])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "92827496",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a logger that will write hourly profiles to WhyLabs every 10 minutes\n",
+    "writer = WhyLabsWriter(\n",
+    "    org_id=os.environ[\"WHYLABS_DEFAULT_ORG_ID\"], \n",
+    "    api_key=os.environ[\"WHYLABS_API_KEY\"], \n",
+    "    dataset_id=\"model-1\"\n",
+    ")\n",
+    "schedule = Schedule(cadence=TimeGranularity.Minute, interval=10)\n",
+    "logger = MultiDatasetRollingLogger(\n",
+    "    aggregate_by=TimeGranularity.Hour, \n",
+    "    write_schedule=schedule,\n",
+    "    writers=[writer],\n",
+    "    # Can optionally provide a dataset schema here as well.\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e029ae5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = [\n",
+    "    {'col1': 2, 'col2': 6.0, 'col3': 'FOO'},\n",
+    "    {'col1': 57, 'col2': 7.0, 'col3': 'BAR'},\n",
+    "    {'col1': 2, 'col2': 9.0, 'col3': 'FOO'},\n",
+    "    {'col1': 60, 'col2': 1.1, 'col3': 'FOO'},\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "337e97f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Log a collectio nof rows. It can be a single row, or a pandas data frame as well.\n",
+    "logger.log(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "066c2dfc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Manually trigger a write.\n",
+    "logger.flush()\n",
+    "\n",
+    "# Writes also automatically happen when you close the logger\n",
+    "logger.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -96,8 +96,7 @@ cov = ["attrs[tests]", "coverage-enable-subprocess", "coverage[toml] (>=5.3)"]
 dev = ["attrs[docs,tests]"]
 docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope.interface"]
 tests = ["attrs[tests-no-zope]", "zope.interface"]
-tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=0.971,<0.990)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-tests_no_zope = ["cloudpickle", "hypothesis", "mypy (>=0.971,<0.990)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy (>=0.971,<0.990)", "mypy (>=0.971,<0.990)", "pympler", "pympler", "pytest (>=4.3.0)", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-mypy-plugins", "pytest-xdist[psutil]", "pytest-xdist[psutil]"]
 
 [[package]]
 name = "autoflake"
@@ -475,7 +474,7 @@ triad = ">=0.8.1"
 
 [package.extras]
 all = ["dask[dataframe,distributed]", "dask[dataframe,distributed] (>=2022.9.0)", "duckdb (>=0.5.0)", "fugue-sql-antlr[cpp] (>=0.1.5)", "ibis-framework (>=2.1.1)", "ibis-framework (>=3.2.0)", "ipython (>=7.10.0)", "jupyterlab", "notebook", "pyarrow (>=6.0.1)", "pyspark", "qpd[dask] (>=0.4.0)", "ray[data] (>=2.0.0)"]
-cpp_sql_parser = ["fugue-sql-antlr[cpp] (>=0.1.5)"]
+cpp-sql-parser = ["fugue-sql-antlr[cpp] (>=0.1.5)"]
 dask = ["dask[dataframe,distributed]", "dask[dataframe,distributed] (>=2022.9.0)", "qpd[dask] (>=0.4.0)"]
 duckdb = ["duckdb (>=0.5.0)", "numpy", "pyarrow (>=6.0.1)"]
 ibis = ["ibis-framework (>=2.1.1)", "ibis-framework (>=3.2.0)"]
@@ -584,7 +583,7 @@ six = ">=1.9.0"
 
 [package.extras]
 aiohttp = ["aiohttp (>=3.6.2,<4.0.0dev)", "requests (>=2.20.0,<3.0.0dev)"]
-enterprise_cert = ["cryptography (==36.0.2)", "pyopenssl (==22.0.0)"]
+enterprise-cert = ["cryptography (==36.0.2)", "pyopenssl (==22.0.0)"]
 pyopenssl = ["cryptography (>=38.0.3)", "pyopenssl (>=20.0.0)"]
 reauth = ["pyu2f (>=0.1.5)"]
 requests = ["requests (>=2.20.0,<3.0.0dev)"]
@@ -1010,7 +1009,7 @@ typing_extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 benchmarking = ["psutil", "pytest", "pytest-benchmark (>=3.2,<4.0)"]
-code_style = ["pre-commit (==2.6)"]
+code-style = ["pre-commit (==2.6)"]
 compare = ["commonmark (>=0.9.1,<0.10.0)", "markdown (>=3.3.6,<3.4.0)", "mistletoe (>=0.8.1,<0.9.0)", "mistune (>=2.0.2,<2.1.0)", "panflute (>=2.1.3,<2.2.0)"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
 plugins = ["mdit-py-plugins"]
@@ -1057,7 +1056,7 @@ python-versions = ">=3.7"
 markdown-it-py = ">=1.0.0,<3.0.0"
 
 [package.extras]
-code_style = ["pre-commit"]
+code-style = ["pre-commit"]
 rtd = ["attrs", "myst-parser (>=0.16.1,<0.17.0)", "sphinx-book-theme (>=0.1.0,<0.2.0)"]
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
@@ -1189,15 +1188,15 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "mypy-protobuf"
-version = "3.4.0"
+version = "3.3.0"
 description = "Generate mypy stub files from protobuf specs"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-protobuf = ">=4.21.8"
-types-protobuf = ">=3.20.4"
+protobuf = ">=3.19.4"
+types-protobuf = ">=3.19.12"
 
 [[package]]
 name = "myst-parser"
@@ -1217,7 +1216,7 @@ sphinx = ">=3.1,<5"
 typing-extensions = "*"
 
 [package.extras]
-code_style = ["pre-commit (>=2.12,<3.0)"]
+code-style = ["pre-commit (>=2.12,<3.0)"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
 rtd = ["ipython", "sphinx-book-theme", "sphinx-panels", "sphinxcontrib-bibtex (>=2.4,<3.0)", "sphinxcontrib.mermaid (>=0.7.1,<0.8.0)", "sphinxext-opengraph (>=0.6.3,<0.7.0)", "sphinxext-rediraffe (>=0.2.7,<0.3.0)"]
 testing = ["beautifulsoup4", "coverage", "docutils (>=0.17.0,<0.18.0)", "pytest (>=6,<7)", "pytest-cov", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions"]
@@ -1561,7 +1560,7 @@ wcwidth = "*"
 
 [[package]]
 name = "protobuf"
-version = "4.21.12"
+version = "4.22.0"
 description = ""
 category = "main"
 optional = false
@@ -1733,7 +1732,7 @@ py4j = "0.10.9.5"
 [package.extras]
 ml = ["numpy (>=1.15)"]
 mllib = ["numpy (>=1.15)"]
-pandas_on_spark = ["numpy (>=1.15)", "pandas (>=1.0.5)", "pyarrow (>=1.0.0)"]
+pandas-on-spark = ["numpy (>=1.15)", "pandas (>=1.0.5)", "pyarrow (>=1.0.0)"]
 sql = ["pandas (>=1.0.5)", "pyarrow (>=1.0.0)"]
 
 [[package]]
@@ -1904,7 +1903,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "requests-toolbelt"
@@ -2169,7 +2168,7 @@ python-versions = ">=3.7"
 sphinx = ">=1.8"
 
 [package.extras]
-code_style = ["pre-commit (==2.12.1)"]
+code-style = ["pre-commit (==2.12.1)"]
 rtd = ["ipython", "myst-nb", "sphinx", "sphinx-book-theme", "sphinx-examples"]
 
 [[package]]
@@ -2287,21 +2286,21 @@ aiomysql = ["aiomysql", "greenlet (!=0.4.17)"]
 aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing-extensions (!=3.10.0.1)"]
 asyncio = ["greenlet (!=0.4.17)"]
 asyncmy = ["asyncmy (>=0.2.3,!=0.2.4,!=0.2.6)", "greenlet (!=0.4.17)"]
-mariadb_connector = ["mariadb (>=1.0.1,!=1.1.2,!=1.1.5)"]
+mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2,!=1.1.5)"]
 mssql = ["pyodbc"]
-mssql_pymssql = ["pymssql"]
-mssql_pyodbc = ["pyodbc"]
+mssql-pymssql = ["pymssql"]
+mssql-pyodbc = ["pyodbc"]
 mypy = ["mypy (>=0.910)"]
 mysql = ["mysqlclient (>=1.4.0)"]
-mysql_connector = ["mysql-connector-python"]
+mysql-connector = ["mysql-connector-python"]
 oracle = ["cx-oracle (>=7)"]
-oracle_oracledb = ["oracledb (>=1.0.1)"]
+oracle-oracledb = ["oracledb (>=1.0.1)"]
 postgresql = ["psycopg2 (>=2.7)"]
-postgresql_asyncpg = ["asyncpg", "greenlet (!=0.4.17)"]
-postgresql_pg8000 = ["pg8000 (>=1.29.1)"]
-postgresql_psycopg = ["psycopg (>=3.0.7)"]
-postgresql_psycopg2binary = ["psycopg2-binary"]
-postgresql_psycopg2cffi = ["psycopg2cffi"]
+postgresql-asyncpg = ["asyncpg", "greenlet (!=0.4.17)"]
+postgresql-pg8000 = ["pg8000 (>=1.29.1)"]
+postgresql-psycopg = ["psycopg (>=3.0.7)"]
+postgresql-psycopg2binary = ["psycopg2-binary"]
+postgresql-psycopg2cffi = ["psycopg2cffi"]
 pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3-binary"]
 
@@ -2646,7 +2645,7 @@ whylabs = ["whylabs-client", "requests"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1, <4"
-content-hash = "d9d88e6c2744af4ee166afbdeb12612346f2f3a0bebf336c0b12f8c3e84af4d1"
+content-hash = "95811f64f65118599117a405068fc0bf0c57327a7de6f4214edff942f0700e14"
 
 [metadata.files]
 2to3 = [
@@ -2981,6 +2980,8 @@ cryptography = [
     {file = "cryptography-39.0.1-cp36-abi3-win32.whl", hash = "sha256:fe913f20024eb2cb2f323e42a64bdf2911bb9738a15dba7d3cce48151034e3a8"},
     {file = "cryptography-39.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:ced4e447ae29ca194449a3f1ce132ded8fcab06971ef5f618605aacaa612beac"},
     {file = "cryptography-39.0.1-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:807ce09d4434881ca3a7594733669bd834f5b2c6d5c7e36f8c00f691887042ad"},
+    {file = "cryptography-39.0.1-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c5caeb8188c24888c90b5108a441c106f7faa4c4c075a2bcae438c6e8ca73cef"},
+    {file = "cryptography-39.0.1-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:4789d1e3e257965e960232345002262ede4d094d1a19f4d3b52e48d4d8f3b885"},
     {file = "cryptography-39.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:96f1157a7c08b5b189b16b47bc9db2332269d6680a196341bf30046330d15388"},
     {file = "cryptography-39.0.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e422abdec8b5fa8462aa016786680720d78bdce7a30c652b7fadf83a4ba35336"},
     {file = "cryptography-39.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:b0afd054cd42f3d213bf82c629efb1ee5f22eba35bf0eec88ea9ea7304f511a2"},
@@ -3458,8 +3459,8 @@ mypy-extensions = [
     {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
 ]
 mypy-protobuf = [
-    {file = "mypy-protobuf-3.4.0.tar.gz", hash = "sha256:7d75a079651b105076776a35a5405e3fa773b8a167118f1b712e443e9a6c18a2"},
-    {file = "mypy_protobuf-3.4.0-py3-none-any.whl", hash = "sha256:da33dfde7547ff57e5ba5564126cbfa114f14413b2fa50759b1fa5de1e4ab511"},
+    {file = "mypy-protobuf-3.3.0.tar.gz", hash = "sha256:24f3b0aecb06656e983f58e07c732a90577b9d7af3e1066fc2b663bbf0370248"},
+    {file = "mypy_protobuf-3.3.0-py3-none-any.whl", hash = "sha256:15604f6943b16c05db646903261e3b3e775cf7f7990b7c37b03d043a907b650d"},
 ]
 myst-parser = [
     {file = "myst-parser-0.17.2.tar.gz", hash = "sha256:4c076d649e066f9f5c7c661bae2658be1ca06e76b002bb97f02a09398707686c"},
@@ -3686,20 +3687,19 @@ prompt-toolkit = [
     {file = "prompt_toolkit-3.0.36.tar.gz", hash = "sha256:3e163f254bef5a03b146397d7c1963bd3e2812f0964bb9a24e6ec761fd28db63"},
 ]
 protobuf = [
-    {file = "protobuf-4.21.12-cp310-abi3-win32.whl", hash = "sha256:b135410244ebe777db80298297a97fbb4c862c881b4403b71bac9d4107d61fd1"},
-    {file = "protobuf-4.21.12-cp310-abi3-win_amd64.whl", hash = "sha256:89f9149e4a0169cddfc44c74f230d7743002e3aa0b9472d8c28f0388102fc4c2"},
-    {file = "protobuf-4.21.12-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:299ea899484ee6f44604deb71f424234f654606b983cb496ea2a53e3c63ab791"},
-    {file = "protobuf-4.21.12-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:d1736130bce8cf131ac7957fa26880ca19227d4ad68b4888b3be0dea1f95df97"},
-    {file = "protobuf-4.21.12-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:78a28c9fa223998472886c77042e9b9afb6fe4242bd2a2a5aced88e3f4422aa7"},
-    {file = "protobuf-4.21.12-cp37-cp37m-win32.whl", hash = "sha256:3d164928ff0727d97022957c2b849250ca0e64777ee31efd7d6de2e07c494717"},
-    {file = "protobuf-4.21.12-cp37-cp37m-win_amd64.whl", hash = "sha256:f45460f9ee70a0ec1b6694c6e4e348ad2019275680bd68a1d9314b8c7e01e574"},
-    {file = "protobuf-4.21.12-cp38-cp38-win32.whl", hash = "sha256:6ab80df09e3208f742c98443b6166bcb70d65f52cfeb67357d52032ea1ae9bec"},
-    {file = "protobuf-4.21.12-cp38-cp38-win_amd64.whl", hash = "sha256:1f22ac0ca65bb70a876060d96d914dae09ac98d114294f77584b0d2644fa9c30"},
-    {file = "protobuf-4.21.12-cp39-cp39-win32.whl", hash = "sha256:27f4d15021da6d2b706ddc3860fac0a5ddaba34ab679dc182b60a8bb4e1121cc"},
-    {file = "protobuf-4.21.12-cp39-cp39-win_amd64.whl", hash = "sha256:237216c3326d46808a9f7c26fd1bd4b20015fb6867dc5d263a493ef9a539293b"},
-    {file = "protobuf-4.21.12-py2.py3-none-any.whl", hash = "sha256:a53fd3f03e578553623272dc46ac2f189de23862e68565e83dde203d41b76fc5"},
-    {file = "protobuf-4.21.12-py3-none-any.whl", hash = "sha256:b98d0148f84e3a3c569e19f52103ca1feacdac0d2df8d6533cf983d1fda28462"},
-    {file = "protobuf-4.21.12.tar.gz", hash = "sha256:7cd532c4566d0e6feafecc1059d04c7915aec8e182d1cf7adee8b24ef1e2e6ab"},
+    {file = "protobuf-4.22.0-cp310-abi3-win32.whl", hash = "sha256:b2fea9dc8e3c0f32c38124790ef16cba2ee0628fe2022a52e435e1117bfef9b1"},
+    {file = "protobuf-4.22.0-cp310-abi3-win_amd64.whl", hash = "sha256:a33a273d21852f911b8bda47f39f4383fe7c061eb1814db2c76c9875c89c2491"},
+    {file = "protobuf-4.22.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:e894e9ae603e963f0842498c4cd5d39c6a60f0d7e4c103df50ee939564298658"},
+    {file = "protobuf-4.22.0-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:7c535d126e7dcc714105ab20b418c4fedbd28f8b8afc42b7350b1e317bbbcc71"},
+    {file = "protobuf-4.22.0-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:86c3d20428b007537ba6792b475c0853bba7f66b1f60e610d913b77d94b486e4"},
+    {file = "protobuf-4.22.0-cp37-cp37m-win32.whl", hash = "sha256:1669cb7524221a8e2d9008d0842453dbefdd0fcdd64d67672f657244867635fb"},
+    {file = "protobuf-4.22.0-cp37-cp37m-win_amd64.whl", hash = "sha256:ab4d043865dd04e6b09386981fe8f80b39a1e46139fb4a3c206229d6b9f36ff6"},
+    {file = "protobuf-4.22.0-cp38-cp38-win32.whl", hash = "sha256:29288813aacaa302afa2381db1d6e0482165737b0afdf2811df5fa99185c457b"},
+    {file = "protobuf-4.22.0-cp38-cp38-win_amd64.whl", hash = "sha256:e474b63bab0a2ea32a7b26a4d8eec59e33e709321e5e16fb66e766b61b82a95e"},
+    {file = "protobuf-4.22.0-cp39-cp39-win32.whl", hash = "sha256:47d31bdf58222dd296976aa1646c68c6ee80b96d22e0a3c336c9174e253fd35e"},
+    {file = "protobuf-4.22.0-cp39-cp39-win_amd64.whl", hash = "sha256:c27f371f0159feb70e6ea52ed7e768b3f3a4c5676c1900a7e51a24740381650e"},
+    {file = "protobuf-4.22.0-py3-none-any.whl", hash = "sha256:c3325803095fb4c2a48649c321d2fbde59f8fbfcb9bfc7a86df27d112831c571"},
+    {file = "protobuf-4.22.0.tar.gz", hash = "sha256:652d8dfece122a24d98eebfef30e31e455d300efa41999d1182e015984ac5930"},
 ]
 psutil = [
     {file = "psutil-5.9.4-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c1ca331af862803a42677c120aff8a814a804e09832f166f226bfd22b56feee8"},

--- a/python/test_notebooks/notebook_tests.py
+++ b/python/test_notebooks/notebook_tests.py
@@ -24,6 +24,7 @@ skip_notebooks = [
     "Embeddings_Distance_Logging.ipynb",  # skipped due to data download
     "whylogs_Audio_examples.ipynb",  # skipped because of Kaggle data download and API key for whylabs upload
     "NLP_Summarization.ipynb",
+    "Multi dataset logger.ipynb",
 ]
 
 

--- a/python/tests/api/logger/experimental/multi_dataset_logger/test_future_util.py
+++ b/python/tests/api/logger/experimental/multi_dataset_logger/test_future_util.py
@@ -1,0 +1,36 @@
+from concurrent.futures import Future
+
+import pytest
+
+try:
+    from whylogs.api.logger.experimental.multi_dataset_logger.future_util import (
+        wait_result,
+    )
+except Exception as e:
+    if str(e) == "'type' object is not subscriptable":
+        pytest.skip("Skipping module because of a pytest bug on older python versions.", allow_module_level=True)
+
+
+def test_success() -> None:
+    f: Future[int] = Future()
+    f.set_result(2)
+    result = wait_result(f)
+    assert result == 2
+
+
+def test_error() -> None:
+    f: Future[int] = Future()
+    e = Exception("e")
+    f.set_exception(e)
+
+    with pytest.raises(Exception):
+        wait_result(f)
+
+
+def test_cancel() -> None:
+    f: Future[int] = Future()
+    f.cancel()
+    f.set_running_or_notify_cancel()
+
+    with pytest.raises(Exception):
+        wait_result(f)

--- a/python/tests/api/logger/experimental/multi_dataset_logger/test_multi_dataset_rolling_logger.py
+++ b/python/tests/api/logger/experimental/multi_dataset_logger/test_multi_dataset_rolling_logger.py
@@ -1,0 +1,269 @@
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Optional, Tuple
+
+import pytest
+from dateutil import tz
+
+try:
+    from whylogs.api.logger.experimental.multi_dataset_logger.multi_dataset_rolling_logger import (
+        MultiDatasetRollingLogger,
+    )
+except Exception as e:
+    if str(e) == "'type' object is not subscriptable":
+        pytest.skip("Skipping module because of a pytest bug on older python versions.", allow_module_level=True)
+
+from whylogs.api.logger.experimental.multi_dataset_logger.time_util import (
+    TimeGranularity,
+)
+from whylogs.api.writer import Writer
+from whylogs.api.writer.writer import Writable
+from whylogs.core.schema import DatasetSchema
+from whylogs.core.segmentation_partition import (
+    ColumnMapperFunction,
+    SegmentationPartition,
+)
+
+logging.basicConfig()
+
+
+class BadWriter(Writer):
+    write_count = 0
+
+    def write(self, file: Writable, dest: Optional[str] = None, **kwargs: Any) -> Tuple[bool, str]:
+        self.write_count += 1
+        raise Exception("I'm bad")
+        return False, ""
+
+    def option(self, **kwargs: Any) -> "BadWriter":
+        return self
+
+
+class TestWriter(Writer):
+    write_count = 0
+
+    def write(self, file: Writable, dest: Optional[str] = None, **kwargs: Any) -> Tuple[bool, str]:
+        self.write_count += 1
+        return True, ""
+
+    def option(self, **kwargs: Any) -> "TestWriter":
+        return self
+
+
+def test_happy_path() -> None:
+    writer = TestWriter()
+    logger = MultiDatasetRollingLogger(writers=[writer])
+
+    ts = 1677207714000
+    row = {"col1": 1, "col2": "b"}
+    logger.log(row, timestamp_ms=ts)
+    logger.log(row, timestamp_ms=ts)
+    logger.log(row, timestamp_ms=ts)
+
+    result = logger._status()
+    assert result.dataset_profiles == 1
+    assert result.dataset_timestamps == 1
+    assert result.segment_caches == 0
+    logger.close()
+    assert writer.write_count == 1
+
+
+def test_track_errors_throw() -> None:
+    writer = TestWriter()
+    logger = MultiDatasetRollingLogger(writers=[writer])
+
+    ts = 1677207714000
+    wrong_format: Any = 2  # Invalid data format
+
+    with pytest.raises(Exception):
+        logger.log(wrong_format, timestamp_ms=ts, sync=True)
+    logger.close()
+
+
+def test_log_multiple_rows() -> None:
+    writer = TestWriter()
+    logger = MultiDatasetRollingLogger(writers=[writer])
+
+    ts = 1677207714000
+    row = {"col1": 1, "col2": "b"}
+    logger.log([row, row, row, row], timestamp_ms=ts)
+
+    result = logger._status()
+
+    assert result.dataset_profiles == 1
+    assert result.dataset_timestamps == 1
+    assert result.segment_caches == 0
+    logger.close()
+    assert writer.write_count == 1
+
+
+def test_logging_after_close_throws() -> None:
+    writer = TestWriter()
+    logger = MultiDatasetRollingLogger(writers=[writer])
+
+    ts = 1677207714000
+    row = {"col1": 1, "col2": "b"}
+    logger.log([row, row, row, row], timestamp_ms=ts)
+
+    result = logger._status()
+
+    assert result.dataset_profiles == 1
+    assert result.dataset_timestamps == 1
+    assert result.segment_caches == 0
+
+    logger.close()
+    assert writer.write_count == 1
+
+    with pytest.raises(Exception):
+        logger.log([row, row, row, row], timestamp_ms=ts)
+
+
+def test_multiple_loggers_work() -> None:
+    """
+    This test should finish without hanging forever.
+    """
+    logger = MultiDatasetRollingLogger()
+    logger.close()
+
+    logger = MultiDatasetRollingLogger()
+    row = {"col1": 1, "col2": "b"}
+    logger.log(row)
+
+    logger._status()
+    logger.close()
+
+
+def test_flushing_doesnt_break_everything() -> None:
+    writer = TestWriter()
+    logger = MultiDatasetRollingLogger(writers=[writer])
+
+    ts = 1677207714000
+    row = {"col1": 1, "col2": "b"}
+
+    logger.log(row, timestamp_ms=ts)
+    logger.flush()
+
+    logger.log(row, timestamp_ms=ts)
+    logger.flush()
+
+    logger.log(row, timestamp_ms=ts)
+    logger.flush()
+
+    result = logger._status()
+
+    assert result.dataset_profiles == 0
+    assert result.dataset_timestamps == 0
+    assert result.segment_caches == 0
+    logger.close()
+    assert writer.write_count == 3
+
+
+def test_bad_writer() -> None:
+    row = {"col1": 1, "col2": "b"}
+    writer = BadWriter()
+    logger = MultiDatasetRollingLogger(writers=[writer], aggregate_by=TimeGranularity.Hour)
+
+    # Create profiles for three different time periods
+    date = datetime.fromtimestamp(1677207714, tz=tz.tzutc())
+    one_hour = timedelta(hours=1)
+    logger.log(row, int((date - one_hour).timestamp() * 1000))
+    logger.log(row, int((date - one_hour - one_hour).timestamp() * 1000))
+    logger.log(row, int((date - one_hour - one_hour - one_hour).timestamp() * 1000))
+
+    # Confirm we have three profiles
+    result = logger._status()
+    assert result.dataset_profiles == 3
+    assert result.dataset_timestamps == 3
+    assert result.segment_caches == 0
+    assert result.pending_writables == 0
+    assert result.writers == 1
+    assert writer.write_count == 0
+
+    # Flush and trigger doomed writes. The profiles should still be pending after the flush
+    logger.flush()
+    result2 = logger._status()
+    assert result2.dataset_profiles == 0
+    assert result2.dataset_timestamps == 0
+    assert result2.segment_caches == 0
+    assert result2.pending_writables == 3
+    assert result2.writers == 1
+    assert writer.write_count == 3
+
+    # And confirm that they are retried in further flushes
+    logger.close()
+    assert writer.write_count == 9
+
+
+def test_segments_works() -> None:
+    col1_3_partition = SegmentationPartition(
+        name="col1,col3",
+        mapper=ColumnMapperFunction(col_names=["col1", "col3"]),
+    )
+    multi_column_segments = {col1_3_partition.name: col1_3_partition}
+    schema = DatasetSchema(segments=multi_column_segments)
+
+    ts = 1677207714000
+    row = {"col1": 1, "col2": "b", "col3": 0.1}
+    writer = BadWriter()
+    logger = MultiDatasetRollingLogger(writers=[writer], aggregate_by=TimeGranularity.Hour, schema=schema)
+
+    logger.log(row, timestamp_ms=ts, sync=True)
+
+    result = logger._status()
+    assert result.dataset_profiles == 0
+    assert result.dataset_timestamps == 1
+    assert result.segment_caches == 1
+    assert result.pending_writables == 0
+    assert result.writers == 1
+    assert writer.write_count == 0
+
+    logger.flush()
+    result2 = logger._status()
+
+    assert result2.dataset_profiles == 0
+    assert result2.dataset_timestamps == 0
+    assert result2.segment_caches == 0
+    assert result2.pending_writables == 1
+    assert result2.writers == 1
+    assert writer.write_count == 1
+    logger.close()
+
+
+def test_multiple_segments_works() -> None:
+    col1_3_partition = SegmentationPartition(
+        name="col1",
+        mapper=ColumnMapperFunction(col_names=["col1"]),
+    )
+    multi_column_segments = {col1_3_partition.name: col1_3_partition}
+    schema = DatasetSchema(segments=multi_column_segments)
+
+    ts = 1677207714000
+    # Create data with three segments/three unique col1 values
+    data = [
+        {"col1": 1, "col2": "b", "col3": 0.1},
+        {"col1": 2, "col2": "b", "col3": 0.2},
+        {"col1": 3, "col2": "b", "col3": 0.2},
+    ]
+    writer = BadWriter()
+    logger = MultiDatasetRollingLogger(writers=[writer], aggregate_by=TimeGranularity.Hour, schema=schema)
+
+    logger.log(data, timestamp_ms=ts, sync=True)
+
+    result = logger._status()
+    assert result.dataset_profiles == 0
+    assert result.dataset_timestamps == 1
+    assert result.segment_caches == 1
+    assert result.pending_writables == 0
+    assert result.writers == 1
+    assert writer.write_count == 0
+
+    logger.flush()
+    result2 = logger._status()
+
+    assert result2.dataset_profiles == 0
+    assert result2.dataset_timestamps == 0
+    assert result2.segment_caches == 0
+    assert result2.pending_writables == 3
+    assert result2.writers == 1
+    assert writer.write_count == 3
+    logger.close()

--- a/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
+++ b/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
@@ -1,0 +1,23 @@
+import time
+
+from whylogs.api.logger.experimental.multi_dataset_logger.time_util import (
+    FunctionTimer,
+    Schedule,
+    TimeGranularity,
+)
+
+
+def test_seconds_work() -> None:
+    class Foo:
+        def __init__(self) -> None:
+            self.i = 0
+
+        def inc(self) -> None:
+            self.i += 1
+
+    f = Foo()
+    t = FunctionTimer(Schedule(TimeGranularity.Second, 1), f.inc)
+    time.sleep(3)
+    t.stop()
+
+    assert f.i >= 3

--- a/python/whylogs/api/logger/experimental/multi_dataset_logger/future_util.py
+++ b/python/whylogs/api/logger/experimental/multi_dataset_logger/future_util.py
@@ -1,0 +1,21 @@
+from concurrent.futures import Future, wait
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def wait_result(future: Future[T]) -> T:
+    done, not_done = wait([future])
+    all = done.union(not_done)
+    for it in all:
+        e = it.exception()
+        r = it.result()
+
+        if e is not None:
+            raise e
+        elif it.cancelled():
+            raise Exception("cancelled")
+        else:
+            return r
+
+    raise Exception("Couldn't find a result")

--- a/python/whylogs/api/logger/experimental/multi_dataset_logger/message_processor.py
+++ b/python/whylogs/api/logger/experimental/multi_dataset_logger/message_processor.py
@@ -1,0 +1,67 @@
+import logging
+from abc import ABC, abstractmethod
+from queue import Empty, Full, Queue
+from threading import Event, Thread
+from typing import Generic, TypeVar, Union
+
+
+class CloseMessage:
+    pass
+
+
+MessageType = TypeVar("MessageType")
+
+
+class MessageProcessor(ABC, Generic[MessageType], Thread):
+    def __init__(self) -> None:
+        super().__init__()
+        self._logger = logging.getLogger(f"{type(self).__name__}_{id(self)}")
+        self._queue: Queue[Union[MessageType, CloseMessage]] = Queue(100_000)
+        self.daemon = True
+        self._is_done = Event()
+        self._closed = False
+        self.start()
+
+    def run(self) -> None:
+        self._process_messages()
+
+    def _process_messages(self) -> None:
+        while not self._is_done.is_set():
+            try:
+                message = self._queue.get(timeout=0.1)
+                self._logger.debug(f"Handling message {type(message).__name__}")
+                self._process_message(message)
+            except Empty:
+                if self._closed:
+                    self._logger.info("Done processing message queue")
+                    self._is_done.set()
+            except Full:
+                self._logger.warning("Message queue full")
+            except Exception as e:
+                self._logger.exception(e)
+
+    @abstractmethod
+    def _process_message(self, message: Union[MessageType, CloseMessage]) -> None:
+        pass
+
+    def send(self, message: Union[MessageType, CloseMessage]) -> None:
+        if self._closed:
+            raise Exception("Logger is closed")
+
+        if isinstance(message, CloseMessage):
+            self._closed = True
+
+        done = False
+        while not done:
+            try:
+                self._queue.put(message, timeout=0.1)
+                done = True
+            except Full:
+                self._logger.warn("Message queue full, trying again")
+
+    def close(self) -> None:
+        self.send(CloseMessage())
+        self._logger.info("Waiting for message processing to finish")
+        self._is_done.wait()
+        self._logger.info("Message processing finished")
+        self.join()

--- a/python/whylogs/api/logger/experimental/multi_dataset_logger/multi_dataset_rolling_logger.py
+++ b/python/whylogs/api/logger/experimental/multi_dataset_logger/multi_dataset_rolling_logger.py
@@ -1,0 +1,362 @@
+from concurrent.futures import Future
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
+
+import pandas as pd
+from dateutil import tz
+
+from whylogs.api.logger.result_set import ProfileResultSet, ResultSet
+from whylogs.api.logger.segment_cache import SegmentCache
+from whylogs.api.logger.segment_processing import segment_processing
+from whylogs.api.store import ProfileStore
+from whylogs.api.writer import Writer
+from whylogs.api.writer.writer import Writable
+from whylogs.core import DatasetProfile, DatasetSchema
+
+from .future_util import wait_result
+from .message_processor import CloseMessage, MessageProcessor
+from .time_util import (
+    FunctionTimer,
+    Schedule,
+    TimeGranularity,
+    current_time_ms,
+    truncate_time_ms,
+)
+
+Row = Dict[str, Any]
+TrackData = Union[pd.DataFrame, Row, List[Row]]
+
+
+class DatasetProfileContainer:
+    """
+    A container that abstracts over different types of profiles.
+
+    This does the work of deciding how to track data and how to create profiles given a DatasetSchema.
+    This can only be used to manage a single entity for a given time. For example, this can represent
+    a normal DatasetProfile or segment that has a given dataset timestamp.
+    """
+
+    _target: Union[DatasetProfile, SegmentCache]
+
+    def __init__(self, dataset_timestamp: int, schema: Optional[DatasetSchema]) -> None:
+        self._schema: Optional[DatasetSchema] = schema
+        self._active = True
+        self._dataset_timestamp = datetime.fromtimestamp(dataset_timestamp / 1000.0, tz=tz.tzutc())
+        if self._has_segments() and schema is not None:  # Need the duplicate None check for type safety
+            self._target = SegmentCache(schema=schema)
+        else:
+            self._target = DatasetProfile(dataset_timestamp=self._dataset_timestamp)
+
+    def _has_segments(self) -> bool:
+        return self._schema is not None and self._schema.segments is not None
+
+    def _track_segments(self, data: TrackData) -> None:
+        if self._schema is None:
+            raise Exception("Schema missing in logger while using segments")
+
+        if not isinstance(self._target, SegmentCache):
+            raise Exception("Segment cache missing in logger while using segments")
+
+        if isinstance(data, List):
+            for row in data:
+                segment_processing(self._schema, row=row, segment_cache=self._target)
+        else:
+            segment_processing(self._schema, data, segment_cache=self._target)
+
+    def _track_profile(self, data: TrackData) -> None:
+        if not isinstance(self._target, DatasetProfile):
+            raise Exception("Dataset profile missing in logger")
+
+        if isinstance(data, List):
+            for row in data:
+                self._target.track(row=row)
+        else:
+            self._target.track(data)
+
+    def track(self, data: TrackData) -> None:
+        """
+        Track data against the contained profile or segment.
+        """
+        if not self._active:
+            # Should never happen
+            raise Exception("Profile container no longer active.")
+
+        if self._has_segments():
+            self._track_segments(data)
+        else:
+            self._track_profile(data)
+
+    def to_result_set(self) -> ResultSet:
+        """
+        Get the ResultSet of the contained profile/segment.
+
+        This doesn't have any side effects. It generates a ResultSet of whatever
+        is inside when this is called.
+        """
+        try:
+            if isinstance(self._target, SegmentCache):
+                return self._target.flush(dataset_timestamp=self._dataset_timestamp)
+            elif isinstance(self._target, DatasetProfile):
+                return ProfileResultSet(self._target)
+        finally:
+            self._active = False
+
+
+@dataclass
+class TrackMessage:
+    """
+    Send some data to be tracked.
+
+    Attributes:
+        data: The data to be tracked.
+        timestamp_ms: The time in milliseconds when the data occurred.
+        result: an optional Future that is fulfilled when the track has completed. It will either
+            be a success (None) or a failure (Exception).
+    """
+
+    data: TrackData
+    timestamp_ms: int
+    result: Optional[Future[None]]
+
+
+@dataclass
+class FlushMessage:
+    """
+    Trigger a flush, converting all managed profiles to result sets and attempt to write them if there are writers.
+    """
+
+    pass
+
+
+@dataclass
+class LoggerStatus:
+    """
+    Various status metrics.
+
+    This returns various metadata about the current state. Useful for logging, testing, and debugging.
+
+    Attributes:
+        dataset_timestamps: The amount of dataset timestamps being managed. Each of these will map
+            to either a profile or a segment.
+        dataset_profiles: The amount of dataset profiles being managed. One of these is created for
+            each time period that the logger is configured to manage. For example, if the logger is configured
+            to aggregate by hour and TrackMessages come in for two hours, then there will be two of these.
+        segment_caches: Same as dataset_profiles, but for segments.
+        writers: Amount of writers that the logger is configured to have.
+        pending_writables: The amount of items that have been flushed but have not yet been written.
+    """
+
+    dataset_timestamps: int
+    dataset_profiles: int
+    segment_caches: int
+    writers: int
+    pending_writables: int
+
+
+@dataclass
+class StatusMessage:
+    """
+    Get various status metrics.
+    """
+
+    result: Future[LoggerStatus]
+
+
+@dataclass
+class PendingWritable:
+    attempts: int
+    writable: Writable
+
+
+LoggerMessage = Union[TrackMessage, FlushMessage, StatusMessage]
+
+
+class MultiDatasetRollingLogger(MessageProcessor[LoggerMessage]):
+    """
+    A logger that manages profiles and segments for various dataset timestamps.
+
+    This logger manages a map of dataset timestamp to dataset profile/segment and handles proper
+    logging to each type. Given a TimeGranularity to aggregate by, for each call to track(), roughly
+    the following will happen:
+
+        - The timestamp_ms will be truncated to the start of the day/hour (depending on aggregate_by). This
+            is the dataset timestamp.
+        - That dataset timestamp is used as the key to either create a dataset profile/segment, or to add
+            the current data to.
+
+    The logger also periodically attempts to write out the internal state according to the write_schedule. It
+    will attempt to write three times before considering a result set unwritable and dropping it. o
+
+    The logger is associated with one or no dataset schema as well. That will determine if the logger creates
+    normal profiles or segments internally, among other things.
+    """
+
+    def __init__(
+        self,
+        aggregate_by: TimeGranularity = TimeGranularity.Hour,
+        write_schedule: Schedule = Schedule(cadence=TimeGranularity.Minute, interval=10),
+        schema: Optional[DatasetSchema] = None,
+        writers: List[Writer] = [],
+    ) -> None:
+        self._aggregate_by = aggregate_by
+        self._cache: Dict[int, DatasetProfileContainer] = {}
+        self._writers: Dict[Writer, List[PendingWritable]] = {}
+        # TODO support stores as well after its updated to be able to handle Writable. This tracks segments
+        # as well as profiles and I would have to manually convert the SegmentCache into a compatible type.
+        for writer in writers:
+            self._writers[writer] = []
+        self._schema: Optional[DatasetSchema] = schema
+        self._store_list: List[ProfileStore] = []
+
+        if write_schedule.cadence == TimeGranularity.Second:
+            raise Exception("Minimum write schedule is five minutes.")
+
+        if write_schedule.cadence == TimeGranularity.Minute and write_schedule.interval < 5:
+            raise Exception("Minimum write schedule is five minutes.")
+
+        self._timer = FunctionTimer(write_schedule, self.flush)
+        super().__init__()
+
+    def _process_message(self, message: Union[LoggerMessage, CloseMessage]) -> None:
+        if isinstance(message, TrackMessage):
+            self._process_track_message(message)
+        elif isinstance(message, FlushMessage):
+            self._process_flush_message(message)
+        elif isinstance(message, CloseMessage):
+            self._process_close_message(message)
+        elif isinstance(message, StatusMessage):
+            self._process_status_message(message)
+        else:
+            # Safe guard for forgetting to handle a message in development
+            raise Exception(f"Don't know how to handle message {message}")
+
+    def _process_status_message(self, message: StatusMessage) -> None:
+        profiles = 0
+        segment_caches = 0
+        for ts, container in self._cache.items():
+            if container._has_segments():
+                segment_caches += 1
+            else:
+                profiles += 1
+
+        writers = 0
+        writables = 0
+        for writer, stuff in self._writers.items():
+            writers += 1
+            writables += len(stuff)
+
+        status = LoggerStatus(
+            dataset_timestamps=len(self._cache),
+            dataset_profiles=profiles,
+            segment_caches=segment_caches,
+            writers=writers,
+            pending_writables=writables,
+        )
+        message.result.set_result(status)
+
+    def _process_close_message(self, message: CloseMessage) -> None:
+        self._timer.stop()
+        # Force wait for all writers to handle their pending items
+        self._process_flush_message(FlushMessage())
+        while self._has_pending():
+            self._process_flush_message(FlushMessage())
+
+    def _has_pending(self) -> bool:
+        has_pending = False
+        for writer, pending in self._writers.items():
+            has_pending = len(pending) > 0
+        return has_pending
+
+    def _process_flush_message(self, message: FlushMessage) -> None:
+        for dataset_timestamp, container in self._cache.items():
+            self._logger.debug(f"Generating result set for dataset timestamp {dataset_timestamp}")
+
+            for pending in self._writers.values():
+                for writable in container.to_result_set().get_writables() or []:
+                    pending.append(PendingWritable(attempts=0, writable=writable))
+
+        self._cache = {}
+        self._write_pending()
+
+    def _write_pending(self) -> None:
+        new_state: Dict[Writer, List[PendingWritable]] = {}
+        for writer, pending in self._writers.items():
+            failures: List[PendingWritable] = []
+            self._logger.info(f"Writing out result set with {type(writer).__name__}")
+            for p in pending:
+                self._logger.debug(f"Writing {p.attempts} attempt")
+                failed = False
+                try:
+                    success, msg = writer.write(p.writable)
+
+                    if not success:
+                        self._logger.error(f"Couldn't write profile: {msg}")
+                        failed = True
+                except Exception as e:
+                    self._logger.exception(e)
+                    failed = True
+
+                if failed:
+                    p.attempts += 1
+                    if p.attempts < 3:
+                        failures.append(p)
+                    else:
+                        self._logger.info(f"Writing failed too many times ({p.attempts}) for {type(writer).__name__}")
+            new_state[writer] = failures
+        self._writers = new_state
+
+    def _get_profile_container(self, dataset_timestamp: int) -> DatasetProfileContainer:
+        if dataset_timestamp not in self._cache:
+            self._cache[dataset_timestamp] = DatasetProfileContainer(dataset_timestamp, schema=self._schema)
+
+        return self._cache[dataset_timestamp]
+
+    def _process_track_message(self, message: TrackMessage) -> None:
+        try:
+            timestamp_ms = message.timestamp_ms
+            data = message.data
+
+            ts = timestamp_ms or current_time_ms()
+            dataset_timestamp = truncate_time_ms(ts, self._aggregate_by)
+            profile_container = self._get_profile_container(dataset_timestamp)
+            profile_container.track(data)
+            if message.result is not None:
+                message.result.set_result(None)
+        except Exception as e:
+            if message.result is not None:
+                message.result.set_exception(e)
+
+    def _status(self) -> LoggerStatus:
+        result: Future[LoggerStatus] = Future()
+        self.send(StatusMessage(result))
+        return wait_result(result)
+
+    def log(
+        self,
+        data: TrackData,
+        timestamp_ms: Optional[int] = None,  # Not the dataset timestamp, but the timestamp of the data
+        sync: bool = False,
+    ) -> None:
+        """
+        Log some data.
+
+        Parameters:
+            data: The data to log. This can either be a pandas data frame, a row (dictionary of str to str/int/float/etc),
+                or a list of rows.
+            timestamp_ms: The timestamp of the data. If this isn't supplied then it is assumed to have happened now.
+            sync: Whether or not to perform this action synchronously. By default, this is an asynchronous operation.
+                You can make this synchronous in order to react to errors. Mostly useful when initially setting up
+                logging since the only errors that can be responded to are data format related.
+
+        """
+        result: Optional[Future[None]] = Future() if sync else None
+        self.send(TrackMessage(data=data, timestamp_ms=timestamp_ms or current_time_ms(), result=result))
+        if result is not None:
+            wait_result(result)
+
+    def flush(self) -> None:
+        """
+        Flush the internal state, causing everything to be written using the configured writers.
+        """
+        self.send(FlushMessage())

--- a/python/whylogs/api/logger/experimental/multi_dataset_logger/time_util.py
+++ b/python/whylogs/api/logger/experimental/multi_dataset_logger/time_util.py
@@ -1,0 +1,99 @@
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import Enum
+from threading import Timer
+from typing import Callable
+
+from dateutil import tz
+
+
+def current_time_ms() -> int:
+    return time.time_ns() // 1_000_000
+
+
+class TimeGranularity(Enum):
+    Second = "Second"
+    Minute = "Minute"
+    Hour = "Hour"
+    Day = "Day"
+    Month = "Month"
+
+
+def truncate_time_ms(t: int, granularity: TimeGranularity) -> int:
+    dt = datetime.fromtimestamp(t / 1000, tz=tz.tzutc()).replace(second=0, microsecond=0)
+
+    if granularity == TimeGranularity.Minute:
+        trunc = dt
+    elif granularity == TimeGranularity.Hour:
+        trunc = dt.replace(minute=0)
+    elif granularity == TimeGranularity.Day:
+        trunc = dt.replace(minute=0, hour=0)
+    elif granularity == TimeGranularity.Month:
+        trunc = dt.replace(minute=0, hour=0, day=0)
+
+    return int(trunc.timestamp() * 1000)
+
+
+@dataclass
+class Schedule:
+    cadence: TimeGranularity
+    interval: int
+
+
+class FunctionTimer:
+    """
+    A timer that executes a function repeatedly given a Schedule. It will execute at the bottom of
+    that time period. For example, a schedule of Schedule(TimeGranularity.Hour, 1) will execute at
+    the start of each hour. If you start the timer 5 minutes before the next hour then it will first
+    execute in five minutes, and then each hour after that.
+    """
+
+    def __init__(self, schedule: Schedule, fn: Callable) -> None:
+        self._logger = logging.getLogger(f"{type(self).__name__}_{id(self)}")
+        self._fn = fn
+        self._schedule = schedule
+        self._running = True
+        now = datetime.now(tz=tz.tzutc())
+
+        # Convert each of the intervals into seconds
+        if schedule.cadence == TimeGranularity.Second:
+            self.repeat_interval = schedule.interval
+            next_second = (now + timedelta(minutes=self._schedule.interval)).replace(microsecond=0)
+            initial_interval = min(0, (next_second - now).seconds)
+        elif schedule.cadence == TimeGranularity.Minute:
+            self.repeat_interval = schedule.interval * 60
+            next_minute = (now + timedelta(minutes=self._schedule.interval)).replace(microsecond=0, second=0)
+            initial_interval = (next_minute - now).seconds
+        elif schedule.cadence == TimeGranularity.Hour:
+            self.repeat_interval = schedule.interval * 60 * 60
+            next_hour = (now + timedelta(hours=self._schedule.interval)).replace(microsecond=0, second=0, minute=0)
+            initial_interval = (next_hour - now).seconds
+        elif schedule.cadence == TimeGranularity.Day:
+            self.repeat_interval = schedule.interval * 60 * 60 * 24
+            next_day = (now + timedelta(days=self._schedule.interval)).replace(
+                microsecond=0, second=0, minute=0, hour=0
+            )
+            initial_interval = (next_day - now).seconds
+        elif schedule.cadence == TimeGranularity.Month:
+            raise Exception("Can't use Monthly schedule.")
+
+        self._logger.debug(f"scheduled for {initial_interval} seconds from now")
+        self._timer = Timer(initial_interval, self._run)
+        self._timer.start()
+
+    def _run(self) -> None:
+        self._logger.debug(f"scheduled for {self.repeat_interval} seconds from now")
+        self._timer = Timer(self.repeat_interval, self._run)
+        self._timer.start()
+        self._fn()
+
+    def is_alive(self) -> bool:
+        return self._timer.is_alive()
+
+    def stop(self) -> None:
+        if not self._running:
+            raise Exception("Timer already stopped")
+        self._timer.cancel()
+        self._running = False

--- a/python/whylogs/api/logger/logger.py
+++ b/python/whylogs/api/logger/logger.py
@@ -70,7 +70,14 @@ class Logger(ABC):
         pandas: Optional[pd.DataFrame] = None,
         row: Optional[Dict[str, Any]] = None,
         schema: Optional[DatasetSchema] = None,
+        timestamp_ms: Optional[int] = None,  # Not the dataset timestamp, but the timestamp of the data
     ) -> ResultSet:
+        """
+        Args:
+            timestamp_ms: The timestamp of the data being logged. This defaults to now if it isn't provided.
+             This is used to determine what the dataset timestamp should be. For an hourly model, the dataset
+             timestamp will end up being the start of the hour of the provided timestamp_ms, UTC.
+        """
         if self._is_closed:
             raise LoggingError("Cannot log to a closed logger")
         if obj is None and pandas is None and row is None:

--- a/python/whylogs/api/store/profile_store.py
+++ b/python/whylogs/api/store/profile_store.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from typing import List
+from typing import Generator, List
 
 from whylogs.api.store.query import BaseQuery, DateQuery
 from whylogs.core import DatasetProfileView
@@ -15,12 +15,18 @@ class ProfileStore(ABC):
     def get(self, query: BaseQuery) -> DatasetProfileView:
         pass
 
+    # TODO this has to be updated to be able to handle more types of things. It might be better to just
+    # accept any Writable instead of the concrete types, like Writer does.
     @abstractmethod
     def write(self, profile_view: DatasetProfileView, dataset_id: str) -> None:
         pass
 
     @staticmethod
-    def _get_date_range(query: DateQuery):
+    def _get_date_range(query: DateQuery) -> Generator[datetime, None, None]:
+        if query.end_date is None:
+            yield query.start_date
+            return
+
         for n in range(int((query.end_date - query.start_date).days) + 1):
             yield query.start_date + timedelta(n)
 


### PR DESCRIPTION
The current implementation of rolling logger has a few properties that make it unusable for the python whylogs container:

- It assumes all logged data has a dataset timestamp of now() and merges it into the current (only) profile.
- It has potential to upload data for future dates.
- It conflates upload schedule with dataset profile timestamp.
- It has the potential to tear logging between dataset profiles if logging happens during writing.

The new logger breaks the interface of the current Logger to enable different behavior. Now, the log() method takes in a timestamp that indicates when the data being logged happened, which is used to determine what dataset profile or segment cache the data should be logged to. Internally, it maintains a map of dataset timestamp to dataset profile/segment cache. The dataset timestamp is created by the aggregate_by configuration, where it can be Hourly, Daily, etc. For Hourly, the timestamp will be truncated to the hour.

Dataset timestamps are always the floor of the time interval so no data can be uploaded to future times.

You can separately configure the upload interval and the model type, which is important for the container since it has to distinguish between the two in the context of late data.

The tearing issue is resolved by using a message queue internally for all actions so that they're handled in serial. This does mean that logging is paused while uploading happens but log() is also asynchronous by default now so that won't add additional latency to the caller. The message queue is processed using a Thread. It's up to the caller to close the logger during application shutdown as well, which will start a synchronous series of cleanup events and profile writing.
