### PR TITLE
update pip install command in examples

### DIFF
--- a/python/examples/advanced/Condition_Count_Metrics.ipynb
+++ b/python/examples/advanced/Condition_Count_Metrics.ipynb
@@ -62,15 +62,6 @@
       ]
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "uGg7aTA_LESq"
-      },
-      "source": [
-        "Uncomment the cell below if you don't have whylogs installed yet:"
-      ]
-    },
-    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -78,6 +69,7 @@
       },
       "outputs": [],
       "source": [
+        "# Note: you may need to restart the kernel to use updated packages.\n",
         "%pip install whylogs"
       ]
     },
@@ -441,24 +433,7 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "        condition_count/between10and50  condition_count/not_42  \\\n",
-              "column                                                           \n",
-              "floats                               2                       4   \n",
-              "ints                                 2                       3   \n",
-              "\n",
-              "        condition_count/outside10and50  condition_count/total  \\\n",
-              "column                                                          \n",
-              "floats                               2                      4   \n",
-              "ints                                 2                      4   \n",
-              "\n",
-              "                      type  \n",
-              "column                      \n",
-              "floats  SummaryType.COLUMN  \n",
-              "ints    SummaryType.COLUMN  "
-            ],
             "text/html": [
               "\n",
               "  <div id=\"df-e9b14aa9-2dcb-420c-ada4-a9d10e954ac3\">\n",
@@ -592,10 +567,27 @@
               "    </div>\n",
               "  </div>\n",
               "  "
+            ],
+            "text/plain": [
+              "        condition_count/between10and50  condition_count/not_42  \\\n",
+              "column                                                           \n",
+              "floats                               2                       4   \n",
+              "ints                                 2                       3   \n",
+              "\n",
+              "        condition_count/outside10and50  condition_count/total  \\\n",
+              "column                                                          \n",
+              "floats                               2                      4   \n",
+              "ints                                 2                      4   \n",
+              "\n",
+              "                      type  \n",
+              "column                      \n",
+              "floats  SummaryType.COLUMN  \n",
+              "ints    SummaryType.COLUMN  "
             ]
           },
+          "execution_count": 16,
           "metadata": {},
-          "execution_count": 16
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -692,14 +684,7 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "        condition_count/isEven  condition_count/total                type\n",
-              "column                                                                   \n",
-              "floats                       0                      4  SummaryType.COLUMN\n",
-              "ints                         3                      4  SummaryType.COLUMN"
-            ],
             "text/html": [
               "\n",
               "  <div id=\"df-2592c9b8-9bb2-4345-ad73-92412b086290\">\n",
@@ -825,10 +810,17 @@
               "    </div>\n",
               "  </div>\n",
               "  "
+            ],
+            "text/plain": [
+              "        condition_count/isEven  condition_count/total                type\n",
+              "column                                                                   \n",
+              "floats                       0                      4  SummaryType.COLUMN\n",
+              "ints                         3                      4  SummaryType.COLUMN"
             ]
           },
+          "execution_count": 20,
           "metadata": {},
-          "execution_count": 20
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -959,19 +951,7 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "        condition_count/isPreprocessed  condition_count/total  \\\n",
-              "column                                                          \n",
-              "floats                               0                      4   \n",
-              "ints                                 0                      4   \n",
-              "\n",
-              "                      type  \n",
-              "column                      \n",
-              "floats  SummaryType.COLUMN  \n",
-              "ints    SummaryType.COLUMN  "
-            ],
             "text/html": [
               "\n",
               "  <div id=\"df-9f91867e-56a1-4a62-aab4-0a0694efe063\">\n",
@@ -1097,10 +1077,22 @@
               "    </div>\n",
               "  </div>\n",
               "  "
+            ],
+            "text/plain": [
+              "        condition_count/isPreprocessed  condition_count/total  \\\n",
+              "column                                                          \n",
+              "floats                               0                      4   \n",
+              "ints                                 0                      4   \n",
+              "\n",
+              "                      type  \n",
+              "column                      \n",
+              "floats  SummaryType.COLUMN  \n",
+              "ints    SummaryType.COLUMN  "
             ]
           },
+          "execution_count": 22,
           "metadata": {},
-          "execution_count": 22
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1197,24 +1189,7 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "                condition_count/containsCreditCard  \\\n",
-              "column                                               \n",
-              "emails                                           0   \n",
-              "transcriptions                                   1   \n",
-              "\n",
-              "                condition_count/containsEmail  condition_count/total  \\\n",
-              "column                                                                 \n",
-              "emails                                      1                      4   \n",
-              "transcriptions                              0                      4   \n",
-              "\n",
-              "                              type  \n",
-              "column                              \n",
-              "emails          SummaryType.COLUMN  \n",
-              "transcriptions  SummaryType.COLUMN  "
-            ],
             "text/html": [
               "\n",
               "  <div id=\"df-fd80b596-4462-432a-b0d8-0454ea183145\">\n",
@@ -1344,10 +1319,27 @@
               "    </div>\n",
               "  </div>\n",
               "  "
+            ],
+            "text/plain": [
+              "                condition_count/containsCreditCard  \\\n",
+              "column                                               \n",
+              "emails                                           0   \n",
+              "transcriptions                                   1   \n",
+              "\n",
+              "                condition_count/containsEmail  condition_count/total  \\\n",
+              "column                                                                 \n",
+              "emails                                      1                      4   \n",
+              "transcriptions                              0                      4   \n",
+              "\n",
+              "                              type  \n",
+              "column                              \n",
+              "emails          SummaryType.COLUMN  \n",
+              "transcriptions  SummaryType.COLUMN  "
             ]
           },
+          "execution_count": 23,
           "metadata": {},
-          "execution_count": 23
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1417,24 +1409,7 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "        condition_count/equals42  condition_count/equals42.2  \\\n",
-              "column                                                         \n",
-              "floats                         0                           1   \n",
-              "ints                           1                           0   \n",
-              "\n",
-              "        condition_count/lessthan5  condition_count/morethan40  \\\n",
-              "column                                                          \n",
-              "floats                          2                           1   \n",
-              "ints                            2                           1   \n",
-              "\n",
-              "        condition_count/total                type  \n",
-              "column                                             \n",
-              "floats                      4  SummaryType.COLUMN  \n",
-              "ints                        4  SummaryType.COLUMN  "
-            ],
             "text/html": [
               "\n",
               "  <div id=\"df-806fa713-1cff-4453-9433-6c837790efe5\">\n",
@@ -1572,10 +1547,27 @@
               "    </div>\n",
               "  </div>\n",
               "  "
+            ],
+            "text/plain": [
+              "        condition_count/equals42  condition_count/equals42.2  \\\n",
+              "column                                                         \n",
+              "floats                         0                           1   \n",
+              "ints                           1                           0   \n",
+              "\n",
+              "        condition_count/lessthan5  condition_count/morethan40  \\\n",
+              "column                                                          \n",
+              "floats                          2                           1   \n",
+              "ints                            2                           1   \n",
+              "\n",
+              "        condition_count/total                type  \n",
+              "column                                             \n",
+              "floats                      4  SummaryType.COLUMN  \n",
+              "ints                        4  SummaryType.COLUMN  "
             ]
           },
+          "execution_count": 24,
           "metadata": {},
-          "execution_count": 24
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1648,24 +1640,7 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "        condition_count/between10and50  condition_count/not_42  \\\n",
-              "column                                                           \n",
-              "floats                               2                       4   \n",
-              "ints                                 2                       3   \n",
-              "\n",
-              "        condition_count/outside10and50  condition_count/total  \\\n",
-              "column                                                          \n",
-              "floats                               2                      4   \n",
-              "ints                                 2                      4   \n",
-              "\n",
-              "                      type  \n",
-              "column                      \n",
-              "floats  SummaryType.COLUMN  \n",
-              "ints    SummaryType.COLUMN  "
-            ],
             "text/html": [
               "\n",
               "  <div id=\"df-f436c34d-7cbd-4388-9094-e85de1080bb6\">\n",
@@ -1799,10 +1774,27 @@
               "    </div>\n",
               "  </div>\n",
               "  "
+            ],
+            "text/plain": [
+              "        condition_count/between10and50  condition_count/not_42  \\\n",
+              "column                                                           \n",
+              "floats                               2                       4   \n",
+              "ints                                 2                       3   \n",
+              "\n",
+              "        condition_count/outside10and50  condition_count/total  \\\n",
+              "column                                                          \n",
+              "floats                               2                      4   \n",
+              "ints                                 2                      4   \n",
+              "\n",
+              "                      type  \n",
+              "column                      \n",
+              "floats  SummaryType.COLUMN  \n",
+              "ints    SummaryType.COLUMN  "
             ]
           },
+          "execution_count": 25,
           "metadata": {},
-          "execution_count": 25
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -1875,21 +1867,7 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "                condition_count/isEven  condition_count/isPreprocessed  \\\n",
-              "column                                                                   \n",
-              "floats                               0                               0   \n",
-              "ints                                 3                               0   \n",
-              "trasncriptions                       0                               1   \n",
-              "\n",
-              "                condition_count/total                type  \n",
-              "column                                                     \n",
-              "floats                              4  SummaryType.COLUMN  \n",
-              "ints                                4  SummaryType.COLUMN  \n",
-              "trasncriptions                      4  SummaryType.COLUMN  "
-            ],
             "text/html": [
               "\n",
               "  <div id=\"df-5f8813de-2372-495d-bf77-3e8e459efd37\">\n",
@@ -2026,10 +2004,24 @@
               "    </div>\n",
               "  </div>\n",
               "  "
+            ],
+            "text/plain": [
+              "                condition_count/isEven  condition_count/isPreprocessed  \\\n",
+              "column                                                                   \n",
+              "floats                               0                               0   \n",
+              "ints                                 3                               0   \n",
+              "trasncriptions                       0                               1   \n",
+              "\n",
+              "                condition_count/total                type  \n",
+              "column                                                     \n",
+              "floats                              4  SummaryType.COLUMN  \n",
+              "ints                                4  SummaryType.COLUMN  \n",
+              "trasncriptions                      4  SummaryType.COLUMN  "
             ]
           },
+          "execution_count": 27,
           "metadata": {},
-          "execution_count": 27
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -2097,8 +2089,11 @@
     }
   ],
   "metadata": {
+    "colab": {
+      "provenance": []
+    },
     "kernelspec": {
-      "display_name": "Python 3.9.5 ('base')",
+      "display_name": ".venv",
       "language": "python",
       "name": "python3"
     },
@@ -2112,16 +2107,13 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.9.5"
+      "version": "3.8.10"
     },
     "orig_nbformat": 4,
     "vscode": {
       "interpreter": {
-        "hash": "8148c804a5838694570acf40aa3269caeebb6c584d51452dd558e946dfc16d39"
+        "hash": "5dd5901cadfd4b29c2aaf95ecd29c0c3b10829ad94dcfe59437dbee391154aea"
       }
-    },
-    "colab": {
-      "provenance": []
     }
   },
   "nbformat": 4,

--- a/python/examples/advanced/Condition_Validators.ipynb
+++ b/python/examples/advanced/Condition_Validators.ipynb
@@ -52,6 +52,23 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Installing whylogs and importing modules"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Note: you may need to restart the kernel to use updated packages.\n",
+        "%pip install whylogs"
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "PTTPMKPSd2cz"
       },
@@ -310,16 +327,16 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "yzfke2a-d2c9",
-        "outputId": "bd6661aa-aa0b-469b-b4a6-6492db954acd",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "yzfke2a-d2c9",
+        "outputId": "bd6661aa-aa0b-469b-b4a6-6492db954acd"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Validator: has_emails\n",
             "    Condition name hasEmail failed for value my email is my_email_1989@gmail.com\n",
@@ -364,22 +381,22 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "mV33aJUYd2c_",
-        "outputId": "f64cf6e4-4224-4fe6-cc46-1c05121fcbb2",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "mV33aJUYd2c_",
+        "outputId": "f64cf6e4-4224-4fe6-cc46-1c05121fcbb2"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "{'total_evaluations': 4, 'hasEmail': 3}"
             ]
           },
+          "execution_count": 9,
           "metadata": {},
-          "execution_count": 9
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -390,22 +407,22 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "YdhYweCZd2c_",
-        "outputId": "3ab7bb42-44ab-4fb2-9604-b5d9b51857e7",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "YdhYweCZd2c_",
+        "outputId": "3ab7bb42-44ab-4fb2-9604-b5d9b51857e7"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "{'total_evaluations': 4, 'noCreditCard': 1}"
             ]
           },
+          "execution_count": 10,
           "metadata": {},
