### PR TITLE
Fix to embeddings freq_items and handling of numpy strings

### DIFF
--- a/python/tests/core/test_preprocessing.py
+++ b/python/tests/core/test_preprocessing.py
@@ -5,9 +5,9 @@ from logging import getLogger
 from typing import Any, List, Optional, Union
 
 import numpy as np
+import numpy.testing as npt
 import pandas as pd
 import pytest
-from pandas.testing import assert_series_equal
 
 from whylogs.core.preprocessing import (
     ListView,
@@ -53,11 +53,36 @@ def assert_numpy_view_is_empty(view: NumpyView) -> None:
     assert_subview_is_empty(view.strings)
 
 
+def assert_list_view_correct_types(view: ListView) -> None:
+    for subview in [view.ints, view.floats, view.strings, view.tensors, view.objs]:
+        if subview is not None:
+            assert isinstance(subview, list)
+
+
+def assert_numpy_view_correct_types(view: ListView) -> None:
+    for subview in [view.ints, view.floats, view.strings]:
+        if subview is not None:
+            assert isinstance(subview, np.ndarray)
+
+
+def assert_pandas_view_correct_types(view: ListView) -> None:
+    for subview in [view.strings, view.tensors, view.objs]:
+        if subview is not None:
+            assert isinstance(subview, pd.Series)
+
+
+def assert_correct_types(view: PreprocessedColumn) -> None:
+    assert_list_view_correct_types(view.list)
+    assert_numpy_view_correct_types(view.numpy)
+    assert_pandas_view_correct_types(view.pandas)
+
+
 class TestListElements(object):
     def test_floats_and_ints_and_str(self) -> None:
         mixed = pd.Series([1.0, 1, 2.0, 2, "str", None])
 
         res = PreprocessedColumn.apply(mixed)
+        assert_correct_types(res)
 
         assert res.numpy.floats.tolist() == [1.0, 2.0]  # type: ignore
         assert res.numpy.ints.tolist() == [1, 2]  # type: ignore
@@ -75,6 +100,7 @@ class TestListElements(object):
         mixed = pd.Series([None, math.nan, "hi"])
 
         res = PreprocessedColumn.apply(mixed)
+        assert_correct_types(res)
         assert len(res.pandas.strings) == 1
         assert_subview_is_empty(res.pandas.tensors)
         assert_subview_is_empty(res.pandas.objs)  # type: ignore
@@ -91,6 +117,7 @@ class TestListElements(object):
         mixed = pd.Series([math.inf, None])  # when all types are numeric None->NaN
 
         res = PreprocessedColumn.apply(mixed)
+        assert_correct_types(res)
         assert_subview_is_empty(res.pandas.strings)
         assert_subview_is_empty(res.pandas.tensors)
         assert_subview_is_empty(res.pandas.objs)
@@ -108,6 +135,7 @@ class TestListElements(object):
         mixed = pd.Series([np.nan, None, "test"])
 
         res = PreprocessedColumn.apply(mixed)
+        assert_correct_types(res)
         assert len(res.pandas.strings) == 1
         assert_subview_is_empty(res.pandas.tensors)
         assert_subview_is_empty(res.pandas.objs)
@@ -124,6 +152,7 @@ class TestListElements(object):
         mixed = pd.Series([np.inf, None, "t"])
 
         res = PreprocessedColumn.apply(mixed)
+        assert_correct_types(res)
         assert len(res.pandas.strings) == 1
         assert_subview_is_empty(res.pandas.tensors)
         assert_subview_is_empty(res.pandas.objs)
@@ -141,6 +170,7 @@ class TestListElements(object):
         mixed = pd.Series([np.inf, None, float("nan"), "t"])
 
         res = PreprocessedColumn.apply(mixed)
+        assert_correct_types(res)
         assert len(res.pandas.strings) == 1
         assert_subview_is_empty(res.pandas.tensors)
         assert_subview_is_empty(res.pandas.objs)
@@ -158,6 +188,7 @@ class TestListElements(object):
         mixed = pd.Series([True, True, False, 2, 1, 0])
 
         res = PreprocessedColumn.apply(mixed)
+        assert_correct_types(res)
         TEST_LOGGER.info(f"{res}")
         assert_subview_is_empty(res.numpy.floats)
         assert res.numpy.ints.tolist() == [2, 1, 0]  # type: ignore
@@ -177,8 +208,9 @@ class TestListElements(object):
     def test_floats_no_null(self, data_type) -> None:
         floats = pd.Series([1.0, 2.0, 3.0], dtype=data_type).astype(float)
         res = PreprocessedColumn.apply(floats)
+        assert_correct_types(res)
 
-        assert_series_equal(res.numpy.floats, floats)
+        npt.assert_array_equal(res.numpy.floats, floats.to_numpy())
         assert_subview_is_empty(res.numpy.ints)
         assert_subview_is_empty(res.numpy.strings)
 
@@ -193,9 +225,10 @@ class TestListElements(object):
     def test_floats_with_null(self, data_type) -> None:
         f_with_none = pd.Series([1.0, 2.0, 3.0, None], dtype=data_type)
         res = PreprocessedColumn.apply(f_with_none)
+        assert_correct_types(res)
         assert res.null_count == 1
 
-        assert_series_equal(res.numpy.floats, pd.Series([1.0, 2.0, 3.0]))
+        npt.assert_array_equal(res.numpy.floats, pd.Series([1.0, 2.0, 3.0]).to_numpy())
         assert_subview_is_empty(res.numpy.ints)
         assert_subview_is_empty(res.numpy.strings)
 
@@ -209,9 +242,10 @@ class TestListElements(object):
         strings = pd.Series(["foo", "bar"])
 
         res = PreprocessedColumn.apply(strings)
+        assert_correct_types(res)
         assert res.null_count == 0
 
-        assert_series_equal(res.pandas.strings, strings)
+        npt.assert_array_equal(res.pandas.strings, strings.to_numpy())
         assert_subview_is_empty(res.pandas.tensors)
         assert_subview_is_empty(res.pandas.objs)
 
@@ -225,9 +259,10 @@ class TestListElements(object):
         strings = pd.Series(["foo", "bar", None, None])
 
         res = PreprocessedColumn.apply(strings)
+        assert_correct_types(res)
         assert res.null_count == 2
 
-        assert_series_equal(res.pandas.strings, pd.Series(["foo", "bar"]))
+        npt.assert_array_equal(res.pandas.strings, pd.Series(["foo", "bar"]).to_numpy())
         assert_subview_is_empty(res.pandas.objs)
         assert_subview_is_empty(res.pandas.tensors)
 
@@ -271,6 +306,7 @@ def test_process_scalar_called_with_scalar_nonobject(
     monkeypatch.setattr("whylogs.core.preprocessing.pd", PandasStub() if pd_stubbed else pd)
 
     column = PreprocessedColumn._process_scalar_value(value)
+    assert_correct_types(column)
 
     if isinstance(value, (int)):
         if isinstance(value, (bool)):
@@ -405,6 +441,7 @@ def test_process_scalar_called_with_tensorable(value: Any, np_stubbed: bool, pd_
     monkeypatch.setattr("whylogs.core.preprocessing.pd", PandasStub() if pd_stubbed else pd)
 
     column = PreprocessedColumn._process_scalar_value(value)
+    assert_correct_types(column)
 
     assert column.bool_count == 0
     assert column.bool_count_where_true == 0
@@ -484,6 +521,7 @@ def test_process_scalar_called_with_scalar_object(value: Any, np_stubbed: bool, 
     monkeypatch.setattr("whylogs.core.preprocessing.pd", PandasStub() if pd_stubbed else pd)
 
     column = PreprocessedColumn._process_scalar_value(value)
+    assert_correct_types(column)
 
     assert column.bool_count == 0
     assert column.bool_count_where_true == 0
@@ -529,6 +567,7 @@ def test_process_scalar_called_with_scalar_object(value: Any, np_stubbed: bool, 
 )
 def test_apply_tensorable_series(column: List[Any]) -> None:
     res = PreprocessedColumn.apply(pd.Series(column))
+    assert_correct_types(res)
     assert len(res.pandas.tensors) == len(column)
     for i in range(len(column)):
         X = res.pandas.tensors[i]
@@ -557,6 +596,7 @@ def test_apply_tensorable_series(column: List[Any]) -> None:
 )
 def test_apply_nontensorable_series(column: Any) -> None:
     res = PreprocessedColumn.apply(pd.Series(column))
+    assert_correct_types(res)
 
     assert len(res.pandas.objs) == len(column)
     assert_subview_is_empty(res.pandas.strings)
@@ -582,6 +622,7 @@ def test_apply_nontensorable_series(column: Any) -> None:
 )
 def test_apply_ndarray(column: np.ndarray) -> None:
     res = PreprocessedColumn.apply(column)
+    assert_correct_types(res)
 
     if issubclass(column.dtype.type, np.floating):
         assert res.numpy.floats.tolist() == column.tolist()
@@ -644,6 +685,7 @@ def test_apply_list(
     monkeypatch.setattr("whylogs.core.preprocessing.np", NumpyStub() if np_stubbed else np)
     monkeypatch.setattr("whylogs.core.preprocessing.pd", PandasStub() if pd_stubbed else pd)
     res = PreprocessedColumn.apply(column)
+    assert_correct_types(res)
     if pd_stubbed:
         assert_pandas_view_is_empty(res.pandas)
 

--- a/python/tests/experimental/extras/test_embedding_metric.py
+++ b/python/tests/experimental/extras/test_embedding_metric.py
@@ -33,6 +33,7 @@ def test_embedding_metric_row() -> None:
     assert summary["embedding/A_distance:distribution/mean"] > 0
     assert summary["embedding/B_distance:distribution/mean"] > 0
     assert summary["embedding/closest:counts/n"] == 3
+    assert summary["embedding/closest:frequent_items/frequent_strings"] != []
 
 
 def test_embedding_metric_pandas() -> None:
@@ -60,6 +61,7 @@ def test_embedding_metric_pandas() -> None:
     assert summary["embedding/A_distance:distribution/mean"] > 0
     assert summary["embedding/B_distance:distribution/mean"] > 0
     assert summary["embedding/closest:counts/n"] == 3
+    assert summary["embedding/closest:frequent_items/frequent_strings"] != []
 
 
 def test_embedding_metric_merge_happy_case() -> None:
@@ -75,11 +77,13 @@ def test_embedding_metric_merge_happy_case() -> None:
     metric2.columnar_update(data)
     merged = metric1.merge(metric2)
     summary = merged.to_summary_dict()
+    print(summary)
     assert summary["A_distance:counts/n"] == 6
     assert summary["B_distance:counts/n"] == 6
     assert summary["A_distance:distribution/mean"] > 0
     assert summary["B_distance:distribution/mean"] > 0
     assert summary["closest:counts/n"] == 6
+    assert summary["closest:frequent_items/frequent_strings"] != []
 
 
 def test_embedding_metric_serialization() -> None:

--- a/python/tests/experimental/extras/test_embedding_metric.py
+++ b/python/tests/experimental/extras/test_embedding_metric.py
@@ -77,7 +77,6 @@ def test_embedding_metric_merge_happy_case() -> None:
     metric2.columnar_update(data)
     merged = metric1.merge(metric2)
     summary = merged.to_summary_dict()
-    print(summary)
     assert summary["A_distance:counts/n"] == 6
     assert summary["B_distance:counts/n"] == 6
     assert summary["A_distance:distribution/mean"] > 0

--- a/python/whylogs/core/metrics/column_metrics.py
+++ b/python/whylogs/core/metrics/column_metrics.py
@@ -45,7 +45,7 @@ class TypeCountersMetric(Metric):
         integral = 0
         if data.numpy.ints is not None:
             integral += len(data.numpy.ints)
-        elif data.list.ints is not None:
+        if data.list.ints is not None:
             integral += len(data.list.ints)
         successes += integral
         self.integral.set(integral + integral_prev)
@@ -54,7 +54,7 @@ class TypeCountersMetric(Metric):
         fractional_prev = self.fractional.value
         if data.numpy.floats is not None:
             fractional += len(data.numpy.floats)
-        elif data.list.floats is not None:
+        if data.list.floats is not None:
             fractional += len(data.list.floats)
         successes += fractional
         self.fractional.set(fractional + fractional_prev)
@@ -67,9 +67,10 @@ class TypeCountersMetric(Metric):
         string_count_prev = self.string.value
         if data.pandas.strings is not None:
             string_count += len(data.pandas.strings)
-        elif data.list.strings is not None:
+        if data.list.strings is not None:
             string_count += len(data.list.strings)
-
+        if data.numpy.strings is not None:
+            string_count += len(data.numpy.strings)
         successes += string_count
         self.string.set(string_count + string_count_prev)
 
@@ -77,7 +78,7 @@ class TypeCountersMetric(Metric):
         tensor_count_prev = self.tensor.value
         if data.pandas.tensors is not None:
             tensor_count += len(data.pandas.tensors)
-        elif data.list.tensors is not None:
+        if data.list.tensors is not None:
             tensor_count += len(data.list.tensors)
 
         successes += tensor_count
@@ -87,7 +88,7 @@ class TypeCountersMetric(Metric):
         objects_prev = self.object.value
         if data.pandas.objs is not None:
             objects += len(data.pandas.objs)
-        elif data.list.objs is not None:
+        if data.list.objs is not None:
             objects += len(data.list.objs)
 
         successes += objects

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -273,15 +273,7 @@ class DistributionMetric(Metric):
                     if n_b > 1:
                         n_b = len(arr)
                         mean_b = arr.mean()
-                        # NOTE: there was a bug in PreprocessedColumn that would sometimes put
-                        # pd.Series values in the numpy subviews. pandas and numpy have opposite
-                        # default degrees of freedom :( so this matches the behavior from before
-                        # the bug fix to make the numpy subviews always np.ndarray
-                        if isinstance(view.original, pd.Series):
-                            ddof = 1
-                        else:
-                            ddof = 0
-                        m2_b = arr.var(ddof=ddof) * (n_b - 1)
+                        m2_b = arr.var() * (n_b - 1)
 
                         second = VarianceM2Result(n=n_b, mean=mean_b, m2=m2_b)
                         first = parallel_variance_m2(first=first, second=second)

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -458,10 +458,12 @@ class FrequentItemsMetric(Metric):
         successes = 0
         for arr in [view.numpy.floats, view.numpy.ints]:
             if arr is not None:
-                if isinstance(arr, pd.Series):
-                    arr = arr.to_numpy()
                 self.frequent_strings.value.update_np(arr)
                 successes += len(arr)
+        # TODO: Include strings in above when we update whylogs-sketching fi.update_np to take strings
+        if view.numpy.strings is not None:
+            self.frequent_strings.value.update_np(view.numpy.strings.to_list())
+            successes += len(view.numpy.strings)
         if view.pandas.strings is not None:
             strings = [s[0 : self.max_frequent_item_size] for s in view.pandas.strings.to_list()]
             self.frequent_strings.value.update_str_list(strings)

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -130,11 +130,11 @@ class PreprocessedColumn:
                 floats = non_null_series.astype(float)
                 inf_mask = floats.apply(lambda x: np.isinf(x))
                 self.inf_count = len(floats[inf_mask])
-                self.numpy.floats = floats
+                self.numpy.floats = floats.values
                 return
             else:
                 ints = non_null_series.astype(int)
-                self.numpy.ints = ints
+                self.numpy.ints = ints.values
                 return
 
         if series.hasnans:

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -130,11 +130,11 @@ class PreprocessedColumn:
                 floats = non_null_series.astype(float)
                 inf_mask = floats.apply(lambda x: np.isinf(x))
                 self.inf_count = len(floats[inf_mask])
-                self.numpy.floats = floats.values
+                self.numpy.floats = floats.to_numpy()
                 return
             else:
                 ints = non_null_series.astype(int)
-                self.numpy.ints = ints.values
+                self.numpy.ints = ints.to_numpy()
                 return
 
         if series.hasnans:
@@ -183,7 +183,7 @@ class PreprocessedColumn:
             inf_mask = floats.apply(lambda x: np.isinf(x))
             self.inf_count = len(floats[inf_mask])
 
-        self.numpy = NumpyView(floats=floats, ints=ints)
+        self.numpy = NumpyView(floats=floats.to_numpy(), ints=ints.to_numpy())
         self.pandas.strings = strings
         self.pandas.tensors = tensors
         self.pandas.objs = objs

--- a/python/whylogs/experimental/extras/embedding_metric.py
+++ b/python/whylogs/experimental/extras/embedding_metric.py
@@ -157,7 +157,7 @@ class EmbeddingMetric(MultiMetric):
                 self._update_submetrics(f"{self.labels[i]}_distance", PreprocessedColumn.apply(ref_dists[:, i]))
 
             closest = [self.labels[i] for i in ref_closest]
-            self._update_submetrics("closest", PreprocessedColumn.apply(np.asarray(closest)))
+            self._update_submetrics("closest", PreprocessedColumn.apply(closest))
             successes += 1
 
         return OperationResult(failures, successes)

--- a/python/whylogs/experimental/extras/embedding_metric.py
+++ b/python/whylogs/experimental/extras/embedding_metric.py
@@ -156,6 +156,7 @@ class EmbeddingMetric(MultiMetric):
             for i in range(ref_dists.shape[1]):
                 self._update_submetrics(f"{self.labels[i]}_distance", PreprocessedColumn.apply(ref_dists[:, i]))
 
+            # TODO: We can replace with numpy version if we update whylogs-sketching fi.update_np to take strings
             closest = [self.labels[i] for i in ref_closest]
             self._update_submetrics("closest", PreprocessedColumn.apply(closest))
             successes += 1

--- a/python/whylogs/experimental/extras/embedding_metric.py
+++ b/python/whylogs/experimental/extras/embedding_metric.py
@@ -156,9 +156,8 @@ class EmbeddingMetric(MultiMetric):
             for i in range(ref_dists.shape[1]):
                 self._update_submetrics(f"{self.labels[i]}_distance", PreprocessedColumn.apply(ref_dists[:, i]))
 
-            # TODO: replace with numpy-only version if it helps performance
             closest = [self.labels[i] for i in ref_closest]
-            self._update_submetrics("closest", PreprocessedColumn.apply(closest))
+            self._update_submetrics("closest", PreprocessedColumn.apply(np.asarray(closest)))
             successes += 1
 
         return OperationResult(failures, successes)

--- a/python/whylogs/experimental/extras/embedding_metric.py
+++ b/python/whylogs/experimental/extras/embedding_metric.py
@@ -156,7 +156,7 @@ class EmbeddingMetric(MultiMetric):
             for i in range(ref_dists.shape[1]):
                 self._update_submetrics(f"{self.labels[i]}_distance", PreprocessedColumn.apply(ref_dists[:, i]))
 
-            # TODO: We can replace with numpy version if we update whylogs-sketching fi.update_np to take strings
+            # TODO: replace with numpy-only version if it helps performance
             closest = [self.labels[i] for i in ref_closest]
             self._update_submetrics("closest", PreprocessedColumn.apply(closest))
             successes += 1


### PR DESCRIPTION
Frequent items sketches were empty due to the performance improvement change to wrapping closest array in numpy. We should check out if there's still a numpy solution and the effect of this on performance, but this at least fixes the bug.

This turned up a few other bugs. This PR includes the following:
 * numpy subviews are now always ndarrays (there were cases where they could be pd.Series)
 * unit tests to type check all subviews
 * TypeCountersMetric includes numpy string subview now
 * CardinalityMetric includes numpy string subview now
 * ~np.ndarray and pd.Series use different degrees of freedom in their variance computations. This PR is consistent with the previous DoF behavior, but this issue warrants further consideration...~ this is dealt with in #1173 
 * FrequentItemsMetric includes numpy string subview (the original bug that prompted this PR)