### PR TITLE
Homogeneous column preprocessing specified by tuple in types map passed to schema

### DIFF
--- a/python/tests/core/test_preprocessing.py
+++ b/python/tests/core/test_preprocessing.py
@@ -688,7 +688,8 @@ def test_apply_list(
 def test_homogeneous_column() -> None:
     d = {"col1": [1, 2, 3, 4], "col2": [5.0, 6.0, 7.0, 8.0], "col3": ["a", "b", "c", "d"]}
     df = pd.DataFrame(data=d)
-    schema = DeclarativeSchema(STANDARD_RESOLVER, homogeneous_column_names={"col1"})
+    types = {"col1": (int, True)}
+    schema = DeclarativeSchema(STANDARD_RESOLVER, types=types)
     results = why.log(pandas=df, schema=schema)
     view = results.profile().view()
 

--- a/python/tests/core/test_preprocessing.py
+++ b/python/tests/core/test_preprocessing.py
@@ -11,6 +11,7 @@ from pandas.testing import assert_series_equal
 
 import whylogs as why
 from whylogs.core.preprocessing import (
+    ColumnProperties,
     ListView,
     NumpyView,
     PandasView,
@@ -688,7 +689,7 @@ def test_apply_list(
 def test_homogeneous_column() -> None:
     d = {"col1": [1, 2, 3, 4], "col2": [5.0, 6.0, 7.0, 8.0], "col3": ["a", "b", "c", "d"]}
     df = pd.DataFrame(data=d)
-    types = {"col1": (int, True)}
+    types = {"col1": (int, ColumnProperties.homogeneous), "col2": (float, ColumnProperties.default)}
     schema = DeclarativeSchema(STANDARD_RESOLVER, types=types)
     results = why.log(pandas=df, schema=schema)
     view = results.profile().view()

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -9,6 +9,7 @@ from whylogs.core.metrics import Metric
 from whylogs.core.model_performance_metrics.model_performance_metrics import (
     ModelPerformanceMetrics,
 )
+from whylogs.core.preprocessing import ColumnProperties
 from whylogs.core.utils.utils import deprecated_alias
 
 from .column_profile import ColumnProfile
@@ -155,8 +156,8 @@ class DatasetProfile(Writable):
                     dtype is not None
                     and isinstance(dtype, tuple)
                     and len(dtype) == 2
-                    and isinstance(dtype[1], bool)
-                    and dtype[1]
+                    and isinstance(dtype[1], ColumnProperties)
+                    and dtype[1] == ColumnProperties.homogeneous
                 )
                 if homogeneous:
                     self._columns[k]._track_homogeneous_column(column_values)

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -152,11 +152,11 @@ class DatasetProfile(Writable):
 
                 dtype = self._schema.types.get(k)
                 homogeneous = (
-                    dtype is not None and
-                    isinstance(dtype, tuple) and
-                    len(dtype) == 2 and
-                    isinstance(dtype[1], bool) and
-                    dtype[1]
+                    dtype is not None
+                    and isinstance(dtype, tuple)
+                    and len(dtype) == 2
+                    and isinstance(dtype[1], bool)
+                    and dtype[1]
                 )
                 if homogeneous:
                     self._columns[k]._track_homogeneous_column(column_values)

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -149,7 +149,16 @@ class DatasetProfile(Writable):
                         f"whylogs was passed a pandas DataFrame with key [{k}] but DataFrame.get({k}) returned nothing!"
                     )
                     return
-                if k in self._schema.homogeneous_column_names:
+
+                dtype = self._schema.types.get(k)
+                homogeneous = (
+                    dtype is not None and
+                    isinstance(dtype, tuple) and
+                    len(dtype) == 2 and
+                    isinstance(dtype[1], bool) and
+                    dtype[1]
+                )
+                if homogeneous:
                     self._columns[k]._track_homogeneous_column(column_values)
                 else:
                     self._columns[k].track_column(column_values)

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -2,6 +2,7 @@ import itertools
 import logging
 from dataclasses import dataclass
 from decimal import Decimal
+from enum import Enum
 from math import isinf, isnan
 from typing import Any, Iterable, Iterator, List, Optional, Union
 
@@ -13,6 +14,11 @@ try:
     import pandas.core.dtypes.common as pdc
 except:  # noqa
     pass
+
+
+class ColumnProperties(Enum):
+    default = 0
+    homogeneous = 1
 
 
 @dataclass

--- a/python/whylogs/core/schema.py
+++ b/python/whylogs/core/schema.py
@@ -1,7 +1,7 @@
 import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Mapping, Optional, Set, TypeVar
+from typing import Any, Dict, List, Mapping, Optional, TypeVar
 
 from whylogs.core.datatypes import StandardTypeMapper, TypeMapper
 from whylogs.core.metrics.metrics import Metric, MetricConfig

--- a/python/whylogs/core/schema.py
+++ b/python/whylogs/core/schema.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Mapping, Optional, TypeVar
 
 from whylogs.core.datatypes import StandardTypeMapper, TypeMapper
 from whylogs.core.metrics.metrics import Metric, MetricConfig
+from whylogs.core.preprocessing import ColumnProperties
 from whylogs.core.resolvers import (
     DeclarativeResolver,
     Resolver,
@@ -99,7 +100,7 @@ class DatasetSchema:
             )
 
         for col, data_type in self.types.items():
-            if isinstance(data_type, tuple) and len(data_type) == 2 and isinstance(data_type[1], bool):
+            if isinstance(data_type, tuple) and len(data_type) == 2 and isinstance(data_type[1], ColumnProperties):
                 dtype = data_type[0]
             else:
                 dtype = data_type

--- a/python/whylogs/core/schema.py
+++ b/python/whylogs/core/schema.py
@@ -76,7 +76,6 @@ class DatasetSchema:
         schema_based_automerge: bool = False,
         segments: Optional[Dict[str, SegmentationPartition]] = None,
         validators: Optional[Dict[str, List[Validator]]] = None,
-        homogeneous_column_names: Set[str] = set(),
     ) -> None:
         self._columns = dict()
         self.types = types or dict()