-          "execution_count": 10
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -414,8 +431,11 @@
     }
   ],
   "metadata": {
+    "colab": {
+      "provenance": []
+    },
     "kernelspec": {
-      "display_name": "Python 3.9.5 ('base')",
+      "display_name": ".venv",
       "language": "python",
       "name": "python3"
     },
@@ -429,16 +449,13 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.9.5"
+      "version": "3.8.10"
     },
     "orig_nbformat": 4,
     "vscode": {
       "interpreter": {
-        "hash": "8148c804a5838694570acf40aa3269caeebb6c584d51452dd558e946dfc16d39"
+        "hash": "5dd5901cadfd4b29c2aaf95ecd29c0c3b10829ad94dcfe59437dbee391154aea"
       }
-    },
-    "colab": {
-      "provenance": []
     }
   },
   "nbformat": 4,

--- a/python/examples/advanced/Custom_Metrics.ipynb
+++ b/python/examples/advanced/Custom_Metrics.ipynb
@@ -32,6 +32,7 @@
       },
       "outputs": [],
       "source": [
+        "# Note: you may need to restart the kernel to use updated packages.\n",
         "%pip install whylogs"
       ]
     },
@@ -295,7 +296,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3.8.10 ('.venv': poetry)",
+      "display_name": ".venv",
       "language": "python",
       "name": "python3"
     },
@@ -313,7 +314,7 @@
     },
     "vscode": {
       "interpreter": {
-        "hash": "d39f874c9b8a97550ecbd783714b95e79c9b905449b34f44c40e3bf053b54b41"
+        "hash": "5dd5901cadfd4b29c2aaf95ecd29c0c3b10829ad94dcfe59437dbee391154aea"
       }
     }
   },

--- a/python/examples/advanced/Drift_Algorithm_Configuration.ipynb
+++ b/python/examples/advanced/Drift_Algorithm_Configuration.ipynb
@@ -46,6 +46,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Installing whylogs\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install whylogs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Generating the Target and Reference Profiles"
    ]
   },

--- a/python/examples/advanced/Image_Logging.ipynb
+++ b/python/examples/advanced/Image_Logging.ipynb
@@ -47,7 +47,7 @@
       "outputs": [],
       "source": [
         "# Note: you may need to restart the kernel to use updated packages.\n",
-        "%pip install -q 'whylogs[image,whylabs]'"
+        "%pip install 'whylogs[image,whylabs]'"
       ]
     },
     {

--- a/python/examples/advanced/Image_Logging.ipynb
+++ b/python/examples/advanced/Image_Logging.ipynb
@@ -46,6 +46,7 @@
       },
       "outputs": [],
       "source": [
+        "# Note: you may need to restart the kernel to use updated packages.\n",
         "%pip install -q 'whylogs[image,whylabs]'"
       ]
     },
@@ -459,7 +460,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3.8.10 ('.venv': poetry)",
+      "display_name": "Python 3",
       "language": "python",
       "name": "python3"
     },
@@ -477,7 +478,7 @@
     },
     "vscode": {
       "interpreter": {
-        "hash": "d39f874c9b8a97550ecbd783714b95e79c9b905449b34f44c40e3bf053b54b41"
+        "hash": "916dbcbb3f70747c44a77c7bcd40155683ae19c65e1c03b4aa3499c5328201f1"
       }
     }
   },

--- a/python/examples/advanced/Log_Rotation_for_Streaming_Data/Streaming_Data_with_Log_Rotation.ipynb
+++ b/python/examples/advanced/Log_Rotation_for_Streaming_Data/Streaming_Data_with_Log_Rotation.ipynb
@@ -88,7 +88,8 @@
     }
    ],
    "source": [
-    "%pip install -q whylogs;"
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install whylogs;"
    ]
   },
   {

--- a/python/examples/advanced/Metric_Constraints.ipynb
+++ b/python/examples/advanced/Metric_Constraints.ipynb
@@ -35,6 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
     "%pip install 'whylogs[viz]'"
    ]
   },

--- a/python/examples/advanced/Metric_Constraints_with_Condition_Count_Metrics.ipynb
+++ b/python/examples/advanced/Metric_Constraints_with_Condition_Count_Metrics.ipynb
@@ -27,6 +27,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installing whylogs\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install whylogs"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/python/examples/advanced/Profile_Store/LocalStore/LocalStore_with_Constraints.ipynb
+++ b/python/examples/advanced/Profile_Store/LocalStore/LocalStore_with_Constraints.ipynb
@@ -1,37 +1,56 @@
 {
   "cells": [
     {
+      "attachments": {},
       "cell_type": "markdown",
+      "metadata": {
+        "collapsed": false,
+        "id": "DPe5QBtcib8V",
+        "pycharm": {
+          "name": "#%% md\n"
+        }
+      },
       "source": [
         "# Local Profile Store with Constraints\n",
         "\n",
         "Hey there! In this example we will understand how to setup the `LocalStore` and use it to track changes to our incoming data. It is an implementation of the `ProfileStore` that will manage listing, reading and writing whylogs' Dataset Profiles locally.\n",
         "\n",
+        "## Installing whylogs\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install whylogs"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "## Setting up\n",
         "The first thing you'll need to do to start using the `LocalStore` is instantiate the object and check if any profiles were written with the `list` method."
-      ],
-      "metadata": {
-        "collapsed": false,
-        "pycharm": {
-          "name": "#%% md\n"
-        },
-        "id": "DPe5QBtcib8V"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "6aTdd-q9ib8Z",
+        "outputId": "4628fb91-f4ce-487c-b6da-c0daafa0acce",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "6aTdd-q9ib8Z",
-        "outputId": "4628fb91-f4ce-487c-b6da-c0daafa0acce"
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/plain": "[]"
+            "text/plain": [
+              "[]"
+            ]
           },
           "execution_count": 1,
           "metadata": {},
@@ -48,10 +67,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "KJ02JYHRib8d",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "KJ02JYHRib8d"
+        }
       },
       "source": [
         "And since we have an empty list returned, it means that we haven't used the profile store in this location so far. But we can already check that a new directory called `profile_store` was created on our working directory:"
@@ -61,16 +80,18 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "iNFlI8awib8d",
+        "outputId": "b735310a-de1e-432c-e802-05425b7fec55",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "iNFlI8awib8d",
-        "outputId": "b735310a-de1e-432c-e802-05425b7fec55"
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/plain": "True"
+            "text/plain": [
+              "True"
+            ]
           },
           "execution_count": 2,
           "metadata": {},
@@ -85,10 +106,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "uCL2jzlwib8e",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "uCL2jzlwib8e"
+        }
       },
       "source": [
         "## Logging profiles\n",
@@ -100,10 +121,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "TSAPmEyqib8e",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "TSAPmEyqib8e"
+        }
       },
       "outputs": [],
       "source": [
@@ -116,10 +137,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "UsD2XQbKib8e",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "UsD2XQbKib8e"
+        }
       },
       "outputs": [],
       "source": [
@@ -137,10 +158,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "_GSEE5Qiib8f",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "_GSEE5Qiib8f"
+        }
       },
       "source": [
         "And then you should see new profiles created on your LocalStore. Let's investigate if that is actually the case:"
@@ -150,16 +171,19 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "IFxqGCLpib8f",
+        "outputId": "9a944577-a182-4d97-d811-4648a1d94dde",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "IFxqGCLpib8f",
-        "outputId": "9a944577-a182-4d97-d811-4648a1d94dde"
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/plain": "['profile_2022-11-29_14:11:3_019528a6-f5a9-4be5-8c53-709d9fec2f19.bin',\n 'profile_2022-11-29_14:11:0_a2f92dac-98a8-4fa2-b62c-b88733def863.bin']"
+            "text/plain": [
+              "['profile_2022-11-29_14:11:3_019528a6-f5a9-4be5-8c53-709d9fec2f19.bin',\n",
+              " 'profile_2022-11-29_14:11:0_a2f92dac-98a8-4fa2-b62c-b88733def863.bin']"
+            ]
           },
           "execution_count": 5,
           "metadata": {},
