### PR TITLE
constraints generation

### DIFF
--- a/python/tests/experimental/constraints_generation/test_constraints_generation.py
+++ b/python/tests/experimental/constraints_generation/test_constraints_generation.py
@@ -39,8 +39,7 @@ def reference_profile_view():
             ),
         ],
     )
-    schema = DeclarativeSchema(STANDARD_RESOLVER)
-    schema.add_resolver(legs_spec)
+    schema = DeclarativeSchema(STANDARD_RESOLVER + [legs_spec])
 
     results = why.log(df, schema=schema)
     profile_view = results.view()

--- a/python/tests/experimental/constraints_generation/test_constraints_generation.py
+++ b/python/tests/experimental/constraints_generation/test_constraints_generation.py
@@ -1,0 +1,67 @@
+import pandas as pd
+import pytest
+import whylogs as why
+import pandas as pd
+from whylogs.core.constraints import ConstraintsBuilder
+from whylogs.experimental.constraints_generation import generate_constraints_from_reference_profile
+from whylogs.core.relations import Predicate
+from whylogs.core.metrics.condition_count_metric import (
+    Condition,
+    ConditionCountConfig,
+    ConditionCountMetric,
+)
+from whylogs.core.resolvers import (
+    STANDARD_RESOLVER,
+    MetricSpec,
+    ResolverSpec,
+)
+from whylogs.core.schema import DeclarativeSchema
+
+
+@pytest.fixture
+def reference_profile_view():
+    data = {
+        "animal": ["cat", "hawk", "snake", "cat", "mosquito"],
+        "legs": [4, 2, 0, 4, 6],
+        "weight": [4.3, 1.8, 1.3, 4.1, 5.5e-6],
+    }
+    df = pd.DataFrame(data)
+
+    def even(x) -> bool:
+        return x % 2 == 0
+
+    regex_conditions = {"legs_even": Condition(Predicate().is_(even))}
+
+    legs_spec = ResolverSpec(
+        column_name="legs",
+        metrics=[
+            MetricSpec(
+                ConditionCountMetric,
+                ConditionCountConfig(conditions=regex_conditions),
+            ),
+        ],
+    )
+    schema = DeclarativeSchema(STANDARD_RESOLVER)
+    schema.add_resolver(legs_spec)
+
+    results = why.log(df, schema=schema)
+    profile_view = results.view()
+    return profile_view
+
+
+def test_constraints_generation(reference_profile_view):
+    suggested_constraints = generate_constraints_from_reference_profile(reference_profile_view=reference_profile_view)
+    # since the profile is the reference itself, every condition should pass
+    builder = ConstraintsBuilder(dataset_profile_view=reference_profile_view)
+    builder.add_constraints(suggested_constraints)
+    constraints = builder.build()
+    report = constraints.generate_constraints_report()
+    assert all(result.passed == 1 for result in report)
+    assert report[0].name == "animal has no missing values"
+    assert report[1].name == "animal types count non-zero for ['string']"
+    assert report[2].name == "legs has no missing values"
+    assert report[3].name == "legs types count non-zero for ['integral']"
+    assert report[4].name == "legs meets condition legs_even"
+    assert report[5].name == "weight has no missing values"
+    assert report[6].name == "weight types count non-zero for ['fractional']"
+    print("h")

--- a/python/tests/experimental/constraints_generation/test_constraints_generation.py
+++ b/python/tests/experimental/constraints_generation/test_constraints_generation.py
@@ -1,21 +1,19 @@
 import pandas as pd
 import pytest
+
 import whylogs as why
-import pandas as pd
 from whylogs.core.constraints import ConstraintsBuilder
-from whylogs.experimental.constraints_generation import generate_constraints_from_reference_profile
-from whylogs.core.relations import Predicate
 from whylogs.core.metrics.condition_count_metric import (
     Condition,
     ConditionCountConfig,
     ConditionCountMetric,
 )
-from whylogs.core.resolvers import (
-    STANDARD_RESOLVER,
-    MetricSpec,
-    ResolverSpec,
-)
+from whylogs.core.relations import Predicate
+from whylogs.core.resolvers import STANDARD_RESOLVER, MetricSpec, ResolverSpec
 from whylogs.core.schema import DeclarativeSchema
