### PR TITLE
Fix reading older profiles without tensors counts

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.28
+current_version = 1.1.29
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 

--- a/python/Makefile
+++ b/python/Makefile
@@ -5,7 +5,7 @@ src.proto.dir := ../proto/src
 src.proto := $(shell find $(src.proto.dir) -type f -name "*.proto")
 src.proto.v0.dir := ../proto/v0
 src.proto.v0 := $(shell find $(src.proto.v0.dir) -type f -name "*.proto")
-version := 1.1.28
+version := 1.1.29
 
 dist.dir := dist
 egg.dir := .eggs

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -8,7 +8,7 @@ if shutil.which("pandoc") is None:
     print("Pandoc is required to build our documentation.")
     sys.exit(1)
 
-version = "1.1.28"
+version = "1.1.29"
 
 project = "whylogs"
 author = "whylogs developers"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "whylogs"
-version = "1.1.28"
+version = "1.1.29"
 description = "Profile and monitor your ML data pipeline end-to-end"
 authors = ["WhyLabs.ai <support@whylabs.ai>"]
 license = "Apache-2.0"

--- a/python/tests/core/metrics/test_column_metrics.py
+++ b/python/tests/core/metrics/test_column_metrics.py
@@ -4,6 +4,7 @@ import pytest
 
 from whylogs.core import ColumnSchema
 from whylogs.core.metrics import ColumnCountsMetric, TypeCountersMetric
+from whylogs.core.metrics.metric_components import IntegralComponent
 from whylogs.core.preprocessing import PreprocessedColumn
 
 INTEGER_TYPES = [int, np.intc, np.uintc, np.int_, np.uint, np.longlong, np.ulonglong]
@@ -67,3 +68,27 @@ def test_different_types_col_update_on_series(counts, data_type) -> None:
     assert counts.n.value == expected_int_count
     assert operation_result.ok
     assert operation_result.successes == integers_per_input
+
+
+def test_type_counts_with_and_without_tensor_field():
+    type_counts = TypeCountersMetric(
+        boolean=IntegralComponent(1),
+        integral=IntegralComponent(2),
+        fractional=IntegralComponent(3),
+        string=IntegralComponent(4),
+        object=IntegralComponent(5),
+    )
+    assert type_counts.tensor.value == 0
+    type_counts.tensor.set(1)
+    assert type_counts.boolean.value == 1
+    full_type_counts = TypeCountersMetric(
+        boolean=IntegralComponent(1),
+        integral=IntegralComponent(2),
+        fractional=IntegralComponent(3),
+        string=IntegralComponent(4),
+        object=IntegralComponent(5),
+        tensor=IntegralComponent(6),
+    )
+    assert full_type_counts.tensor.value == 6
+    merged_counts = full_type_counts.merge(type_counts)
+    assert merged_counts.tensor.value == 7

--- a/python/tests/smoketest.py
+++ b/python/tests/smoketest.py
@@ -12,7 +12,7 @@ intended to test the wheel in a production environment,
 not a development environment.
 """
 
-current_version = "1.1.28"
+current_version = "1.1.29"
 
 
 def test_package_version() -> None:

--- a/python/whylogs/core/metrics/column_metrics.py
+++ b/python/whylogs/core/metrics/column_metrics.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
 from whylogs.core.configs import SummaryConfig
@@ -19,7 +19,7 @@ class TypeCountersMetric(Metric):
     boolean: IntegralComponent
     string: IntegralComponent
     object: IntegralComponent
-    tensor: IntegralComponent
+    tensor: IntegralComponent = field(default_factory=lambda: IntegralComponent(0))
 
     @property
     def namespace(self) -> str:


### PR DESCRIPTION
## Description

Fixes #1130 by creating a default value for the tensors field in TypeCountersMetric

## Changes

- added a test that reproduces the issue, but more realistically any older dataset profile file would not be readable by 1.1.29
- added default factory for the tensors field to instantiate an integral component when this field is not passed to init.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