@@ -174,10 +198,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "TAJurTBlib8f",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "TAJurTBlib8f"
+        }
       },
       "source": [
         "## Read profiles from the store\n",
@@ -189,10 +213,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "SxZilMQYib8g",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "SxZilMQYib8g"
+        }
       },
       "outputs": [],
       "source": [
@@ -207,17 +231,198 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "UfGbEDS_ib8g",
+        "outputId": "5040bb7f-4ac0-4370-91a4-bbc7f28cc91f",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "UfGbEDS_ib8g",
-        "outputId": "5040bb7f-4ac0-4370-91a4-bbc7f28cc91f"
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/plain": "          cardinality/est  cardinality/lower_1  cardinality/upper_1  \\\ncolumn                                                                \ncolumn_1              4.0                  4.0               4.0002   \ncolumn_2              2.0                  2.0               2.0001   \ncolumn_3              2.0                  2.0               2.0001   \n\n          counts/inf  counts/n  counts/nan  counts/null  distribution/max  \\\ncolumn                                                                      \ncolumn_1           0       240           0            0              45.0   \ncolumn_2           0       240          60           60               2.0   \ncolumn_3           0       240           0            0               NaN   \n\n          distribution/mean  distribution/median  ...  distribution/stddev  \\\ncolumn                                            ...                        \ncolumn_1          12.750000                  3.0  ...            18.671909   \ncolumn_2           1.666667                  2.0  ...             0.472719   \ncolumn_3           0.000000                  NaN  ...             0.000000   \n\n                            frequent_items/frequent_strings  ints/max  \\\ncolumn                                                                  \ncolumn_1  [FrequentItem(value='2', est=60, upper=60, low...      45.0   \ncolumn_2                                                NaN       NaN   \ncolumn_3  [FrequentItem(value='strings', est=120, upper=...       NaN   \n\n          ints/min                type  types/boolean  types/fractional  \\\ncolumn                                                                    \ncolumn_1       1.0  SummaryType.COLUMN              0                 0   \ncolumn_2       NaN  SummaryType.COLUMN              0               180   \ncolumn_3       NaN  SummaryType.COLUMN              0                 0   \n\n          types/integral  types/object  types/string  \ncolumn                                                \ncolumn_1             240             0             0  \ncolumn_2               0             0             0  \ncolumn_3               0             0           240  \n\n[3 rows x 30 columns]",
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>cardinality/est</th>\n      <th>cardinality/lower_1</th>\n      <th>cardinality/upper_1</th>\n      <th>counts/inf</th>\n      <th>counts/n</th>\n      <th>counts/nan</th>\n      <th>counts/null</th>\n      <th>distribution/max</th>\n      <th>distribution/mean</th>\n      <th>distribution/median</th>\n      <th>...</th>\n      <th>distribution/stddev</th>\n      <th>frequent_items/frequent_strings</th>\n      <th>ints/max</th>\n      <th>ints/min</th>\n      <th>type</th>\n      <th>types/boolean</th>\n      <th>types/fractional</th>\n      <th>types/integral</th>\n      <th>types/object</th>\n      <th>types/string</th>\n    </tr>\n    <tr>\n      <th>column</th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>column_1</th>\n      <td>4.0</td>\n      <td>4.0</td>\n      <td>4.0002</td>\n      <td>0</td>\n      <td>240</td>\n      <td>0</td>\n      <td>0</td>\n      <td>45.0</td>\n      <td>12.750000</td>\n      <td>3.0</td>\n      <td>...</td>\n      <td>18.671909</td>\n      <td>[FrequentItem(value='2', est=60, upper=60, low...</td>\n      <td>45.0</td>\n      <td>1.0</td>\n      <td>SummaryType.COLUMN</td>\n      <td>0</td>\n      <td>0</td>\n      <td>240</td>\n      <td>0</td>\n      <td>0</td>\n    </tr>\n    <tr>\n      <th>column_2</th>\n      <td>2.0</td>\n      <td>2.0</td>\n      <td>2.0001</td>\n      <td>0</td>\n      <td>240</td>\n      <td>60</td>\n      <td>60</td>\n      <td>2.0</td>\n      <td>1.666667</td>\n      <td>2.0</td>\n      <td>...</td>\n      <td>0.472719</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>SummaryType.COLUMN</td>\n      <td>0</td>\n      <td>180</td>\n      <td>0</td>\n      <td>0</td>\n      <td>0</td>\n    </tr>\n    <tr>\n      <th>column_3</th>\n      <td>2.0</td>\n      <td>2.0</td>\n      <td>2.0001</td>\n      <td>0</td>\n      <td>240</td>\n      <td>0</td>\n      <td>0</td>\n      <td>NaN</td>\n      <td>0.000000</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>0.000000</td>\n      <td>[FrequentItem(value='strings', est=120, upper=...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>SummaryType.COLUMN</td>\n      <td>0</td>\n      <td>0</td>\n      <td>0</td>\n      <td>0</td>\n      <td>240</td>\n    </tr>\n  </tbody>\n</table>\n<p>3 rows × 30 columns</p>\n</div>"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>cardinality/est</th>\n",
+              "      <th>cardinality/lower_1</th>\n",
+              "      <th>cardinality/upper_1</th>\n",
+              "      <th>counts/inf</th>\n",
+              "      <th>counts/n</th>\n",
+              "      <th>counts/nan</th>\n",
+              "      <th>counts/null</th>\n",
+              "      <th>distribution/max</th>\n",
+              "      <th>distribution/mean</th>\n",
+              "      <th>distribution/median</th>\n",
+              "      <th>...</th>\n",
+              "      <th>distribution/stddev</th>\n",
+              "      <th>frequent_items/frequent_strings</th>\n",
+              "      <th>ints/max</th>\n",
+              "      <th>ints/min</th>\n",
+              "      <th>type</th>\n",
+              "      <th>types/boolean</th>\n",
+              "      <th>types/fractional</th>\n",
+              "      <th>types/integral</th>\n",
+              "      <th>types/object</th>\n",
+              "      <th>types/string</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>column</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>column_1</th>\n",
+              "      <td>4.0</td>\n",
+              "      <td>4.0</td>\n",
+              "      <td>4.0002</td>\n",
+              "      <td>0</td>\n",
+              "      <td>240</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>45.0</td>\n",
+              "      <td>12.750000</td>\n",
+              "      <td>3.0</td>\n",
+              "      <td>...</td>\n",
+              "      <td>18.671909</td>\n",
+              "      <td>[FrequentItem(value='2', est=60, upper=60, low...</td>\n",
+              "      <td>45.0</td>\n",
+              "      <td>1.0</td>\n",
+              "      <td>SummaryType.COLUMN</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>240</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>column_2</th>\n",
+              "      <td>2.0</td>\n",
+              "      <td>2.0</td>\n",
+              "      <td>2.0001</td>\n",
+              "      <td>0</td>\n",
+              "      <td>240</td>\n",
+              "      <td>60</td>\n",
+              "      <td>60</td>\n",
+              "      <td>2.0</td>\n",
+              "      <td>1.666667</td>\n",
+              "      <td>2.0</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0.472719</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>SummaryType.COLUMN</td>\n",
+              "      <td>0</td>\n",
+              "      <td>180</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>column_3</th>\n",
+              "      <td>2.0</td>\n",
+              "      <td>2.0</td>\n",
+              "      <td>2.0001</td>\n",
+              "      <td>0</td>\n",
+              "      <td>240</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>[FrequentItem(value='strings', est=120, upper=...</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>SummaryType.COLUMN</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>240</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>3 rows × 30 columns</p>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "          cardinality/est  cardinality/lower_1  cardinality/upper_1  \\\n",
+              "column                                                                \n",
+              "column_1              4.0                  4.0               4.0002   \n",
+              "column_2              2.0                  2.0               2.0001   \n",
+              "column_3              2.0                  2.0               2.0001   \n",
+              "\n",
+              "          counts/inf  counts/n  counts/nan  counts/null  distribution/max  \\\n",
+              "column                                                                      \n",
+              "column_1           0       240           0            0              45.0   \n",
+              "column_2           0       240          60           60               2.0   \n",
+              "column_3           0       240           0            0               NaN   \n",
+              "\n",
+              "          distribution/mean  distribution/median  ...  distribution/stddev  \\\n",
+              "column                                            ...                        \n",
+              "column_1          12.750000                  3.0  ...            18.671909   \n",
+              "column_2           1.666667                  2.0  ...             0.472719   \n",
+              "column_3           0.000000                  NaN  ...             0.000000   \n",
+              "\n",
+              "                            frequent_items/frequent_strings  ints/max  \\\n",
+              "column                                                                  \n",
+              "column_1  [FrequentItem(value='2', est=60, upper=60, low...      45.0   \n",
+              "column_2                                                NaN       NaN   \n",
+              "column_3  [FrequentItem(value='strings', est=120, upper=...       NaN   \n",
+              "\n",
+              "          ints/min                type  types/boolean  types/fractional  \\\n",
+              "column                                                                    \n",
+              "column_1       1.0  SummaryType.COLUMN              0                 0   \n",
+              "column_2       NaN  SummaryType.COLUMN              0               180   \n",
+              "column_3       NaN  SummaryType.COLUMN              0                 0   \n",
+              "\n",
+              "          types/integral  types/object  types/string  \n",
+              "column                                                \n",
+              "column_1             240             0             0  \n",
+              "column_2               0             0             0  \n",
+              "column_3               0             0           240  \n",
+              "\n",
+              "[3 rows x 30 columns]"
+            ]
           },
           "execution_count": 7,
           "metadata": {},
@@ -231,10 +436,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "yJLRM6gZib8h",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "yJLRM6gZib8h"
+        }
       },
       "source": [
         "The second approach is to get from a certain date range. Since we have written only two profiles for the same minute, we will end up with the same result from before. The nice thing about this is that it will allow users to fetch profiles for a moving window of reference, as we will demonstrate below:"
@@ -244,10 +449,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "HwKyZ6ICib8h",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "HwKyZ6ICib8h"
+        }
       },
       "outputs": [],
       "source": [
@@ -267,17 +472,198 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "vyjXqlM5ib8h",
+        "outputId": "519c5a92-2410-4337-9ff1-3ee7730dc83e",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "vyjXqlM5ib8h",
-        "outputId": "519c5a92-2410-4337-9ff1-3ee7730dc83e"
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/plain": "          cardinality/est  cardinality/lower_1  cardinality/upper_1  \\\ncolumn                                                                \ncolumn_1              4.0                  4.0               4.0002   \ncolumn_2              2.0                  2.0               2.0001   \ncolumn_3              2.0                  2.0               2.0001   \n\n          counts/inf  counts/n  counts/nan  counts/null  distribution/max  \\\ncolumn                                                                      \ncolumn_1           0       240           0            0              45.0   \ncolumn_2           0       240          60           60               2.0   \ncolumn_3           0       240           0            0               NaN   \n\n          distribution/mean  distribution/median  ...  distribution/stddev  \\\ncolumn                                            ...                        \ncolumn_1          12.750000                  3.0  ...            18.671909   \ncolumn_2           1.666667                  2.0  ...             0.472719   \ncolumn_3           0.000000                  NaN  ...             0.000000   \n\n                            frequent_items/frequent_strings  ints/max  \\\ncolumn                                                                  \ncolumn_1  [FrequentItem(value='2', est=60, upper=60, low...      45.0   \ncolumn_2                                                NaN       NaN   \ncolumn_3  [FrequentItem(value='strings', est=120, upper=...       NaN   \n\n          ints/min                type  types/boolean  types/fractional  \\\ncolumn                                                                    \ncolumn_1       1.0  SummaryType.COLUMN              0                 0   \ncolumn_2       NaN  SummaryType.COLUMN              0               180   \ncolumn_3       NaN  SummaryType.COLUMN              0                 0   \n\n          types/integral  types/object  types/string  \ncolumn                                                \ncolumn_1             240             0             0  \ncolumn_2               0             0             0  \ncolumn_3               0             0           240  \n\n[3 rows x 30 columns]",
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>cardinality/est</th>\n      <th>cardinality/lower_1</th>\n      <th>cardinality/upper_1</th>\n      <th>counts/inf</th>\n      <th>counts/n</th>\n      <th>counts/nan</th>\n      <th>counts/null</th>\n      <th>distribution/max</th>\n      <th>distribution/mean</th>\n      <th>distribution/median</th>\n      <th>...</th>\n      <th>distribution/stddev</th>\n      <th>frequent_items/frequent_strings</th>\n      <th>ints/max</th>\n      <th>ints/min</th>\n      <th>type</th>\n      <th>types/boolean</th>\n      <th>types/fractional</th>\n      <th>types/integral</th>\n      <th>types/object</th>\n      <th>types/string</th>\n    </tr>\n    <tr>\n      <th>column</th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>column_1</th>\n      <td>4.0</td>\n      <td>4.0</td>\n      <td>4.0002</td>\n      <td>0</td>\n      <td>240</td>\n      <td>0</td>\n      <td>0</td>\n      <td>45.0</td>\n      <td>12.750000</td>\n      <td>3.0</td>\n      <td>...</td>\n      <td>18.671909</td>\n      <td>[FrequentItem(value='2', est=60, upper=60, low...</td>\n      <td>45.0</td>\n      <td>1.0</td>\n      <td>SummaryType.COLUMN</td>\n      <td>0</td>\n      <td>0</td>\n      <td>240</td>\n      <td>0</td>\n      <td>0</td>\n    </tr>\n    <tr>\n      <th>column_2</th>\n      <td>2.0</td>\n      <td>2.0</td>\n      <td>2.0001</td>\n      <td>0</td>\n      <td>240</td>\n      <td>60</td>\n      <td>60</td>\n      <td>2.0</td>\n      <td>1.666667</td>\n      <td>2.0</td>\n      <td>...</td>\n      <td>0.472719</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>SummaryType.COLUMN</td>\n      <td>0</td>\n      <td>180</td>\n      <td>0</td>\n      <td>0</td>\n      <td>0</td>\n    </tr>\n    <tr>\n      <th>column_3</th>\n      <td>2.0</td>\n      <td>2.0</td>\n      <td>2.0001</td>\n      <td>0</td>\n      <td>240</td>\n      <td>0</td>\n      <td>0</td>\n      <td>NaN</td>\n      <td>0.000000</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>0.000000</td>\n      <td>[FrequentItem(value='strings', est=120, upper=...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>SummaryType.COLUMN</td>\n      <td>0</td>\n      <td>0</td>\n      <td>0</td>\n      <td>0</td>\n      <td>240</td>\n    </tr>\n  </tbody>\n</table>\n<p>3 rows × 30 columns</p>\n</div>"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>cardinality/est</th>\n",
+              "      <th>cardinality/lower_1</th>\n",
+              "      <th>cardinality/upper_1</th>\n",
+              "      <th>counts/inf</th>\n",
+              "      <th>counts/n</th>\n",
+              "      <th>counts/nan</th>\n",
+              "      <th>counts/null</th>\n",
+              "      <th>distribution/max</th>\n",
+              "      <th>distribution/mean</th>\n",
+              "      <th>distribution/median</th>\n",
+              "      <th>...</th>\n",
+              "      <th>distribution/stddev</th>\n",
+              "      <th>frequent_items/frequent_strings</th>\n",
+              "      <th>ints/max</th>\n",
+              "      <th>ints/min</th>\n",
+              "      <th>type</th>\n",
+              "      <th>types/boolean</th>\n",
+              "      <th>types/fractional</th>\n",
+              "      <th>types/integral</th>\n",
+              "      <th>types/object</th>\n",
+              "      <th>types/string</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>column</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>column_1</th>\n",
+              "      <td>4.0</td>\n",
+              "      <td>4.0</td>\n",
+              "      <td>4.0002</td>\n",
+              "      <td>0</td>\n",
+              "      <td>240</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>45.0</td>\n",
+              "      <td>12.750000</td>\n",
+              "      <td>3.0</td>\n",
+              "      <td>...</td>\n",
+              "      <td>18.671909</td>\n",
+              "      <td>[FrequentItem(value='2', est=60, upper=60, low...</td>\n",
+              "      <td>45.0</td>\n",
+              "      <td>1.0</td>\n",
+              "      <td>SummaryType.COLUMN</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>240</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>column_2</th>\n",
+              "      <td>2.0</td>\n",
+              "      <td>2.0</td>\n",
+              "      <td>2.0001</td>\n",
+              "      <td>0</td>\n",
+              "      <td>240</td>\n",
+              "      <td>60</td>\n",
+              "      <td>60</td>\n",
+              "      <td>2.0</td>\n",
+              "      <td>1.666667</td>\n",
+              "      <td>2.0</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0.472719</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>SummaryType.COLUMN</td>\n",
+              "      <td>0</td>\n",
+              "      <td>180</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>column_3</th>\n",
+              "      <td>2.0</td>\n",
+              "      <td>2.0</td>\n",
+              "      <td>2.0001</td>\n",
+              "      <td>0</td>\n",
+              "      <td>240</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>[FrequentItem(value='strings', est=120, upper=...</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>SummaryType.COLUMN</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>240</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>3 rows × 30 columns</p>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "          cardinality/est  cardinality/lower_1  cardinality/upper_1  \\\n",
+              "column                                                                \n",
+              "column_1              4.0                  4.0               4.0002   \n",
+              "column_2              2.0                  2.0               2.0001   \n",
+              "column_3              2.0                  2.0               2.0001   \n",
+              "\n",
+              "          counts/inf  counts/n  counts/nan  counts/null  distribution/max  \\\n",
+              "column                                                                      \n",
+              "column_1           0       240           0            0              45.0   \n",
+              "column_2           0       240          60           60               2.0   \n",
+              "column_3           0       240           0            0               NaN   \n",
+              "\n",
+              "          distribution/mean  distribution/median  ...  distribution/stddev  \\\n",
+              "column                                            ...                        \n",
+              "column_1          12.750000                  3.0  ...            18.671909   \n",
+              "column_2           1.666667                  2.0  ...             0.472719   \n",
+              "column_3           0.000000                  NaN  ...             0.000000   \n",
+              "\n",
+              "                            frequent_items/frequent_strings  ints/max  \\\n",
+              "column                                                                  \n",
+              "column_1  [FrequentItem(value='2', est=60, upper=60, low...      45.0   \n",
+              "column_2                                                NaN       NaN   \n",
+              "column_3  [FrequentItem(value='strings', est=120, upper=...       NaN   \n",
+              "\n",
+              "          ints/min                type  types/boolean  types/fractional  \\\n",
+              "column                                                                    \n",
+              "column_1       1.0  SummaryType.COLUMN              0                 0   \n",
+              "column_2       NaN  SummaryType.COLUMN              0               180   \n",
+              "column_3       NaN  SummaryType.COLUMN              0                 0   \n",
+              "\n",
+              "          types/integral  types/object  types/string  \n",
+              "column                                                \n",
+              "column_1             240             0             0  \n",
+              "column_2               0             0             0  \n",
+              "column_3               0             0           240  \n",
+              "\n",
+              "[3 rows x 30 columns]"
+            ]
           },
           "execution_count": 9,
           "metadata": {},
@@ -291,10 +677,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "1Vpx-uI4ib8i",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "1Vpx-uI4ib8i"
+        }
       },
       "source": [
         "So everytime you run `get` with this specified `DateQuery`, you will get 7 previous days worth of data. And this can be useful, for instance, to compare a reference profile against a newly logged one. Let's see how to do that on the next section. "
@@ -303,10 +689,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "rVTWrDuOib8i",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "rVTWrDuOib8i"
+        }
       },
       "source": [
         ">**IMPORTANT**: Please note that even if we pass a milisecond granular datetime in the `DateQuery` range, `store.get` will always search for profiles on a daily basis. We decided to do that to simplify the API usage as well as having a more statistically significant merged profile view when reading. If this does not fit your current needs for the `LocalStore`, please submit an issue on our Github repo and also feel free to ask others on our [community Slack](http://join.slack.whylabs.ai/).  "
@@ -315,10 +701,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "OpOrUXjoib8i",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "OpOrUXjoib8i"
+        }
       },
       "source": [
         "## Validating profiles with the Local Store\n",
@@ -330,10 +716,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "spR6tgQrib8j",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "spR6tgQrib8j"
+        }
       },
       "outputs": [],
       "source": [
@@ -347,10 +733,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "y-IfXOKVib8j",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "y-IfXOKVib8j"
+        }
       },
       "source": [
         "After defining the conditions that we wish to validate, we need to set the callback that will be triggered when this condition is met. We will simply print something to the screen for this example, but in a real usage scenario, you could possibly stop your processes and trigger an alert to your central communications channel, for example :) "
@@ -360,10 +746,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "Zu9MY4K1ib8j",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "Zu9MY4K1ib8j"
+        }
       },
       "outputs": [],
       "source": [
@@ -376,10 +762,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "Ur8N6jH8ib8k",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "Ur8N6jH8ib8k"
+        }
       },
       "source": [
         "Lastly, we need to create the validator, that will take in the condition that we set along with the callback function."
@@ -389,10 +775,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "SZMgkbR0ib8k",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "SZMgkbR0ib8k"
+        }
       },
       "outputs": [],
       "source": [
@@ -409,10 +795,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "lCgTBfWjib8k",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "lCgTBfWjib8k"
+        }
       },
       "source": [
         "And now we will map the condition to specific columns: "
@@ -422,10 +808,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "e9s92QBuib8k",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "e9s92QBuib8k"
+        }
       },
       "outputs": [],
       "source": [
@@ -437,10 +823,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "D6fW1-0fib8l",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "D6fW1-0fib8l"
+        }
       },
       "source": [
         "Finally, we can again log incoming data. For this example, we will log data for approximately 2 minutes, which will dump 2 new profiles to our `LocalStore`. Then, we will introduce data that won't match the validator condition, and we will see the callback being executed while logging! Please note that both DataFrames follow the **same schema**, only invalid data is being brought to the second one."
@@ -450,11 +836,11 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "BrslYrRXib8l",
+        "outputId": "1f2d3b2e-5f15-438d-b61e-823261bfb16e",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "BrslYrRXib8l",
-        "outputId": "1f2d3b2e-5f15-438d-b61e-823261bfb16e"
+        }
       },
       "outputs": [
         {
@@ -485,10 +871,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "T4fULFVMib8m",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "T4fULFVMib8m"
+        }
       },
       "source": [
         "And as we can see, the validation failed, since we introduced a DataFrame with an invalid data point! Let's check how does the stored profile look like:"
@@ -498,17 +884,198 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "3Fe__X4gib8m",
+        "outputId": "3d12d7c5-ef5e-49bd-dc4d-4bb848f71ec0",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "3Fe__X4gib8m",
-        "outputId": "3d12d7c5-ef5e-49bd-dc4d-4bb848f71ec0"
+        }
       },
       "outputs": [
         {
           "data": {
-            "text/plain": "          cardinality/est  cardinality/lower_1  cardinality/upper_1  \\\ncolumn                                                                \ncolumn_1              4.0                  4.0              4.00020   \ncolumn_2              2.0                  2.0              2.00010   \ncolumn_3              3.0                  3.0              3.00015   \n\n          counts/inf  counts/n  counts/nan  counts/null  distribution/max  \\\ncolumn                                                                      \ncolumn_1           0       484           0            0              45.0   \ncolumn_2           0       484         121          121               2.0   \ncolumn_3           0       484           0            0               NaN   \n\n          distribution/mean  distribution/median  ...  distribution/stddev  \\\ncolumn                                            ...                        \ncolumn_1          12.750000                  3.0  ...            18.652247   \ncolumn_2           1.666667                  2.0  ...             0.472055   \ncolumn_3           0.000000                  NaN  ...             0.000000   \n\n                            frequent_items/frequent_strings  ints/max  \\\ncolumn                                                                  \ncolumn_1  [FrequentItem(value='2', est=121, upper=121, l...      45.0   \ncolumn_2                                                NaN       NaN   \ncolumn_3  [FrequentItem(value='strings', est=241, upper=...       NaN   \n\n          ints/min                type  types/boolean  types/fractional  \\\ncolumn                                                                    \ncolumn_1       1.0  SummaryType.COLUMN              0                 0   \ncolumn_2       NaN  SummaryType.COLUMN              0               363   \ncolumn_3       NaN  SummaryType.COLUMN              0                 0   \n\n          types/integral  types/object  types/string  \ncolumn                                                \ncolumn_1             484             0             0  \ncolumn_2               0             0             0  \ncolumn_3               0             0           484  \n\n[3 rows x 30 columns]",
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>cardinality/est</th>\n      <th>cardinality/lower_1</th>\n      <th>cardinality/upper_1</th>\n      <th>counts/inf</th>\n      <th>counts/n</th>\n      <th>counts/nan</th>\n      <th>counts/null</th>\n      <th>distribution/max</th>\n      <th>distribution/mean</th>\n      <th>distribution/median</th>\n      <th>...</th>\n      <th>distribution/stddev</th>\n      <th>frequent_items/frequent_strings</th>\n      <th>ints/max</th>\n      <th>ints/min</th>\n      <th>type</th>\n      <th>types/boolean</th>\n      <th>types/fractional</th>\n      <th>types/integral</th>\n      <th>types/object</th>\n      <th>types/string</th>\n    </tr>\n    <tr>\n      <th>column</th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>column_1</th>\n      <td>4.0</td>\n      <td>4.0</td>\n      <td>4.00020</td>\n      <td>0</td>\n      <td>484</td>\n      <td>0</td>\n      <td>0</td>\n      <td>45.0</td>\n      <td>12.750000</td>\n      <td>3.0</td>\n      <td>...</td>\n      <td>18.652247</td>\n      <td>[FrequentItem(value='2', est=121, upper=121, l...</td>\n      <td>45.0</td>\n      <td>1.0</td>\n      <td>SummaryType.COLUMN</td>\n      <td>0</td>\n      <td>0</td>\n      <td>484</td>\n      <td>0</td>\n      <td>0</td>\n    </tr>\n    <tr>\n      <th>column_2</th>\n      <td>2.0</td>\n      <td>2.0</td>\n      <td>2.00010</td>\n      <td>0</td>\n      <td>484</td>\n      <td>121</td>\n      <td>121</td>\n      <td>2.0</td>\n      <td>1.666667</td>\n      <td>2.0</td>\n      <td>...</td>\n      <td>0.472055</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>SummaryType.COLUMN</td>\n      <td>0</td>\n      <td>363</td>\n      <td>0</td>\n      <td>0</td>\n      <td>0</td>\n    </tr>\n    <tr>\n      <th>column_3</th>\n      <td>3.0</td>\n      <td>3.0</td>\n      <td>3.00015</td>\n      <td>0</td>\n      <td>484</td>\n      <td>0</td>\n      <td>0</td>\n      <td>NaN</td>\n      <td>0.000000</td>\n      <td>NaN</td>\n      <td>...</td>\n      <td>0.000000</td>\n      <td>[FrequentItem(value='strings', est=241, upper=...</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>SummaryType.COLUMN</td>\n      <td>0</td>\n      <td>0</td>\n      <td>0</td>\n      <td>0</td>\n      <td>484</td>\n    </tr>\n  </tbody>\n</table>\n<p>3 rows × 30 columns</p>\n</div>"
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>cardinality/est</th>\n",
+              "      <th>cardinality/lower_1</th>\n",
+              "      <th>cardinality/upper_1</th>\n",
+              "      <th>counts/inf</th>\n",
+              "      <th>counts/n</th>\n",
+              "      <th>counts/nan</th>\n",
+              "      <th>counts/null</th>\n",
+              "      <th>distribution/max</th>\n",
+              "      <th>distribution/mean</th>\n",
+              "      <th>distribution/median</th>\n",
+              "      <th>...</th>\n",
+              "      <th>distribution/stddev</th>\n",
+              "      <th>frequent_items/frequent_strings</th>\n",
+              "      <th>ints/max</th>\n",
+              "      <th>ints/min</th>\n",
+              "      <th>type</th>\n",
+              "      <th>types/boolean</th>\n",
+              "      <th>types/fractional</th>\n",
+              "      <th>types/integral</th>\n",
+              "      <th>types/object</th>\n",
+              "      <th>types/string</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>column</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>column_1</th>\n",
+              "      <td>4.0</td>\n",
+              "      <td>4.0</td>\n",
+              "      <td>4.00020</td>\n",
+              "      <td>0</td>\n",
+              "      <td>484</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>45.0</td>\n",
+              "      <td>12.750000</td>\n",
+              "      <td>3.0</td>\n",
+              "      <td>...</td>\n",
+              "      <td>18.652247</td>\n",
+              "      <td>[FrequentItem(value='2', est=121, upper=121, l...</td>\n",
+              "      <td>45.0</td>\n",
+              "      <td>1.0</td>\n",
+              "      <td>SummaryType.COLUMN</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>484</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>column_2</th>\n",
+              "      <td>2.0</td>\n",
+              "      <td>2.0</td>\n",
+              "      <td>2.00010</td>\n",
+              "      <td>0</td>\n",
+              "      <td>484</td>\n",
+              "      <td>121</td>\n",
+              "      <td>121</td>\n",
+              "      <td>2.0</td>\n",
+              "      <td>1.666667</td>\n",
+              "      <td>2.0</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0.472055</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>SummaryType.COLUMN</td>\n",
+              "      <td>0</td>\n",
+              "      <td>363</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>column_3</th>\n",
+              "      <td>3.0</td>\n",
+              "      <td>3.0</td>\n",
+              "      <td>3.00015</td>\n",
+              "      <td>0</td>\n",
+              "      <td>484</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>[FrequentItem(value='strings', est=241, upper=...</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>SummaryType.COLUMN</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>484</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>3 rows × 30 columns</p>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "          cardinality/est  cardinality/lower_1  cardinality/upper_1  \\\n",
+              "column                                                                \n",
+              "column_1              4.0                  4.0              4.00020   \n",
+              "column_2              2.0                  2.0              2.00010   \n",
+              "column_3              3.0                  3.0              3.00015   \n",
+              "\n",
+              "          counts/inf  counts/n  counts/nan  counts/null  distribution/max  \\\n",
+              "column                                                                      \n",
+              "column_1           0       484           0            0              45.0   \n",
+              "column_2           0       484         121          121               2.0   \n",
+              "column_3           0       484           0            0               NaN   \n",
+              "\n",
+              "          distribution/mean  distribution/median  ...  distribution/stddev  \\\n",
+              "column                                            ...                        \n",
+              "column_1          12.750000                  3.0  ...            18.652247   \n",
+              "column_2           1.666667                  2.0  ...             0.472055   \n",
+              "column_3           0.000000                  NaN  ...             0.000000   \n",
+              "\n",
+              "                            frequent_items/frequent_strings  ints/max  \\\n",
+              "column                                                                  \n",
+              "column_1  [FrequentItem(value='2', est=121, upper=121, l...      45.0   \n",
+              "column_2                                                NaN       NaN   \n",
+              "column_3  [FrequentItem(value='strings', est=241, upper=...       NaN   \n",
+              "\n",
+              "          ints/min                type  types/boolean  types/fractional  \\\n",
+              "column                                                                    \n",
+              "column_1       1.0  SummaryType.COLUMN              0                 0   \n",
+              "column_2       NaN  SummaryType.COLUMN              0               363   \n",
+              "column_3       NaN  SummaryType.COLUMN              0                 0   \n",
+              "\n",
+              "          types/integral  types/object  types/string  \n",
+              "column                                                \n",
+              "column_1             484             0             0  \n",
+              "column_2               0             0             0  \n",
+              "column_3               0             0           484  \n",
+              "\n",
+              "[3 rows x 30 columns]"
+            ]
           },
           "execution_count": 15,
           "metadata": {},
@@ -524,10 +1091,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "4ljkzZipib8m",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "4ljkzZipib8m"
+        }
       },
       "source": [
         "## Comparing profiles with the Profile Store\n",
@@ -539,10 +1106,10 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "16CByOp8ib8m",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "16CByOp8ib8m"
+        }
       },
       "outputs": [],
       "source": [
@@ -558,10 +1125,10 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "M3TAR0P1ib8n",
         "pycharm": {
           "name": "#%% md\n"
-        },
-        "id": "M3TAR0P1ib8n"
+        }
       },
       "source": [
         "With both profiles read, now what we need to do is define our constraints suite. For demonstration purposes, we will check if the column values are **not** greater than the average of the reference. "
@@ -571,11 +1138,11 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "L1PFJT0Wib8o",
+        "outputId": "a696d0c6-8f72-4f15-c36a-c95538b90397",
         "pycharm": {
           "name": "#%%\n"
-        },
-        "id": "L1PFJT0Wib8o",
-        "outputId": "a696d0c6-8f72-4f15-c36a-c95538b90397"
+        }
       },
       "outputs": [
         {
@@ -604,36 +1171,39 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "collapsed": false,
+        "id": "_rcsE2fkib8o",
+        "pycharm": {
+          "name": "#%% md\n"
+        }
+      },
       "source": [
         "So we have just validated our recently read profile against the reference, which has 7 days worth of profiles. We can also mix the reference profile checks with other ones just for the newest. \n",
         "Hopefully this short demonstration notebook can bring some of the features that the `LocalStore` brings to help you make the most out of whylogs and make your data and ML pipelines more robust and responsible. To learn more, check out our [other examples](https://github.com/whylabs/whylogs/tree/mainline/python/examples)."
-      ],
-      "metadata": {
-        "collapsed": false,
-        "pycharm": {
-          "name": "#%% md\n"
-        },
-        "id": "_rcsE2fkib8o"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {
+        "id": "5JnYKq5Wib8p",
+        "pycharm": {
+          "name": "#%%\n"
+        }
+      },
       "outputs": [],
       "source": [
         "# cleaning up\n",
         "import shutil\n",
         "shutil.rmtree(\"./profile_store\")"
-      ],
-      "metadata": {
-        "pycharm": {
-          "name": "#%%\n"
-        },
-        "id": "5JnYKq5Wib8p"
-      }
+      ]
     }
   ],
   "metadata": {
+    "colab": {
+      "provenance": []
+    },
     "kernelspec": {
       "display_name": "Python 3.9.13 ('.venv': poetry)",
       "language": "python",
@@ -656,9 +1226,6 @@
       "interpreter": {
         "hash": "0f484380554f045e8316d9ef136659363ef199c84a7347221e49b73e46486d36"
       }
-    },
-    "colab": {
-      "provenance": []
     }
   },
   "nbformat": 4,