+from whylogs.experimental.constraints_generation import (
+    generate_constraints_from_reference_profile,
+)
 
 
 @pytest.fixture

--- a/python/tests/experimental/constraints_generation/test_constraints_generation.py
+++ b/python/tests/experimental/constraints_generation/test_constraints_generation.py
@@ -28,14 +28,14 @@ def reference_profile_view():
     def even(x) -> bool:
         return x % 2 == 0
 
-    regex_conditions = {"legs_even": Condition(Predicate().is_(even))}
+    legs_conditions = {"legs_even": Condition(Predicate().is_(even))}
 
     legs_spec = ResolverSpec(
         column_name="legs",
         metrics=[
             MetricSpec(
                 ConditionCountMetric,
-                ConditionCountConfig(conditions=regex_conditions),
+                ConditionCountConfig(conditions=legs_conditions),
             ),
         ],
     )
@@ -62,4 +62,3 @@ def test_constraints_generation(reference_profile_view):
     assert report[4].name == "legs meets condition legs_even"
     assert report[5].name == "weight has no missing values"
     assert report[6].name == "weight types count non-zero for ['fractional']"
-    print("h")

--- a/python/whylogs/core/constraints/factories/__init__.py
+++ b/python/whylogs/core/constraints/factories/__init__.py
@@ -20,6 +20,7 @@ from .frequent_items import (
     n_most_common_items_in_set,
 )
 from .types_metrics import (
+    column_has_non_zero_types,
     column_is_nullable_boolean,
     column_is_nullable_datatype,
     column_is_nullable_fractional,
@@ -49,5 +50,6 @@ ALL = [
     column_is_nullable_fractional,
     column_is_nullable_object,
     column_is_nullable_string,
+    column_has_non_zero_types,
     condition_meets,
 ]

--- a/python/whylogs/core/constraints/factories/types_metrics.py
+++ b/python/whylogs/core/constraints/factories/types_metrics.py
@@ -1,4 +1,22 @@
+from typing import List
+
 from ..metric_constraints import MetricConstraint, MetricsSelector
+
+
+def column_has_non_zero_types(column_name: str, types_list: List[str]) -> MetricConstraint:
+    def has_non_zero_types(x) -> bool:
+        types_dict = x.to_summary_dict()
+        for key in types_dict.keys():
+            if key in types_list and types_dict[key] == 0:
+                return False
+        return True
+
+    constraint = MetricConstraint(
+        name=f"{column_name} types count non-zero for {types_list}",
+        condition=has_non_zero_types,
+        metric_selector=MetricsSelector(column_name=column_name, metric_name="types"),
+    )
+    return constraint
 
 
 def column_is_nullable_integral(column_name: str) -> MetricConstraint:

--- a/python/whylogs/core/constraints/metric_constraints.py
+++ b/python/whylogs/core/constraints/metric_constraints.py
@@ -591,7 +591,11 @@ class Constraints:
 
 
 class ConstraintsBuilder:
-    def __init__(self, dataset_profile_view: DatasetProfileView, constraints: Optional[Constraints] = None) -> None:
+    def __init__(
+        self,
+        dataset_profile_view: DatasetProfileView,
+        constraints: Optional[Constraints] = None,
+    ) -> None:
         self._dataset_profile_view = dataset_profile_view
         if constraints is None:
             constraints = Constraints(dataset_profile_view=dataset_profile_view)
@@ -605,6 +609,11 @@ class ConstraintsBuilder:
             for metric_path in metric_component_paths:
                 selectors.append(MetricsSelector(metric_name=metric_path, column_name=column_name))
         return selectors
+
+    def add_constraints(self, constraints: List[Union[MetricConstraint, DatasetConstraint]]) -> "ConstraintsBuilder":
+        for constraint in constraints:
+            self.add_constraint(constraint)
+        return self
 
     def add_constraint(
         self, constraint: Union[MetricConstraint, DatasetConstraint], ignore_missing: bool = False

--- a/python/whylogs/experimental/constraints_generation/__init__.py
+++ b/python/whylogs/experimental/constraints_generation/__init__.py
@@ -1,9 +1,16 @@
-from whylogs.experimental.constraints_generation.count_metrics import generate_column_count_constraints
-from whylogs.experimental.constraints_generation.types_metrics import generate_column_types_constraints
-from whylogs.experimental.constraints_generation.condition_counts import generate_column_condition_count_constraints
-from whylogs.core.view.dataset_profile_view import DatasetProfileView
-from whylogs.core.constraints.metric_constraints import MetricConstraint
 from typing import List
+
+from whylogs.core.constraints.metric_constraints import MetricConstraint
+from whylogs.core.view.dataset_profile_view import DatasetProfileView
+from whylogs.experimental.constraints_generation.condition_counts import (
+    generate_column_condition_count_constraints,
+)
+from whylogs.experimental.constraints_generation.count_metrics import (
+    generate_column_count_constraints,
+)
+from whylogs.experimental.constraints_generation.types_metrics import (
+    generate_column_types_constraints,
+)
 
 
 def generate_constraints_from_reference_profile(reference_profile_view: DatasetProfileView) -> List[MetricConstraint]:

--- a/python/whylogs/experimental/constraints_generation/__init__.py
+++ b/python/whylogs/experimental/constraints_generation/__init__.py
@@ -1,0 +1,40 @@
+from whylogs.experimental.constraints_generation.count_metrics import generate_column_count_constraints
+from whylogs.experimental.constraints_generation.types_metrics import generate_column_types_constraints
+from whylogs.experimental.constraints_generation.condition_counts import generate_column_condition_count_constraints
+from whylogs.core.view.dataset_profile_view import DatasetProfileView
+from whylogs.core.constraints.metric_constraints import MetricConstraint
+from typing import List
+
+
+def generate_constraints_from_reference_profile(reference_profile_view: DatasetProfileView) -> List[MetricConstraint]:
+    """
+    Generates constraints from a reference profile view.
+    Parameters
+    ----------
+    reference_profile_view : DatasetProfileView
+        Reference profile view
+    """
+
+    if not reference_profile_view:
+        raise ValueError("Reference profile view is not set.")
+    constraints = []
+    reference_column_profiles = reference_profile_view.get_columns()
+    for column_name, column_profile in reference_column_profiles.items():
+        if "counts" in column_profile.get_metric_names():
+            column_count_constraint = generate_column_count_constraints(column_name, column_profile)
+            constraints.extend(column_count_constraint)
+        if "types" in column_profile.get_metric_names():
+            column_types_constraint = generate_column_types_constraints(column_name, column_profile)
+            constraints.extend(column_types_constraint)
+        if "condition_count" in column_profile.get_metric_names():
+            column_condition_count_constraint = generate_column_condition_count_constraints(column_name, column_profile)
+            constraints.extend(column_condition_count_constraint)
+    return constraints
+
+
+__ALL__ = [
+    generate_column_count_constraints,
+    generate_constraints_from_reference_profile,
+    generate_column_condition_count_constraints,
+    generate_column_types_constraints,
+]

--- a/python/whylogs/experimental/constraints_generation/condition_counts.py
+++ b/python/whylogs/experimental/constraints_generation/condition_counts.py
@@ -1,0 +1,23 @@
+from whylogs.core.view.column_profile_view import ColumnProfileView
+from whylogs.core.constraints.factories import condition_meets
+from whylogs.core.constraints.metric_constraints import MetricConstraint
+from typing import List
+
+
+def generate_column_condition_count_constraints(
+    column_name: str, column_profile: ColumnProfileView
+) -> List[MetricConstraint]:
+    """Generates constraints for the condition count metrics of a column.
+    Parameters
+    ----------
+    column_name : str
+        Name of the column
+    column_profile : ColumnProfileView
+        Profile of the column
+    """
+    constraints = []
+    condition_count_metric = column_profile.get_metric("condition_count")
+    for condition, matches in condition_count_metric.matches.items():
+        if matches.value == condition_count_metric.total.value:
+            constraints.append(condition_meets(column_name=column_name, condition_name=condition))
+    return constraints

--- a/python/whylogs/experimental/constraints_generation/condition_counts.py
+++ b/python/whylogs/experimental/constraints_generation/condition_counts.py
@@ -1,7 +1,8 @@
-from whylogs.core.view.column_profile_view import ColumnProfileView
+from typing import List
+
 from whylogs.core.constraints.factories import condition_meets
 from whylogs.core.constraints.metric_constraints import MetricConstraint
-from typing import List
+from whylogs.core.view.column_profile_view import ColumnProfileView
 
 
 def generate_column_condition_count_constraints(

--- a/python/whylogs/experimental/constraints_generation/count_metrics.py
+++ b/python/whylogs/experimental/constraints_generation/count_metrics.py
@@ -1,7 +1,8 @@
-from whylogs.core.constraints.factories import no_missing_values
-from whylogs.core.view.column_profile_view import ColumnProfileView
-from whylogs.core.constraints.metric_constraints import MetricConstraint
 from typing import List
+
+from whylogs.core.constraints.factories import no_missing_values
+from whylogs.core.constraints.metric_constraints import MetricConstraint
+from whylogs.core.view.column_profile_view import ColumnProfileView
 
 
 def generate_column_count_constraints(column_name: str, column_profile: ColumnProfileView) -> List[MetricConstraint]:

--- a/python/whylogs/experimental/constraints_generation/count_metrics.py
+++ b/python/whylogs/experimental/constraints_generation/count_metrics.py
@@ -1,0 +1,21 @@
+from whylogs.core.constraints.factories import no_missing_values
+from whylogs.core.view.column_profile_view import ColumnProfileView
+from whylogs.core.constraints.metric_constraints import MetricConstraint
+from typing import List
+
+
+def generate_column_count_constraints(column_name: str, column_profile: ColumnProfileView) -> List[MetricConstraint]:
+    """Generates constraints for the count metrics of a column.
+    Parameters
+    ----------
+    column_name : str
+        Name of the column
+    column_profile : ColumnProfileView
+        Profile of the column
+    """
+    constraints = []
+    column_null_values = column_profile.get_metric("counts").null.value
+    if column_null_values == 0:
+        no_missing_values_constraint = no_missing_values(column_name)
+        constraints.append(no_missing_values_constraint)
+    return constraints

--- a/python/whylogs/experimental/constraints_generation/types_metrics.py
+++ b/python/whylogs/experimental/constraints_generation/types_metrics.py
@@ -1,7 +1,8 @@
-from whylogs.core.view.column_profile_view import ColumnProfileView
+from typing import List
+
 from whylogs.core.constraints.factories import column_has_non_zero_types
 from whylogs.core.constraints.metric_constraints import MetricConstraint
-from typing import List
+from whylogs.core.view.column_profile_view import ColumnProfileView
 
 
 def generate_column_types_constraints(column_name: str, column_profile: ColumnProfileView) -> List[MetricConstraint]:

--- a/python/whylogs/experimental/constraints_generation/types_metrics.py
+++ b/python/whylogs/experimental/constraints_generation/types_metrics.py
@@ -1,0 +1,24 @@
+from whylogs.core.view.column_profile_view import ColumnProfileView
+from whylogs.core.constraints.factories import column_has_non_zero_types
+from whylogs.core.constraints.metric_constraints import MetricConstraint
+from typing import List
+
+
+def generate_column_types_constraints(column_name: str, column_profile: ColumnProfileView) -> List[MetricConstraint]:
+    """
+    Generates constraints for the types metrics of a column.
+    Parameters
+    ----------
+    column_name : str
+        Name of the column
+    column_profile : ColumnProfileView
+        Profile of the column
+    """
+    constraints = []
+    types_metric = column_profile.get_metric("types")
+    non_zero_empty_types = []
+    for key, component in vars(types_metric).items():
+        if component.value != 0:
+            non_zero_empty_types.append(key)
+    constraints.append(column_has_non_zero_types(column_name=column_name, types_list=non_zero_empty_types))
+    return constraints


### PR DESCRIPTION
## Description

initial implementation of Constraints Generation as a function under the `experimental` namespace.
First group auto-generated constraints:

- Count Metrics: If reference contain no `null` values, create `no_missing_values` constraints for given column
- Types Metrics: If type count is non-zero for a list of data types, creates `column_has_non_zero_types` constraints for the types list
- Condition Count Metrics: If column has a set of conditions attached to it, and the conditions didn't fail once, creates a `condition_meets` constraint

This is just the first few ideas for auto-generated constraints. More to follow.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
