### PR TITLE
preserve mlflow existing run when using mlflow writer

### DIFF
--- a/python/tests/api/writer/test_mlflow.py
+++ b/python/tests/api/writer/test_mlflow.py
@@ -66,7 +66,6 @@ class TestMlflowWriter(object):
     def test_write_leaves_existing_mlflow_runs_open(self, result_set, html_report):
         preexisting_run = mlflow.active_run()
         existing_run = preexisting_run or mlflow.start_run()
-
         run_id = existing_run.info.run_id
 
         result_set_writer = result_set.writer("mlflow")

--- a/python/tests/api/writer/test_mlflow.py
+++ b/python/tests/api/writer/test_mlflow.py
@@ -12,8 +12,8 @@ from whylogs.api.writer.mlflow import MlflowWriter
 class TestMlflowWriter(object):
     @classmethod
     def teardown_class(cls):
-        shutil.rmtree("mlruns")
-        shutil.rmtree("artifact_downloads")
+        shutil.rmtree("mlruns", ignore_errors=True)
+        shutil.rmtree("artifact_downloads", ignore_errors=True)
 
     @pytest.fixture
     def mlflow_writer(self):
@@ -62,3 +62,18 @@ class TestMlflowWriter(object):
         read_profile = why.read(path=f"{local_path}/profile_{timestamp}.bin")
         assert isinstance(read_profile, ViewResultSet)
         assert os.path.isfile(f"{local_path}/ProfileReport.html")
+
+    def test_write_leaves_existing_mlflow_runs_open(self, result_set, html_report):
+        preexisting_run = mlflow.active_run()
+        existing_run = preexisting_run or mlflow.start_run()
+
+        run_id = existing_run.info.run_id
+
+        result_set_writer = result_set.writer("mlflow")
+        result_set_writer.write()
+
+        assert mlflow.active_run()
+        assert mlflow.active_run().info.run_id == run_id
+        if not preexisting_run:
+            mlflow.end_run()
+        assert preexisting_run or not mlflow.active_run()

--- a/python/whylogs/api/writer/mlflow.py
+++ b/python/whylogs/api/writer/mlflow.py
@@ -25,14 +25,15 @@ class MlflowWriter(Writer):
         dest: Optional[str] = None,
         **kwargs: Any,
     ) -> Tuple[bool, str]:
-        run = mlflow.active_run() or mlflow.start_run()
+        preexisting_run = mlflow.active_run()
+        run = preexisting_run or mlflow.start_run()
         self._run_id = run.info.run_id
         dest = dest or self._file_name or file.get_default_path()  # dest has a higher priority than file_name
         output = self._get_temp_directory(dest=dest)
         response = file.write(path=output)  # type: ignore
         mlflow.log_artifact(output, artifact_path=self._file_dir)
 
-        if self._end_run is True:
+        if self._end_run is True and not preexisting_run:
             mlflow.end_run()
         return response
 


### PR DESCRIPTION
## Description

Fixes #1129 by recording if whylogs started the mlflow run or not and only end it if whylogs also started it and the setting to end the run is True (default value).

## Changes

- check if there is a preexisting mlflow run before creating one in the whylogs mlflow writer
  - only end the run if it was also started locally in the write method and the setting is True
- Added new test to check that we don't end preexisting mlflow runs
- Minor test fix for the MLFlow writer tests to not throw if there are no artifacts or runs directory which is the case in the new test if run standalone.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