--- a/python/examples/advanced/Segments.ipynb
+++ b/python/examples/advanced/Segments.ipynb
@@ -68,6 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
     "%pip install 'whylogs[whylabs]'"
    ]
   },

--- a/python/examples/advanced/String_Tracking.ipynb
+++ b/python/examples/advanced/String_Tracking.ipynb
@@ -89,6 +89,7 @@
       },
       "outputs": [],
       "source": [
+        "# Note: you may need to restart the kernel to use updated packages.\n",
         "%pip install whylogs"
       ]
     },
@@ -117,25 +118,16 @@
       "cell_type": "code",
       "execution_count": 2,
       "metadata": {
-        "id": "sCjGDR4ZNrpu",
-        "outputId": "8f8d8be0-63e6-46d5-b045-ee96ca9d2a6e",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 228
-        }
+        },
+        "id": "sCjGDR4ZNrpu",
+        "outputId": "8f8d8be0-63e6-46d5-b045-ee96ca9d2a6e"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "  onlyDigits onlyAlpha                             mixed\n",
-              "0         12     Alice           my_email_1989@gmail.com\n",
-              "1         83       Bob                          ADK-1171\n",
-              "2          1   Chelsea   Copacabana 272 - Rio de Janeiro\n",
-              "3        992     Danny  21º C Friday - Sao Paulo, Brasil\n",
-              "4          7     Eddie                       18127819ASW"
-            ],
             "text/html": [
               "\n",
               "  <div id=\"df-5d415b05-ba54-4744-a7e5-f9aefe0b5d1d\">\n",
@@ -273,10 +265,19 @@
               "    </div>\n",
               "  </div>\n",
               "  "
+            ],
+            "text/plain": [
+              "  onlyDigits onlyAlpha                             mixed\n",
+              "0         12     Alice           my_email_1989@gmail.com\n",
+              "1         83       Bob                          ADK-1171\n",
+              "2          1   Chelsea   Copacabana 272 - Rio de Janeiro\n",
+              "3        992     Danny  21º C Friday - Sao Paulo, Brasil\n",
+              "4          7     Eddie                       18127819ASW"
             ]
           },
