### PR TITLE
Fix monthly grouping in the multi logger, add year support

### DIFF
--- a/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
+++ b/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
@@ -4,7 +4,32 @@ from whylogs.api.logger.experimental.multi_dataset_logger.time_util import (
     FunctionTimer,
     Schedule,
     TimeGranularity,
+    truncate_time_ms,
 )
+
+
+def test_truncate_day() -> None:
+    ts = 1680038612000  # Tuesday, March 28, 2023 9:23:32 PM
+    expected = 1679961600000  # Tuesday, March 28, 2023 0:00:00
+    assert truncate_time_ms(ts, TimeGranularity.Day) == expected
+
+
+def test_truncate_hour() -> None:
+    ts = 1680038612000  # Tuesday, March 28, 2023 9:23:32 PM
+    expected = 1680037200000  # Tuesday, March 28, 2023 21:00:00
+    assert truncate_time_ms(ts, TimeGranularity.Hour) == expected
+
+
+def test_truncate_month() -> None:
+    ts = 1680038612000  # Tuesday, March 28, 2023 9:23:32 PM
+    expected = 1677628800000  # Wednesday, March 1, 2023 0:00:00
+    assert truncate_time_ms(ts, TimeGranularity.Month) == expected
+
+
+def test_truncate_year() -> None:
+    ts = 1680038612000  # Tuesday, March 28, 2023 9:23:32 PM
+    expected = 1672531200000  # Sunday, January 1, 2023 0:00:00
+    assert truncate_time_ms(ts, TimeGranularity.Year) == expected
 
 
 def test_seconds_work() -> None:

--- a/python/whylogs/api/logger/experimental/multi_dataset_logger/time_util.py
+++ b/python/whylogs/api/logger/experimental/multi_dataset_logger/time_util.py
@@ -19,6 +19,7 @@ class TimeGranularity(Enum):
     Hour = "Hour"
     Day = "Day"
     Month = "Month"
+    Year = "Year"
 
 
 def truncate_time_ms(t: int, granularity: TimeGranularity) -> int:
@@ -31,7 +32,11 @@ def truncate_time_ms(t: int, granularity: TimeGranularity) -> int:
     elif granularity == TimeGranularity.Day:
         trunc = dt.replace(minute=0, hour=0)
     elif granularity == TimeGranularity.Month:
-        trunc = dt.replace(minute=0, hour=0, day=0)
+        trunc = dt.replace(minute=0, hour=0, day=1)
+    elif granularity == TimeGranularity.Year:
+        trunc = dt.replace(minute=0, hour=0, day=1, month=1)
+    else:
+        raise ValueError(f"Unsupported granularity: {granularity}")
 
     return int(trunc.timestamp() * 1000)
 


### PR DESCRIPTION
Apparently the first of the month is 1, not 0.

Also adding year support for demo purposes.

I added the exception case to make sure that something goes wrong if the user isn't
using types and supplies something that isn't a valid time granularity.