### PR TITLE
PreprocessedColumn properties enum (homogeneous)

### DIFF
--- a/python/tests/core/test_preprocessing.py
+++ b/python/tests/core/test_preprocessing.py
@@ -11,6 +11,7 @@ from pandas.testing import assert_series_equal
 
 import whylogs as why
 from whylogs.core.preprocessing import (
+    ColumnProperties,
     ListView,
     NumpyView,
     PandasView,
@@ -688,7 +689,7 @@ def test_apply_list(
 def test_homogeneous_column() -> None:
     d = {"col1": [1, 2, 3, 4], "col2": [5.0, 6.0, 7.0, 8.0], "col3": ["a", "b", "c", "d"]}
     df = pd.DataFrame(data=d)
-    types = {"col1": (int, True)}
+    types = {"col1": (int, ColumnProperties.homogeneous), "col2": (float, ColumnProperties.default)}
     schema = DeclarativeSchema(STANDARD_RESOLVER, types=types)
     results = why.log(pandas=df, schema=schema)
     view = results.profile().view()

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -9,6 +9,7 @@ from whylogs.core.metrics import Metric
 from whylogs.core.model_performance_metrics.model_performance_metrics import (
     ModelPerformanceMetrics,
 )
+from whylogs.core.preprocessing import ColumnProperties
 from whylogs.core.utils.utils import deprecated_alias
 
 from .column_profile import ColumnProfile
@@ -152,11 +153,11 @@ class DatasetProfile(Writable):
 
                 dtype = self._schema.types.get(k)
                 homogeneous = (
-                    dtype is not None and
-                    isinstance(dtype, tuple) and
-                    len(dtype) == 2 and
-                    isinstance(dtype[1], bool) and
-                    dtype[1]
+                    dtype is not None
+                    and isinstance(dtype, tuple)
+                    and len(dtype) == 2
+                    and isinstance(dtype[1], ColumnProperties)
+                    and dtype[1] == ColumnProperties.homogeneous
                 )
                 if homogeneous:
                     self._columns[k]._track_homogeneous_column(column_values)

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -2,6 +2,7 @@ import itertools
 import logging
 from dataclasses import dataclass
 from decimal import Decimal
+from enum import Enum
 from math import isinf, isnan
 from typing import Any, Iterable, Iterator, List, Optional, Union
 
@@ -13,6 +14,11 @@ try:
     import pandas.core.dtypes.common as pdc
 except:  # noqa
     pass
+
+
+class ColumnProperties(Enum):
+    default = 0
+    homogeneous = 1
 
 
 @dataclass

--- a/python/whylogs/core/schema.py
+++ b/python/whylogs/core/schema.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Mapping, Optional, TypeVar
 
 from whylogs.core.datatypes import StandardTypeMapper, TypeMapper
 from whylogs.core.metrics.metrics import Metric, MetricConfig
+from whylogs.core.preprocessing import ColumnProperties
 from whylogs.core.resolvers import (
     DeclarativeResolver,
     Resolver,
@@ -99,7 +100,7 @@ class DatasetSchema:
             )
 
         for col, data_type in self.types.items():
-            if isinstance(data_type, tuple) and len(data_type) == 2 and isinstance(data_type[1], bool):
+            if isinstance(data_type, tuple) and len(data_type) == 2 and isinstance(data_type[1], ColumnProperties):
                 dtype = data_type[0]
             else:
                 dtype = data_type


### PR DESCRIPTION
## Description

```
def test_homogeneous_column() -> None:
    d = {"col1": [1, 2, 3, 4], "col2": [5.0, 6.0, 7.0, 8.0], "col3": ["a", "b", "c", "d"]}
    df = pd.DataFrame(data=d)
    types = {
        "col1": (int, ColumnProperties.homogeneous),
        "col2": (float, ColumnProperties.default)
    }
    schema = DeclarativeSchema(STANDARD_RESOLVER, types=types)
    results = why.log(pandas=df, schema=schema)
```