+          "execution_count": 2,
           "metadata": {},
-          "execution_count": 2
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -411,128 +412,16 @@
       "cell_type": "code",
       "execution_count": 6,
       "metadata": {
-        "id": "qiLLsRQiNrpz",
-        "outputId": "f3bd42ae-889f-4859-dbbe-f11b00087b68",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 270
-        }
+        },
+        "id": "qiLLsRQiNrpz",
+        "outputId": "f3bd42ae-889f-4859-dbbe-f11b00087b68"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "                          type  unicode_range/UNKNOWN:cardinality/est  \\\n",
-              "column                                                                  \n",
-              "mixed       SummaryType.COLUMN                                    5.0   \n",
-              "onlyAlpha   SummaryType.COLUMN                                    1.0   \n",
-              "onlyDigits  SummaryType.COLUMN                                    1.0   \n",
-              "\n",
-              "            unicode_range/UNKNOWN:cardinality/lower_1  \\\n",
-              "column                                                  \n",
-              "mixed                                             5.0   \n",
-              "onlyAlpha                                         1.0   \n",
-              "onlyDigits                                        1.0   \n",
-              "\n",
-              "            unicode_range/UNKNOWN:cardinality/upper_1  \\\n",
-              "column                                                  \n",
-              "mixed                                         5.00025   \n",
-              "onlyAlpha                                     1.00005   \n",
-              "onlyDigits                                    1.00005   \n",
-              "\n",
-              "            unicode_range/UNKNOWN:counts/n  unicode_range/UNKNOWN:counts/null  \\\n",
-              "column                                                                          \n",
-              "mixed                                    0                                  0   \n",
-              "onlyAlpha                                0                                  0   \n",
-              "onlyDigits                               0                                  0   \n",
-              "\n",
-              "            unicode_range/UNKNOWN:distribution/max  \\\n",
-              "column                                               \n",
-              "mixed                                          9.0   \n",
-              "onlyAlpha                                      0.0   \n",
-              "onlyDigits                                     0.0   \n",
-              "\n",
-              "            unicode_range/UNKNOWN:distribution/mean  \\\n",
-              "column                                                \n",
-              "mixed                                           4.0   \n",
-              "onlyAlpha                                       0.0   \n",
-              "onlyDigits                                      0.0   \n",
-              "\n",
-              "            unicode_range/UNKNOWN:distribution/median  \\\n",
-              "column                                                  \n",
-              "mixed                                             4.0   \n",
-              "onlyAlpha                                         0.0   \n",
-              "onlyDigits                                        0.0   \n",
-              "\n",
-              "            unicode_range/UNKNOWN:distribution/min  ...  \\\n",
-              "column                                              ...   \n",
-              "mixed                                          0.0  ...   \n",
-              "onlyAlpha                                      0.0  ...   \n",
-              "onlyDigits                                     0.0  ...   \n",
-              "\n",
-              "            unicode_range/string_length:distribution/q_95  \\\n",
-              "column                                                      \n",
-              "mixed                                                32.0   \n",
-              "onlyAlpha                                             7.0   \n",
-              "onlyDigits                                            3.0   \n",
-              "\n",
-              "            unicode_range/string_length:distribution/q_99  \\\n",
-              "column                                                      \n",
-              "mixed                                                32.0   \n",
-              "onlyAlpha                                             7.0   \n",
-              "onlyDigits                                            3.0   \n",
-              "\n",
-              "            unicode_range/string_length:distribution/stddev  \\\n",
-              "column                                                        \n",
-              "mixed                                              9.939819   \n",
-              "onlyAlpha                                          1.264911   \n",
-              "onlyDigits                                         0.748331   \n",
-              "\n",
-              "            unicode_range/string_length:ints/max  \\\n",
-              "column                                             \n",
-              "mixed                       -9223372036854775807   \n",
-              "onlyAlpha                   -9223372036854775807   \n",
-              "onlyDigits                  -9223372036854775807   \n",
-              "\n",
-              "            unicode_range/string_length:ints/min  \\\n",
-              "column                                             \n",
-              "mixed                        9223372036854775807   \n",
-              "onlyAlpha                    9223372036854775807   \n",
-              "onlyDigits                   9223372036854775807   \n",
-              "\n",
-              "            unicode_range/string_length:types/boolean  \\\n",
-              "column                                                  \n",
-              "mixed                                               0   \n",
-              "onlyAlpha                                           0   \n",
-              "onlyDigits                                          0   \n",
-              "\n",
-              "            unicode_range/string_length:types/fractional  \\\n",
-              "column                                                     \n",
-              "mixed                                                  0   \n",
-              "onlyAlpha                                              0   \n",
-              "onlyDigits                                             0   \n",
-              "\n",
-              "            unicode_range/string_length:types/integral  \\\n",
-              "column                                                   \n",
-              "mixed                                                0   \n",
-              "onlyAlpha                                            0   \n",
-              "onlyDigits                                           0   \n",
-              "\n",
-              "            unicode_range/string_length:types/object  \\\n",
-              "column                                                 \n",
-              "mixed                                              0   \n",
-              "onlyAlpha                                          0   \n",
-              "onlyDigits                                         0   \n",
-              "\n",
-              "            unicode_range/string_length:types/string  \n",
-              "column                                                \n",
-              "mixed                                              0  \n",
-              "onlyAlpha                                          0  \n",
-              "onlyDigits                                         0  \n",
-              "\n",
-              "[3 rows x 105 columns]"
-            ],
             "text/html": [
               "\n",
               "  <div id=\"df-2d1ab49b-b679-44db-b321-cfd7b9af06e0\">\n",
@@ -755,10 +644,122 @@
               "    </div>\n",
               "  </div>\n",
               "  "
+            ],
+            "text/plain": [
+              "                          type  unicode_range/UNKNOWN:cardinality/est  \\\n",
+              "column                                                                  \n",
+              "mixed       SummaryType.COLUMN                                    5.0   \n",
+              "onlyAlpha   SummaryType.COLUMN                                    1.0   \n",
+              "onlyDigits  SummaryType.COLUMN                                    1.0   \n",
+              "\n",
+              "            unicode_range/UNKNOWN:cardinality/lower_1  \\\n",
+              "column                                                  \n",
+              "mixed                                             5.0   \n",
+              "onlyAlpha                                         1.0   \n",
+              "onlyDigits                                        1.0   \n",
+              "\n",
+              "            unicode_range/UNKNOWN:cardinality/upper_1  \\\n",
+              "column                                                  \n",
+              "mixed                                         5.00025   \n",
+              "onlyAlpha                                     1.00005   \n",
+              "onlyDigits                                    1.00005   \n",
+              "\n",
+              "            unicode_range/UNKNOWN:counts/n  unicode_range/UNKNOWN:counts/null  \\\n",
+              "column                                                                          \n",
+              "mixed                                    0                                  0   \n",
+              "onlyAlpha                                0                                  0   \n",
+              "onlyDigits                               0                                  0   \n",
+              "\n",
+              "            unicode_range/UNKNOWN:distribution/max  \\\n",
+              "column                                               \n",
+              "mixed                                          9.0   \n",
+              "onlyAlpha                                      0.0   \n",
+              "onlyDigits                                     0.0   \n",
+              "\n",
+              "            unicode_range/UNKNOWN:distribution/mean  \\\n",
+              "column                                                \n",
+              "mixed                                           4.0   \n",
+              "onlyAlpha                                       0.0   \n",
+              "onlyDigits                                      0.0   \n",
+              "\n",
+              "            unicode_range/UNKNOWN:distribution/median  \\\n",
+              "column                                                  \n",
+              "mixed                                             4.0   \n",
+              "onlyAlpha                                         0.0   \n",
+              "onlyDigits                                        0.0   \n",
+              "\n",
+              "            unicode_range/UNKNOWN:distribution/min  ...  \\\n",
+              "column                                              ...   \n",
+              "mixed                                          0.0  ...   \n",
+              "onlyAlpha                                      0.0  ...   \n",
+              "onlyDigits                                     0.0  ...   \n",
+              "\n",
+              "            unicode_range/string_length:distribution/q_95  \\\n",
+              "column                                                      \n",
+              "mixed                                                32.0   \n",
+              "onlyAlpha                                             7.0   \n",
+              "onlyDigits                                            3.0   \n",
+              "\n",
+              "            unicode_range/string_length:distribution/q_99  \\\n",
+              "column                                                      \n",
+              "mixed                                                32.0   \n",
+              "onlyAlpha                                             7.0   \n",
+              "onlyDigits                                            3.0   \n",
+              "\n",
+              "            unicode_range/string_length:distribution/stddev  \\\n",
+              "column                                                        \n",
+              "mixed                                              9.939819   \n",
+              "onlyAlpha                                          1.264911   \n",
+              "onlyDigits                                         0.748331   \n",
+              "\n",
+              "            unicode_range/string_length:ints/max  \\\n",
+              "column                                             \n",
+              "mixed                       -9223372036854775807   \n",
+              "onlyAlpha                   -9223372036854775807   \n",
+              "onlyDigits                  -9223372036854775807   \n",
+              "\n",
+              "            unicode_range/string_length:ints/min  \\\n",
+              "column                                             \n",
+              "mixed                        9223372036854775807   \n",
+              "onlyAlpha                    9223372036854775807   \n",
+              "onlyDigits                   9223372036854775807   \n",
+              "\n",
+              "            unicode_range/string_length:types/boolean  \\\n",
+              "column                                                  \n",
+              "mixed                                               0   \n",
+              "onlyAlpha                                           0   \n",
+              "onlyDigits                                          0   \n",
+              "\n",
+              "            unicode_range/string_length:types/fractional  \\\n",
+              "column                                                     \n",
+              "mixed                                                  0   \n",
+              "onlyAlpha                                              0   \n",
+              "onlyDigits                                             0   \n",
+              "\n",
+              "            unicode_range/string_length:types/integral  \\\n",
+              "column                                                   \n",
+              "mixed                                                0   \n",
+              "onlyAlpha                                            0   \n",
+              "onlyDigits                                           0   \n",
+              "\n",
+              "            unicode_range/string_length:types/object  \\\n",
+              "column                                                 \n",
+              "mixed                                              0   \n",
+              "onlyAlpha                                          0   \n",
+              "onlyDigits                                         0   \n",
+              "\n",
+              "            unicode_range/string_length:types/string  \n",
+              "column                                                \n",
+              "mixed                                              0  \n",
+              "onlyAlpha                                          0  \n",
+              "onlyDigits                                         0  \n",
+              "\n",
+              "[3 rows x 105 columns]"
             ]
           },
