### PR TITLE
Make writing loop a little better

### DIFF
--- a/python/whylogs/api/logger/experimental/multi_dataset_logger/multi_dataset_rolling_logger.py
+++ b/python/whylogs/api/logger/experimental/multi_dataset_logger/multi_dataset_rolling_logger.py
@@ -272,8 +272,8 @@ class MultiDatasetRollingLogger(MessageProcessor[LoggerMessage]):
         for dataset_timestamp, container in self._cache.items():
             self._logger.debug(f"Generating result set for dataset timestamp {dataset_timestamp}")
 
-            for pending in self._writers.values():
-                for writable in container.to_result_set().get_writables() or []:
+            for writable in container.to_result_set().get_writables() or []:
+                for pending in self._writers.values():
                     pending.append(PendingWritable(attempts=0, writable=writable))
 
         self._cache = {}


### PR DESCRIPTION
Not a huge deal but we generate fewer redundant result sets if we invert this loop when there are multiple writers.
