### PR TITLE
trigger registration of non-standard metrics for profile deserialization

### DIFF
--- a/python/whylogs/core/stubs.py
+++ b/python/whylogs/core/stubs.py
@@ -16,6 +16,11 @@ except ImportError:  # noqa
     if _pd is not None:
         logger.error("Pandas is installed but numpy is not. Your environment is probably broken.")
 
+try:
+    import scipy as _sp
+except ImportError:  # noqa
+    _sp = None  # type: ignore
+
 
 class _StubClass:
     pass
@@ -40,6 +45,11 @@ class PandasStub(object):
     DataFrame: type = _StubClass
 
 
+@dataclass(frozen=True)
+class ScipyStub:
+    sparse: type = _StubClass
+
+
 def is_not_stub(stubbed_class: Any) -> bool:
     if stubbed_class and stubbed_class is not _StubClass and not isinstance(stubbed_class, (PandasStub, NumpyStub)):
         return True
@@ -52,5 +62,9 @@ if _np is None:
 if _pd is None:
     _pd = PandasStub()
 
+if _sp is None:
+    _sp = ScipyStub()
+
 np = _np
 pd = _pd
+sp = _sp

--- a/python/whylogs/core/view/column_profile_view.py
+++ b/python/whylogs/core/view/column_profile_view.py
@@ -110,6 +110,11 @@ class ColumnProfileView(object):
 
     @classmethod
     def from_protobuf(cls, msg: ColumnMessage) -> "ColumnProfileView":
+        # importing to trigger registration of non-standard metrics
+        import whylogs.experimental.extras.embedding_metric  # noqa
+        import whylogs.experimental.extras.nlp_metric  # noqa
+        import whylogs.extras.image_metric  # noqa
+
         result_metrics: Dict[str, Metric] = {}
         metric_messages: Dict[str, Dict[str, MetricComponentMessage]] = {}
         for full_path, c_msg in msg.metric_components.items():

--- a/python/whylogs/experimental/extras/embedding_metric.py
+++ b/python/whylogs/experimental/extras/embedding_metric.py
@@ -4,7 +4,6 @@ from enum import Enum
 from itertools import chain
 from typing import List, Optional
 
-import numpy as np
 from sklearn.metrics.pairwise import cosine_distances, euclidean_distances
 
 from whylogs.core.metrics import StandardMetric
@@ -12,6 +11,7 @@ from whylogs.core.metrics.metrics import MetricConfig, OperationResult, register
 from whylogs.core.metrics.multimetric import MultiMetric
 from whylogs.core.preprocessing import PreprocessedColumn
 from whylogs.core.proto import MetricMessage
+from whylogs.core.stubs import np
 from whylogs.experimental.extras.matrix_component import MatrixComponent
 
 logger = logging.getLogger(__name__)

--- a/python/whylogs/experimental/extras/nlp_metric.py
+++ b/python/whylogs/experimental/extras/nlp_metric.py
@@ -3,9 +3,6 @@ from dataclasses import dataclass, field
 from itertools import chain
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import numpy as np
-import scipy as sp
-
 from whylogs.api.logger.result_set import ProfileResultSet, ResultSet
 from whylogs.core import DatasetProfile, DatasetSchema
 from whylogs.core.configs import SummaryConfig
@@ -21,6 +18,7 @@ from whylogs.core.preprocessing import ListView, PreprocessedColumn
 from whylogs.core.proto import MetricMessage
 from whylogs.core.resolvers import Resolver, StandardResolver
 from whylogs.core.schema import ColumnSchema
+from whylogs.core.stubs import np, sp
 from whylogs.experimental.extras.matrix_component import MatrixComponent
 
 _SMALL = np.finfo(float).eps


### PR DESCRIPTION
## Description

Triggers registration of non-standard metrics to allow deserialization of profiles containing such metrics.

## Changes

- Adds stubs for Scipy
- Ensure non-standard metrics use stubs for extra dependencies
- `ColumnProfileView::from_protobuf()` imports the non-standard metrics to trigger their registration

## Related

Relates to whylabs/whylogs#1137

Closes whylabs/whylogs#1137