+          "execution_count": 6,
           "metadata": {},
-          "execution_count": 6
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -795,15 +796,14 @@
       "cell_type": "code",
       "execution_count": 7,
       "metadata": {
-        "id": "W-KtqiTdNrp0",
-        "outputId": "6ede40ca-ad30-454a-d0ca-c93c354f1986",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "W-KtqiTdNrp0",
+        "outputId": "6ede40ca-ad30-454a-d0ca-c93c354f1986"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "column\n",
@@ -813,8 +813,9 @@
               "Name: unicode_range/alpha:distribution/mean, dtype: float64"
             ]
           },
+          "execution_count": 7,
           "metadata": {},
-          "execution_count": 7
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -852,15 +853,14 @@
       "cell_type": "code",
       "execution_count": 8,
       "metadata": {
-        "id": "EJfG4UAlNrp1",
-        "outputId": "b7621078-9043-4a66-9af2-61a0524a3b8d",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "EJfG4UAlNrp1",
+        "outputId": "b7621078-9043-4a66-9af2-61a0524a3b8d"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "column\n",
@@ -870,8 +870,9 @@
               "Name: unicode_range/UNKNOWN:distribution/mean, dtype: float64"
             ]
           },
+          "execution_count": 8,
           "metadata": {},
-          "execution_count": 8
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -900,15 +901,14 @@
       "cell_type": "code",
       "execution_count": 9,
       "metadata": {
-        "id": "AAB90l8INrp2",
-        "outputId": "cdd63600-08f4-4488-ea90-97c1d81986ae",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "AAB90l8INrp2",
+        "outputId": "cdd63600-08f4-4488-ea90-97c1d81986ae"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "column\n",
@@ -918,8 +918,9 @@
               "Name: unicode_range/string_length:distribution/min, dtype: float64"
             ]
           },
+          "execution_count": 9,
           "metadata": {},
-          "execution_count": 9
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -966,6 +967,9 @@
     }
   ],
   "metadata": {
+    "colab": {
+      "provenance": []
+    },
     "kernelspec": {
       "display_name": "Python 3.8.13 ('v1.x')",
       "language": "python",
@@ -988,9 +992,6 @@
       "interpreter": {
         "hash": "f76ec28949fecf16b926a3fc5a03c1aa6468ee82fa5da4ce6fd607df021af5b5"
       }
-    },
-    "colab": {
-      "provenance": []
     }
   },
   "nbformat": 4,

--- a/python/examples/advanced/converting_v0_to_v1.ipynb
+++ b/python/examples/advanced/converting_v0_to_v1.ipynb
@@ -30,6 +30,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Installing whylogs and importing modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install whylogs"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Downloading v0 profile\n",
     "\n",
     "First, we need a sample v0 profile to demonstrate how to convert it.\n",

--- a/python/examples/basic/Constraints_Suite.ipynb
+++ b/python/examples/basic/Constraints_Suite.ipynb
@@ -128,6 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
     "%pip install 'whylogs[viz]'"
    ]
   },

--- a/python/examples/basic/Getting_Started.ipynb
+++ b/python/examples/basic/Getting_Started.ipynb
@@ -74,7 +74,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q whylogs"
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install whylogs"
    ]
   },
   {
@@ -473,7 +474,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.5 ('base')",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -487,12 +488,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.8.10"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "8148c804a5838694570acf40aa3269caeebb6c584d51452dd558e946dfc16d39"
+    "hash": "5dd5901cadfd4b29c2aaf95ecd29c0c3b10829ad94dcfe59437dbee391154aea"
    }
   }
  },

--- a/python/examples/basic/Inspecting_Profiles.ipynb
+++ b/python/examples/basic/Inspecting_Profiles.ipynb
@@ -64,7 +64,8 @@
       "outputs": [],
       "source": [
         "# install whylogs & pandas if needed\n",
-        "%pip install -q whylogs\n",
+        "# Note: you may need to restart the kernel to use updated packages.\n",
+        "%pip install whylogs\n",
         "%pip install pandas "
       ]
     },
@@ -536,7 +537,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3.9.5 ('base')",
+      "display_name": ".venv",
       "language": "python",
       "name": "python3"
     },
@@ -550,11 +551,11 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.9.5"
+      "version": "3.8.10"
     },
     "vscode": {
       "interpreter": {
-        "hash": "8148c804a5838694570acf40aa3269caeebb6c584d51452dd558e946dfc16d39"
+        "hash": "5dd5901cadfd4b29c2aaf95ecd29c0c3b10829ad94dcfe59437dbee391154aea"
       }
     }
   },

--- a/python/examples/basic/Logging_Different_Data.ipynb
+++ b/python/examples/basic/Logging_Different_Data.ipynb
@@ -55,7 +55,8 @@
     }
    ],
    "source": [
-    "%pip install -q whylogs"
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install whylogs"
    ]
   },
   {

--- a/python/examples/basic/Merging_Profiles.ipynb
+++ b/python/examples/basic/Merging_Profiles.ipynb
@@ -61,6 +61,7 @@
    },
    "outputs": [],
    "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
     "%pip install whylogs"
    ]
   },

--- a/python/examples/basic/Notebook_Profile_Visualizer.ipynb
+++ b/python/examples/basic/Notebook_Profile_Visualizer.ipynb
@@ -78,7 +78,7 @@
    "outputs": [],
    "source": [
     "# Note: you may need to restart the kernel to use updated packages.\n",
-    "%pip install -q 'whylogs[viz]'"
+    "%pip install 'whylogs[viz]'"
    ]
   },
   {

--- a/python/examples/basic/Notebook_Profile_Visualizer.ipynb
+++ b/python/examples/basic/Notebook_Profile_Visualizer.ipynb
@@ -73,11 +73,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install -q 'whylogs[viz]'"
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install -q 'whylogs[viz]'"
    ]
   },
   {

--- a/python/examples/basic/Schema_Configuration.ipynb
+++ b/python/examples/basic/Schema_Configuration.ipynb
@@ -64,6 +64,7 @@
       },
       "outputs": [],
       "source": [
+        "# Note: you may need to restart the kernel to use updated packages.\n",
         "%pip install whylogs"
       ]
     },

