### PR TITLE
pyspark embeddings support on vectors

### DIFF
--- a/python/whylogs/api/pyspark/experimental/segmented_profiler.py
+++ b/python/whylogs/api/pyspark/experimental/segmented_profiler.py
@@ -93,7 +93,7 @@ def collect_segmented_column_profile_views(
 
     cp = f"{SEGMENT_KEY_FIELD} string, {COL_NAME_FIELD} string, {COL_PROFILE_FIELD} binary"
     whylogs_pandas_map_profiler_with_schema = partial(whylogs_pandas_segmented_profiler, schema=schema)
-    segmented_profile_bytes_df = input_df.mapInPandas(whylogs_pandas_map_profiler_with_schema, schema=cp)  # type: ignore
+    segmented_profile_bytes_df = input_df_arrays.mapInPandas(whylogs_pandas_map_profiler_with_schema, schema=cp)  # type: ignore
     # aggregate by segment key first, then by column
     segment_column_profiles = segmented_profile_bytes_df.groupby(
         SEGMENT_KEY_FIELD, COL_NAME_FIELD


### PR DESCRIPTION
## Description

the pyspark mapInPandas does not support dataframe that contain vectors, and the whylogs pyspark profiler uses mapInPandas. To support embeddings which might be passed in as DenseVectors we check for any columns of vector type and convert these to arrays inside the whylogs `collect_dataset_profile_view` if present. This creates a transformed dataframe which conforms to the requirements of mapInPandas and is consistent with how whylogs profiles embeddings (counted as tensor types).

As a side effect we now can profile dataframes that contain vector columns, where before this change a vector column would cause an error in the whylogs profiling when using pyspark (even if the configuration did not include embeddings metrics).

## Changes

- Check for VectorUDT columns inside pyspark profiling functions
- transform vectors to arrays before passing to mapInPandas inside whylogs pyspark profiling.
- added tests for vectors and embeddings metrics with pyspark.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