@@ -87,7 +86,6 @@ class DatasetSchema:
         self.schema_based_automerge = schema_based_automerge
         self.segments = segments or dict()
         self.validators = validators or dict()
-        self.homogeneous_column_names = homogeneous_column_names
 
         if self.cache_size < 0:
             logger.warning("Negative cache size value. Disabling caching")
@@ -101,8 +99,13 @@ class DatasetSchema:
             )
 
         for col, data_type in self.types.items():
+            if isinstance(data_type, tuple) and len(data_type) == 2 and isinstance(data_type[1], bool):
+                dtype = data_type[0]
+            else:
+                dtype = data_type
+
             self._columns[col] = ColumnSchema(
-                dtype=data_type,
+                dtype=dtype,
                 resolver=self.resolvers,
                 type_mapper=self.type_mapper,
                 cfg=self.default_configs,
@@ -228,7 +231,6 @@ class DeclarativeSchema(DatasetSchema):
         schema_based_automerge: bool = False,
         segments: Optional[Dict[str, SegmentationPartition]] = None,
         validators: Optional[Dict[str, List[Validator]]] = None,
-        homogeneous_column_names: Set[str] = set(),
     ) -> None:
         if not resolvers:
             logger.warning("No columns specified in DeclarativeSchema")
@@ -242,5 +244,4 @@ class DeclarativeSchema(DatasetSchema):
             schema_based_automerge=schema_based_automerge,
             segments=segments,
             validators=validators,
-            homogeneous_column_names=homogeneous_column_names,
         )

--- a/python/whylogs/experimental/extras/embedding_metric.py
+++ b/python/whylogs/experimental/extras/embedding_metric.py
@@ -152,7 +152,6 @@ class EmbeddingMetric(MultiMetric):
             ref_dists = self.distance_fn(matrix, self.references.value)  # type: ignore
             ref_closest = np.argmin(ref_dists, axis=1)
 
-            # TODO: reshape into a vector?
             for i in range(ref_dists.shape[1]):
                 self._update_submetrics(f"{self.labels[i]}_distance", PreprocessedColumn.apply(ref_dists[:, i]))
 


### PR DESCRIPTION
```
def test_homogeneous_column() -> None:
    d = {"col1": [1, 2, 3, 4], "col2": [5.0, 6.0, 7.0, 8.0], "col3": ["a", "b", "c", "d"]}
    df = pd.DataFrame(data=d)
    types = {"col1": (int, True)}
    schema = DeclarativeSchema(STANDARD_RESOLVER, types=types)
    results = why.log(pandas=df, schema=schema)
```