--- a/python/examples/benchmarks/KS_Profiling.ipynb
+++ b/python/examples/benchmarks/KS_Profiling.ipynb
@@ -120,8 +120,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q 'matplotlib' 'numpy' 'seaborn==0.12.1'\n",
-    "%pip install -q 'scipy==1.7.3' 'whylogs[viz]' 'typing_extensions'"
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install 'matplotlib' 'numpy' 'seaborn==0.12.1'\n",
+    "%pip install 'scipy==1.7.3' 'whylogs[viz]' 'typing_extensions'"
    ]
   },
   {
@@ -1109,7 +1110,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10 (default, Jun  4 2021, 15:09:15) \n[GCC 7.5.0]"
+   "version": "3.8.10"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/python/examples/datasets/ecommerce.ipynb
+++ b/python/examples/datasets/ecommerce.ipynb
@@ -46,7 +46,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q 'whylogs[datasets]'"
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install 'whylogs[datasets]'"
    ]
   },
   {

--- a/python/examples/datasets/employee.ipynb
+++ b/python/examples/datasets/employee.ipynb
@@ -50,7 +50,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q 'whylogs[datasets]'"
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install 'whylogs[datasets]'"
    ]
   },
   {

--- a/python/examples/datasets/weather.ipynb
+++ b/python/examples/datasets/weather.ipynb
@@ -49,7 +49,8 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%pip install -q 'whylogs[datasets]'"
+        "# Note: you may need to restart the kernel to use updated packages.\n",
+        "%pip install 'whylogs[datasets]'"
       ]
     },
     {

--- a/python/examples/experimental/NLP_Summarization.ipynb
+++ b/python/examples/experimental/NLP_Summarization.ipynb
@@ -1,57 +1,43 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "5_hazICzT0AX"
+      },
       "source": [
         ">### 🚩 *Create a free WhyLabs account to get more value out of whylogs!*<br> \n",
         ">*Did you know you can store, visualize, and monitor whylogs profiles with the [WhyLabs Observability Platform](https://whylabs.ai/whylogs-free-signup?utm_source=whylogs-Github&utm_medium=whylogs-example&utm_campaign=Schema_Configuration)? Sign up for a [free WhyLabs account](https://whylabs.ai/whylogs-free-signup?utm_source=whylogs-Github&utm_medium=whylogs-example&utm_campaign=Schema_Configuration) to leverage the power of whylogs and WhyLabs together!*"
-      ],
-      "metadata": {
-        "id": "5_hazICzT0AX"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "# Document Summarization Example"
-      ],
       "metadata": {
         "id": "phJi2VWRUEio"
-      }
+      },
+      "source": [
+        "# Document Summarization Example"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/whylabs/whylogs/blob/mainline/python/examples/basic/Schema_Configuration.ipynb)"
-      ],
       "metadata": {
         "id": "t_TgL10MUrSZ"
-      }
+      },
+      "source": [
+        "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/whylabs/whylogs/blob/mainline/python/examples/basic/Schema_Configuration.ipynb)"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "rH4hheWfUt7-"
+      },
       "source": [
         "In this example, we'll look at how we might use whylogs to monitor a document summarization task.\n",
         "\n",
         "We'll use [NLTK](https://www.nltk.org) and [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/) to do some of the basic NLP tasks, so let's install the packages we'll need now."
-      ],
-      "metadata": {
-        "id": "rH4hheWfUt7-"
-      }
+      ]
     },
     {
       "cell_type": "code",
@@ -61,22 +47,52 @@
       },
       "outputs": [],
       "source": [
+        "# Note: you may need to restart the kernel to use updated packages.\n",
         "%pip install nltk\n",
         "%pip install bs4\n",
-        "%pip install whylogs-1.1.19-py3-none-any.whl "
+        "%pip install whylogs"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "We'll use the NLTK Reuters corpus as the documents to summarize. As a trivial summarization algorithm, we'll pull out the sentence that contains a document's highest log-entropy weighted term as its summary. Let's start by computing the term-frequency index for the corpus and the term global frequencies and entropies. We'll use NLTK's stemming, stopping, and tokenization for those calcuations, but return the unaltered sentence as the summary."
-      ],
       "metadata": {
         "id": "c1D0VHR4YsAC"
-      }
+      },
+      "source": [
+        "We'll use the NLTK Reuters corpus as the documents to summarize. As a trivial summarization algorithm, we'll pull out the sentence that contains a document's highest log-entropy weighted term as its summary. Let's start by computing the term-frequency index for the corpus and the term global frequencies and entropies. We'll use NLTK's stemming, stopping, and tokenization for those calcuations, but return the unaltered sentence as the summary."
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ikXbxGhGaq3d",
+        "outputId": "32ed7e5b-8017-47fa-a4b4-34e2aa54742e"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[nltk_data] Downloading package reuters to /root/nltk_data...\n",
+            "[nltk_data]   Package reuters is already up-to-date!\n",
+            "[nltk_data] Downloading package punkt to /root/nltk_data...\n",
+            "[nltk_data]   Package punkt is already up-to-date!\n",
+            "[nltk_data] Downloading package stopwords to /root/nltk_data...\n",
+            "[nltk_data]   Package stopwords is already up-to-date!\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "500 articles   6275 vocabulary\n"
+          ]
+        }
+      ],
       "source": [
         "from typing import Any, Dict, List, Optional, Set\n",
         "\n",
@@ -165,48 +181,24 @@
         "ndocs = len(train_files)\n",
         "vocab_size = len(vocab)\n",
         "print(f\"{ndocs} articles   {vocab_size} vocabulary\")"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "ikXbxGhGaq3d",
-        "outputId": "32ed7e5b-8017-47fa-a4b4-34e2aa54742e"
-      },
-      "execution_count": 2,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[nltk_data] Downloading package reuters to /root/nltk_data...\n",
-            "[nltk_data]   Package reuters is already up-to-date!\n",
-            "[nltk_data] Downloading package punkt to /root/nltk_data...\n",
-            "[nltk_data]   Package punkt is already up-to-date!\n",
-            "[nltk_data] Downloading package stopwords to /root/nltk_data...\n",
-            "[nltk_data]   Package stopwords is already up-to-date!\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "500 articles   6275 vocabulary\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "It will also be handy to have mappings back and forth between each term (as a string) and the term's row in term frequency matrix. Let's build those up."
-      ],
       "metadata": {
         "id": "sMfucM66kMi9"
-      }
+      },
+      "source": [
+        "It will also be handy to have mappings back and forth between each term (as a string) and the term's row in term frequency matrix. Let's build those up."
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "Ueo9hlKtkdV6"
+      },
+      "outputs": [],
       "source": [
         "vocab_map: Dict[str, int] = dict()\n",
         "rev_map: List[str] = [''] * vocab_size\n",
@@ -223,26 +215,26 @@
         "\n",
         "gf = global_freq(index)\n",
         "g = entropy(index, gf)"
-      ],
-      "metadata": {
-        "id": "Ueo9hlKtkdV6"
-      },
-      "execution_count": 3,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "WC7S59ADmq89"
+      },
       "source": [
         "Now we have the inputs we need to compute the term weights, so we can implement our summarization algorithm. But since we want to monitor our summarization process with whylogs, we'll need to do a little whylogs setup before we start summarizing.\n",
         "\n",
         "By default, whylogs uses a `TransientLogger` that produces a new profile for every `log()` call. For our example, it's nicer to aggregate all the logging into a singe profile. So we'll create a simple `PersistentLogger` to do that."
-      ],
-      "metadata": {
-        "id": "WC7S59ADmq89"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "TrF-XmKsn35M"
+      },
+      "outputs": [],
       "source": [
         "from whylogs.api.logger.logger import Logger\n",
         "from whylogs.core import DatasetProfile, DatasetSchema\n",
@@ -274,24 +266,24 @@
         "                \"because schema is set once when instantiated, please use TimedRollingLogger(schema) instead.\"\n",
         "            )\n",
         "        return [self._current_profile]\n"
-      ],
-      "metadata": {
-        "id": "TrF-XmKsn35M"
-      },
-      "execution_count": 4,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "We also need to attach the `BagOfWordsMetric` to the columns that represent our input articles and output summaries. Unfortunately, whylogs doesn't fully understand bags of words as loggable values yet, so we'll also bump up the Python logging level to suppress a spurious warning message."
-      ],
       "metadata": {
         "id": "JI_c9bxIqy30"
-      }
+      },
+      "source": [
+        "We also need to attach the `BagOfWordsMetric` to the columns that represent our input articles and output summaries. Unfortunately, whylogs doesn't fully understand bags of words as loggable values yet, so we'll also bump up the Python logging level to suppress a spurious warning message."
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "id": "qndtdoXBrmtl"
+      },
+      "outputs": [],
       "source": [
         "from logging import ERROR\n",
         "dp_logger.setLevel(ERROR)\n",
@@ -308,24 +300,24 @@
         "]\n",
         "schema = DeclarativeSchema(resolvers)\n",
         "why = PersistentLogger(schema=schema)"
-      ],
-      "metadata": {
-        "id": "qndtdoXBrmtl"
-      },
-      "execution_count": 5,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Now we're finally ready to do some summarization! We'll compute the log entropy weighted term vector for each article as a whole, then use NLTK's sentence tokenizer to split it into sentences. The first sentence that contains the word with the highest weight in the document will be our summary."
-      ],
       "metadata": {
         "id": "SNm95G61tFtf"
-      }
+      },
+      "source": [
+        "Now we're finally ready to do some summarization! We'll compute the log entropy weighted term vector for each article as a whole, then use NLTK's sentence tokenizer to split it into sentences. The first sentence that contains the word with the highest weight in the document will be our summary."
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "id": "8keC6Y-QtrpD"
+      },
+      "outputs": [],
       "source": [
         "profile = None\n",
         "for file in train_files:\n",
@@ -356,54 +348,20 @@
         "            break\n",
         "    # max_sentence = max_sentence.replace(\"\\n\", \" \")\n",
         "    # print(f\"{max_weight} {max_term}:   {max_sentence}\")"
-      ],
-      "metadata": {
-        "id": "8keC6Y-QtrpD"
-      },
-      "execution_count": 6,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "We've logged the full articles as the `article_bow` column and the summaries as the `summary_bow` column. Now let's grab the profile from the logger and take a look at it."
-      ],
       "metadata": {
         "id": "hs-9ja982gCP"
-      }
+      },
+      "source": [
+        "We've logged the full articles as the `article_bow` column and the summaries as the `summary_bow` column. Now let's grab the profile from the logger and take a look at it."
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "def dump_summary(view: ColumnProfileView) -> None:\n",
-        "    summary = view.to_summary_dict()\n",
-        "    keys = [\n",
-        "        \"nlp_bow/doc_length:counts/n\",\n",
-        "        \"nlp_bow/doc_length:distribution/mean\",\n",
-        "        \"nlp_bow/doc_length:distribution/stddev\",\n",
-        "        \"nlp_bow/doc_length:distribution/max\",\n",
-        "        \"nlp_bow/doc_length:distribution/min\",\n",
-        "        \"nlp_bow/doc_length:distribution/median\",\n",
-        "\n",
-        "        \"nlp_bow/term_length:counts/n\",\n",
-        "        \"nlp_bow/term_length:distribution/mean\",\n",
-        "        \"nlp_bow/term_length:distribution/stddev\",\n",
-        "        \"nlp_bow/term_length:distribution/max\",\n",
-        "        \"nlp_bow/term_length:distribution/min\",\n",
-        "        \"nlp_bow/term_length:distribution/median\",\n",
-        "    ]\n",
-        "    for key in keys:\n",
-        "        print(f\"    {key}: {summary[key]}\")\n",
-        "    print(f\"    frequent terms: {[t.value for t in summary['nlp_bow/frequent_terms:frequent_items/frequent_strings'][:10]]}\")\n",
-        "\n",
-        "\n",
-        "view = profile.view()\n",
-        "columns = view.get_columns()\n",
-        "for col_name, col_view in columns.items():\n",
-        "    print(f\"{col_name}:\")\n",
-        "    dump_summary(col_view)\n",
-        "    print()"
-      ],
+      "execution_count": 7,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -411,11 +369,10 @@
         "id": "DcqenmOo21FB",
         "outputId": "59467895-3ca4-4750-ec95-458b0ddf3559"
       },
-      "execution_count": 7,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "article_bow:\n",
             "    nlp_bow/doc_length:counts/n: 500\n",
