### PR TITLE
DistributionMetric m2 update fix

### DIFF
--- a/python/tests/core/metrics/test_metrics.py
+++ b/python/tests/core/metrics/test_metrics.py
@@ -1,4 +1,5 @@
 from logging import getLogger
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -14,6 +15,7 @@ from whylogs.core.metrics.metrics import (
 from whylogs.core.preprocessing import PreprocessedColumn
 
 TEST_LOGGER = getLogger(__name__)
+
 
 def test_distribution_metrics_numpy() -> None:
     dist = DistributionMetric.zero(MetricConfig())
@@ -43,19 +45,21 @@ def test_distribution_metrics_series() -> None:
     assert dist.mean.value == data.mean()
     assert dist.variance == data.var()
 
+
 def test_distribution_variance_m2() -> None:
     import statistics
+
     dist_list = DistributionMetric.zero(MetricConfig())
     dist_pandas = DistributionMetric.zero(MetricConfig())
     dist_numpy = DistributionMetric.zero(MetricConfig())
     test_input = [1, 2, 3, 4]
-    
+
     list_test_input = PreprocessedColumn()
     list_test_input.list.ints = test_input
     n = len(test_input)
     mean = sum(test_input) / n
     variance = statistics.variance(test_input)
-    m2 = (n-1) * variance
+    m2 = (n - 1) * variance
     TEST_LOGGER.info(f"statistic package using input {test_input} has variance={variance}, m2={m2}, n={n}")
     pandas_test_input = PreprocessedColumn.apply(pd.Series(test_input))
     numpy_test_input = PreprocessedColumn.apply(np.array(test_input))
@@ -75,7 +79,6 @@ def test_distribution_variance_m2() -> None:
     assert dist_list.avg == mean
     assert dist_pandas.avg == mean
     assert dist_numpy.avg == mean
-
 
 
 def test_distribution_metrics_indexed_series_single_row() -> None:

--- a/python/tests/core/metrics/test_metrics.py
+++ b/python/tests/core/metrics/test_metrics.py
@@ -1,3 +1,4 @@
+from logging import getLogger
 import numpy as np
 import pandas as pd
 import pytest
@@ -12,6 +13,7 @@ from whylogs.core.metrics.metrics import (
 )
 from whylogs.core.preprocessing import PreprocessedColumn
 
+TEST_LOGGER = getLogger(__name__)
 
 def test_distribution_metrics_numpy() -> None:
     dist = DistributionMetric.zero(MetricConfig())
@@ -40,6 +42,40 @@ def test_distribution_metrics_series() -> None:
     assert dist.kll.value.get_n() == 100
     assert dist.mean.value == data.mean()
     assert dist.variance == data.var()
+
+def test_distribution_variance_m2() -> None:
+    import statistics
+    dist_list = DistributionMetric.zero(MetricConfig())
+    dist_pandas = DistributionMetric.zero(MetricConfig())
+    dist_numpy = DistributionMetric.zero(MetricConfig())
+    test_input = [1, 2, 3, 4]
+    
+    list_test_input = PreprocessedColumn()
+    list_test_input.list.ints = test_input
+    n = len(test_input)
+    mean = sum(test_input) / n
+    variance = statistics.variance(test_input)
+    m2 = (n-1) * variance
+    TEST_LOGGER.info(f"statistic package using input {test_input} has variance={variance}, m2={m2}, n={n}")
+    pandas_test_input = PreprocessedColumn.apply(pd.Series(test_input))
+    numpy_test_input = PreprocessedColumn.apply(np.array(test_input))
+    dist_list.columnar_update(list_test_input)
+    dist_pandas.columnar_update(pandas_test_input)
+    dist_numpy.columnar_update(numpy_test_input)
+
+    TEST_LOGGER.info(f"dist_list={dist_list.to_summary_dict()}")
+    TEST_LOGGER.info(f"dist_pandas={dist_pandas.to_summary_dict()}")
+    TEST_LOGGER.info(f"dist_numpy={dist_numpy.to_summary_dict()}")
+    assert dist_list.m2.value == m2
+    assert dist_pandas.m2.value == m2
+    assert dist_numpy.m2.value == m2
+    assert dist_list.variance == variance
+    assert dist_pandas.variance == variance
+    assert dist_numpy.variance == variance
+    assert dist_list.avg == mean
+    assert dist_pandas.avg == mean
+    assert dist_numpy.avg == mean
+
 
 
 def test_distribution_metrics_indexed_series_single_row() -> None:

--- a/python/tests/core/metrics/test_metrics.py
+++ b/python/tests/core/metrics/test_metrics.py
@@ -26,7 +26,7 @@ def test_distribution_metrics_numpy() -> None:
 
     assert dist.kll.value.get_n() == 100
     assert dist.mean.value == arr.mean()
-    assert dist.variance == arr.var()
+    assert dist.variance == arr.var(ddof=1)
 
     distribution_summary = dist.to_summary_dict()
     assert distribution_summary["q_01"] == 1.0
@@ -58,7 +58,7 @@ def test_distribution_variance_m2() -> None:
     list_test_input.list.ints = test_input
     n = len(test_input)
     mean = sum(test_input) / n
-    variance = statistics.variance(test_input)
+    variance = statistics.variance(test_input)  # sample variance, uses n-1 normalization
     m2 = (n - 1) * variance
     TEST_LOGGER.info(f"statistic package using input {test_input} has variance={variance}, m2={m2}, n={n}")
     pandas_test_input = PreprocessedColumn.apply(pd.Series(test_input))
@@ -100,7 +100,7 @@ def test_distribution_metrics_list() -> None:
 
     assert dist.kll.value.get_n() == 100
     assert dist.mean.value == np.array(data).mean()
-    assert dist.variance == np.array(data).var()
+    assert dist.variance == np.array(data).var(ddof=1)
 
 
 def test_distribution_metrics_mixed_np_and_list() -> None:
@@ -116,8 +116,8 @@ def test_distribution_metrics_mixed_np_and_list() -> None:
 
     assert dist.mean.value == np.array(np.concatenate([a, b])).mean()
 
-    m2_a = a.var() * (len(a) - 1)
-    m2_b = b.var() * (len(b) - 1)
+    m2_a = a.var(ddof=1) * (len(a) - 1)
+    m2_b = b.var(ddof=1) * (len(b) - 1)
     a_var = VarianceM2Result(n=len(a), mean=a.mean(), m2=m2_a)
     b_var = VarianceM2Result(n=len(b), mean=b.mean(), m2=m2_b)
     overall = parallel_variance_m2(first=a_var, second=b_var)

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -329,7 +329,7 @@ class DistributionMetric(Metric):
 
     @property
     def variance(self) -> float:
-        """Returns the population variance of the stream.
+        """Returns the sample variance of the stream.
 
         https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
         """

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -291,7 +291,7 @@ class DistributionMetric(Metric):
                 n_b = len(lst)
                 if n_b > 1:
                     mean_b = statistics.mean(lst)
-                    m2_b = statistics.pvariance(lst) * (n_b)
+                    m2_b = statistics.variance(lst) * (n_b - 1)
                     second = VarianceM2Result(n=n_b, mean=mean_b, m2=m2_b)
 
                     first = parallel_variance_m2(first=first, second=second)

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -273,7 +273,7 @@ class DistributionMetric(Metric):
                     if n_b > 1:
                         n_b = len(arr)
                         mean_b = arr.mean()
-                        m2_b = arr.var() * (n_b - 1)
+                        m2_b = arr.var(ddof=1) * (n_b - 1)
 
                         second = VarianceM2Result(n=n_b, mean=mean_b, m2=m2_b)
                         first = parallel_variance_m2(first=first, second=second)
@@ -291,7 +291,7 @@ class DistributionMetric(Metric):
                 n_b = len(lst)
                 if n_b > 1:
                     mean_b = statistics.mean(lst)
-                    m2_b = statistics.pvariance(lst) * (n_b - 1)
+                    m2_b = statistics.pvariance(lst) * (n_b)
                     second = VarianceM2Result(n=n_b, mean=mean_b, m2=m2_b)
 
                     first = parallel_variance_m2(first=first, second=second)


### PR DESCRIPTION
## Description

The default value of ddof is different between numpy and pandas arrays but we use the returned variance in a single way. This leads to an incorrect update step for the M2 variable which requires knowing if the variance was normalized with N or N-1.

## Changes
- specify ddof parameter in the var() method, always use 1.
- fix the update steps for M2 to be aware of the ddof value assumed.
- statistics.pvariance also uses N-1 normalization and had the wrong M2 update, so fixed there
- add test to cover numpy, pandas, list input on toy data.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
