### PR TITLE
Add dtype for pd.Series

### DIFF
--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -173,7 +173,7 @@ class PreprocessedColumn:
         bool_count_where_true = non_null_series[bool_mask_where_true].count()
         strings = non_null_series[str_mask]
         tensors = non_null_series[tensor_mask]
-        tensors = pd.Series([x if isinstance(x, np.ndarray) else np.asarray(x) for x in tensors])
+        tensors = pd.Series([x if isinstance(x, np.ndarray) else np.asarray(x) for x in tensors], dtype='object')
         objs = non_null_series[~(float_mask | str_mask | int_mask | bool_mask | tensor_mask)]
 
         # convert numeric types to float if they are considered

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -173,7 +173,7 @@ class PreprocessedColumn:
         bool_count_where_true = non_null_series[bool_mask_where_true].count()
         strings = non_null_series[str_mask]
         tensors = non_null_series[tensor_mask]
-        tensors = pd.Series([x if isinstance(x, np.ndarray) else np.asarray(x) for x in tensors], dtype='object')
+        tensors = pd.Series([x if isinstance(x, np.ndarray) else np.asarray(x) for x in tensors], dtype="object")
         objs = non_null_series[~(float_mask | str_mask | int_mask | bool_mask | tensor_mask)]
 
         # convert numeric types to float if they are considered


### PR DESCRIPTION
There is a lot of logging happening because of missing dtypes. I'm not sure what the right dtype is but we should specify something to silence this error.

```
    ./whylogs/core/preprocessing.py:176: FutureWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.
```