@@ -449,19 +406,95 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "def dump_summary(view: ColumnProfileView) -> None:\n",
+        "    summary = view.to_summary_dict()\n",
+        "    keys = [\n",
+        "        \"nlp_bow/doc_length:counts/n\",\n",
+        "        \"nlp_bow/doc_length:distribution/mean\",\n",
+        "        \"nlp_bow/doc_length:distribution/stddev\",\n",
+        "        \"nlp_bow/doc_length:distribution/max\",\n",
+        "        \"nlp_bow/doc_length:distribution/min\",\n",
+        "        \"nlp_bow/doc_length:distribution/median\",\n",
+        "\n",
+        "        \"nlp_bow/term_length:counts/n\",\n",
+        "        \"nlp_bow/term_length:distribution/mean\",\n",
+        "        \"nlp_bow/term_length:distribution/stddev\",\n",
+        "        \"nlp_bow/term_length:distribution/max\",\n",
+        "        \"nlp_bow/term_length:distribution/min\",\n",
+        "        \"nlp_bow/term_length:distribution/median\",\n",
+        "    ]\n",
+        "    for key in keys:\n",
+        "        print(f\"    {key}: {summary[key]}\")\n",
+        "    print(f\"    frequent terms: {[t.value for t in summary['nlp_bow/frequent_terms:frequent_items/frequent_strings'][:10]]}\")\n",
+        "\n",
+        "\n",
+        "view = profile.view()\n",
+        "columns = view.get_columns()\n",
+        "for col_name, col_view in columns.items():\n",
+        "    print(f\"{col_name}:\")\n",
+        "    dump_summary(col_view)\n",
+        "    print()"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "As expected, we see that the summary documents are shorter than the original articles. We also see some differences and overlap in the most frequent words in the whole articles and the summaries."
-      ],
       "metadata": {
         "id": "KR2FQYlN3Hom"
-      }
+      },
+      "source": [
+        "As expected, we see that the summary documents are shorter than the original articles. We also see some differences and overlap in the most frequent words in the whole articles and the summaries."
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "0KFTk_cvX_kz",
+        "outputId": "082435b3-8e25-47bf-e8d1-487b733c824a"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "original_bow:\n",
+            "    nlp_bow/doc_length:counts/n: 2837\n",
+            "    nlp_bow/doc_length:distribution/mean: 25.89742685935848\n",
+            "    nlp_bow/doc_length:distribution/stddev: 12.005011165947533\n",
+            "    nlp_bow/doc_length:distribution/max: 194.0\n",
+            "    nlp_bow/doc_length:distribution/min: 1.0\n",
+            "    nlp_bow/doc_length:distribution/median: 25.0\n",
+            "    nlp_bow/term_length:counts/n: 73471\n",
+            "    nlp_bow/term_length:distribution/mean: 4.514352601706808\n",
+            "    nlp_bow/term_length:distribution/stddev: 2.7094464333602195\n",
+            "    nlp_bow/term_length:distribution/max: 24.0\n",
+            "    nlp_bow/term_length:distribution/min: 1.0\n",
+            "    nlp_bow/term_length:distribution/median: 4.0\n",
+            "    frequent terms: ['the', '.', ',', 'to', 'of', 'in', 'said', 'and', 'a', 'mln']\n",
+            "\n",
+            "split_bow:\n",
+            "    nlp_bow/doc_length:counts/n: 4072\n",
+            "    nlp_bow/doc_length:distribution/mean: 18.610265225933208\n",
+            "    nlp_bow/doc_length:distribution/stddev: 13.298109555065722\n",
+            "    nlp_bow/doc_length:distribution/max: 195.0\n",
+            "    nlp_bow/doc_length:distribution/min: 1.0\n",
+            "    nlp_bow/doc_length:distribution/median: 18.0\n",
+            "    nlp_bow/term_length:counts/n: 75781\n",
+            "    nlp_bow/term_length:distribution/mean: 4.389306026576576\n",
+            "    nlp_bow/term_length:distribution/stddev: 2.703405605642433\n",
+            "    nlp_bow/term_length:distribution/max: 24.0\n",
+            "    nlp_bow/term_length:distribution/min: 1.0\n",
+            "    nlp_bow/term_length:distribution/median: 4.0\n",
+            "    frequent terms: ['the', '.', ',', 'to', 'of', 'in', 'said', 'and', 'a', 'mln']\n",
+            "\n"
+          ]
+        }
+      ],
       "source": [
         "resolvers = STANDARD_RESOLVER + [\n",
         "    ResolverSpec(\n",
@@ -502,53 +535,21 @@
         "    print(f\"{col_name}:\")\n",
         "    dump_summary(col_view)\n",
         "    print()"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "0KFTk_cvX_kz",
-        "outputId": "082435b3-8e25-47bf-e8d1-487b733c824a"
-      },
-      "execution_count": 8,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "original_bow:\n",
-            "    nlp_bow/doc_length:counts/n: 2837\n",
-            "    nlp_bow/doc_length:distribution/mean: 25.89742685935848\n",
-            "    nlp_bow/doc_length:distribution/stddev: 12.005011165947533\n",
-            "    nlp_bow/doc_length:distribution/max: 194.0\n",
-            "    nlp_bow/doc_length:distribution/min: 1.0\n",
-            "    nlp_bow/doc_length:distribution/median: 25.0\n",
-            "    nlp_bow/term_length:counts/n: 73471\n",
-            "    nlp_bow/term_length:distribution/mean: 4.514352601706808\n",
-            "    nlp_bow/term_length:distribution/stddev: 2.7094464333602195\n",
-            "    nlp_bow/term_length:distribution/max: 24.0\n",
-            "    nlp_bow/term_length:distribution/min: 1.0\n",
-            "    nlp_bow/term_length:distribution/median: 4.0\n",
-            "    frequent terms: ['the', '.', ',', 'to', 'of', 'in', 'said', 'and', 'a', 'mln']\n",
-            "\n",
-            "split_bow:\n",
-            "    nlp_bow/doc_length:counts/n: 4072\n",
-            "    nlp_bow/doc_length:distribution/mean: 18.610265225933208\n",
-            "    nlp_bow/doc_length:distribution/stddev: 13.298109555065722\n",
-            "    nlp_bow/doc_length:distribution/max: 195.0\n",
-            "    nlp_bow/doc_length:distribution/min: 1.0\n",
-            "    nlp_bow/doc_length:distribution/median: 18.0\n",
-            "    nlp_bow/term_length:counts/n: 75781\n",
-            "    nlp_bow/term_length:distribution/mean: 4.389306026576576\n",
-            "    nlp_bow/term_length:distribution/stddev: 2.703405605642433\n",
-            "    nlp_bow/term_length:distribution/max: 24.0\n",
-            "    nlp_bow/term_length:distribution/min: 1.0\n",
-            "    nlp_bow/term_length:distribution/median: 4.0\n",
-            "    frequent terms: ['the', '.', ',', 'to', 'of', 'in', 'said', 'and', 'a', 'mln']\n",
-            "\n"
-          ]
-        }
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/python/examples/experimental/embeddings/Embeddings_Distance_Logging.ipynb
+++ b/python/examples/experimental/embeddings/Embeddings_Distance_Logging.ipynb
@@ -52,6 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
     "%pip install --upgrade whylogs[embeddings,viz]"
    ]
   },

--- a/python/examples/experimental/performance_estimation.ipynb
+++ b/python/examples/experimental/performance_estimation.ipynb
@@ -166,7 +166,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q 'whylogs[whylabs,datasets]'"
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install 'whylogs[whylabs,datasets]'"
    ]
   },
   {

--- a/python/examples/experimental/whylogs_Audio_examples.ipynb
+++ b/python/examples/experimental/whylogs_Audio_examples.ipynb
@@ -61,7 +61,8 @@
         }
       ],
       "source": [
-        "%pip install 'whylogs[whylabs]' pyAudioAnalysis eyed3 pydub -q\n"
+        "# Note: you may need to restart the kernel to use updated packages.\n",
+        "%pip install 'whylogs[whylabs]' pyAudioAnalysis eyed3 pydub"
       ]
     },
     {

--- a/python/examples/integrations/BigQuery_Example.ipynb
+++ b/python/examples/integrations/BigQuery_Example.ipynb
@@ -41,10 +41,11 @@
    },
    "outputs": [],
    "source": [
-    "%pip install -q 'whylogs[viz]'\n",
-    "%pip install -q 'whylogs[whylabs]'\n",
-    "%pip install -q pandas-gbq\n",
-    "%pip install -q tqdm"
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install 'whylogs[viz]'\n",
+    "%pip install 'whylogs[whylabs]'\n",
+    "%pip install pandas-gbq\n",
+    "%pip install tqdm"
    ]
   },
   {

--- a/python/examples/integrations/Dask_Profiling.ipynb
+++ b/python/examples/integrations/Dask_Profiling.ipynb
@@ -33,7 +33,8 @@
     }
    ],
    "source": [
-    "%pip install -q dask 'whylogs[viz]'"
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install dask 'whylogs[viz]'"
    ]
   },
   {
@@ -1563,7 +1564,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.10 ('.venv': poetry)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -1581,7 +1582,7 @@
   },
   "vscode": {
    "interpreter": {
-    "hash": "d39f874c9b8a97550ecbd783714b95e79c9b905449b34f44c40e3bf053b54b41"
+    "hash": "5dd5901cadfd4b29c2aaf95ecd29c0c3b10829ad94dcfe59437dbee391154aea"
    }
   }
  },

--- a/python/examples/integrations/Feature_Stores_and_whylogs.ipynb
+++ b/python/examples/integrations/Feature_Stores_and_whylogs.ipynb
@@ -95,25 +95,11 @@
       "metadata": {},
       "outputs": [],
       "source": [
+        "# Note: you may need to restart the kernel to use updated packages.\n",
         "%pip install --upgrade pip -qq\n",
         "%pip install feast==0.22.4 -qq\n",
-        "%pip install Pygments -qq\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Also, if you don't have whylogs installed:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%pip install whylogs[viz] -U -qq"
+        "%pip install Pygments -qq\n",
+        "%pip install whylogs[viz] -U"
       ]
     },
     {
@@ -6450,7 +6436,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3.8.10 ('.venv': poetry)",
+      "display_name": ".venv",
       "language": "python",
       "name": "python3"
     },
@@ -6468,7 +6454,7 @@
     },
     "vscode": {
       "interpreter": {
-        "hash": "8430e7bcc333486e417258c6fadac662061ebd166d9f3c5ccb12c1968aa41625"
+        "hash": "5dd5901cadfd4b29c2aaf95ecd29c0c3b10829ad94dcfe59437dbee391154aea"
       }
     }
   },

--- a/python/examples/integrations/Fugue_Profiling.ipynb
+++ b/python/examples/integrations/Fugue_Profiling.ipynb
@@ -42,6 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
     "%pip install 'whylogs[fugue]' 'fugue[spark]'"
    ]
   },
@@ -7168,11 +7169,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.8.10"
   },
   "vscode": {
    "interpreter": {
-    "hash": "d4bce4e749e5452baa925b5367e0ce1a24e1936540311006e3497d016ec67e64"
+    "hash": "5dd5901cadfd4b29c2aaf95ecd29c0c3b10829ad94dcfe59437dbee391154aea"
    }
   }
  },

--- a/python/examples/integrations/Mlflow_Logging.ipynb
+++ b/python/examples/integrations/Mlflow_Logging.ipynb
@@ -49,7 +49,8 @@
    },
    "outputs": [],
    "source": [
-    "%pip install -q 'whylogs[mlflow]'"
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install 'whylogs[mlflow]'"
    ]
   },
   {

--- a/python/examples/integrations/Pyspark_Profiling.ipynb
+++ b/python/examples/integrations/Pyspark_Profiling.ipynb
@@ -36,6 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
     "%pip install 'whylogs[spark]'"
    ]
   },

--- a/python/examples/integrations/flask_streaming/flask_with_whylogs.ipynb
+++ b/python/examples/integrations/flask_streaming/flask_with_whylogs.ipynb
@@ -78,8 +78,9 @@
     }
    ],
    "source": [
-    "%pip install -q pandas utils joblib scikit-learn Flask\n",
-    "%pip install -q 'whylogs[whylabs]'"
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install pandas utils joblib scikit-learn Flask\n",
+    "%pip install 'whylogs[whylabs]'"
    ]
   },
   {
@@ -1005,7 +1006,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -1019,7 +1020,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "3.8.10"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "5dd5901cadfd4b29c2aaf95ecd29c0c3b10829ad94dcfe59437dbee391154aea"
+   }
   }
  },
  "nbformat": 4,

--- a/python/examples/integrations/kafka-example/Kafka_Example.ipynb
+++ b/python/examples/integrations/kafka-example/Kafka_Example.ipynb
@@ -42,8 +42,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q whylogs\n",
-    "%pip install -q kafka-python"
+    "# Note: you may need to restart the kernel to use updated packages.\n",
+    "%pip install whylogs\n",
+    "%pip install kafka-python"
    ]
   },
   {
@@ -745,11 +746,8 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "0f484380554f045e8316d9ef136659363ef199c84a7347221e49b73e46486d36"
-  },
   "kernelspec": {
-   "display_name": "Python 3.9.13 ('.venv': poetry)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -763,9 +761,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.8.10"
   },
-  "orig_nbformat": 4
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "5dd5901cadfd4b29c2aaf95ecd29c0c3b10829ad94dcfe59437dbee391154aea"
+   }
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/python/examples/integrations/writers/Getting_Started_with_WhyLabsV1.ipynb
+++ b/python/examples/integrations/writers/Getting_Started_with_WhyLabsV1.ipynb
@@ -93,6 +93,7 @@
       },
       "outputs": [],
       "source": [
+        "# Note: you may need to restart the kernel to use updated packages.\n",
         "### The following WhyLabs Platform integration example requires the latest whylogs version: \n",
         "%pip install 'whylogs[whylabs]'"
       ]

--- a/python/examples/integrations/writers/Writing_Classification_Performance_Metrics_to_WhyLabs.ipynb
+++ b/python/examples/integrations/writers/Writing_Classification_Performance_Metrics_to_WhyLabs.ipynb
@@ -49,6 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
     "%pip install 'whylogs[whylabs, datasets]'"
    ]
   },

--- a/python/examples/integrations/writers/Writing_Feature_Weights_to_WhyLabs.ipynb
+++ b/python/examples/integrations/writers/Writing_Feature_Weights_to_WhyLabs.ipynb
@@ -61,6 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
     "%pip install whylogs[whylabs]\n",
     "%pip install scikit-learn==1.0.2"
    ]

--- a/python/examples/integrations/writers/Writing_Profiles.ipynb
+++ b/python/examples/integrations/writers/Writing_Profiles.ipynb
@@ -64,6 +64,7 @@
     }
    ],
    "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
     "import shutil\n",
     "%pip install whylogs"
    ]

--- a/python/examples/integrations/writers/Writing_Reference_Profiles_to_WhyLabs.ipynb
+++ b/python/examples/integrations/writers/Writing_Reference_Profiles_to_WhyLabs.ipynb
@@ -58,6 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
     "%pip install 'whylogs[whylabs]'"
    ]
   },

--- a/python/examples/integrations/writers/Writing_Regression_Performance_Metrics_to_WhyLabs.ipynb
+++ b/python/examples/integrations/writers/Writing_Regression_Performance_Metrics_to_WhyLabs.ipynb
@@ -49,6 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
     "%pip install 'whylogs[whylabs, datasets]'"
    ]
   },

--- a/python/examples/integrations/writers/Writing_to_WhyLabs.ipynb
+++ b/python/examples/integrations/writers/Writing_to_WhyLabs.ipynb
@@ -51,6 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Note: you may need to restart the kernel to use updated packages.\n",
     "%pip install 'whylogs[whylabs]'"
    ]
   },


### PR DESCRIPTION
## Description

There were some issues with the pip install commands in some notebooks

- some were commented out or absent
- most had the `-q` flag: in some environments, this hides the warning about needing to restart the kernel. This can lead to a confusing experience where not restarting the kernel lead to errors running the example

## Changes

Considering this, changes were made:

- uncommented/introduced pip install commands
- removed the `-q` flag in examples
- Added comment warning that it might be required to restart the kernel

fixes #1114

