### PR TITLE
Use fake timer to get rid of sleeps in unit tests

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs=tests/helpers

--- a/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
+++ b/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
@@ -1,10 +1,51 @@
-import time
+from threading import Timer
+from typing import Callable, List
 
 from whylogs.api.logger.experimental.multi_dataset_logger.time_util import (
     FunctionTimer,
     Schedule,
     TimeGranularity,
 )
+
+# A sequence of times get instantiated, so we need global state for them
+# to simulate universal time.
+
+_FAKE_TIMES: List[float] = []  # list of times (seconds) where the FakeTimer
+_TIME_INDEX: int = 0  # where are we in the lsit of times
+
+
+class FakeTimer:
+    def __init__(self, interval: int, fn: Callable) -> None:
+        self._interval = interval
+        self._fn = fn
+        self._prev_start_time = 0
+        if _TIME_INDEX < len(_FAKE_TIMES):
+            self._prev_start_time = _FAKE_TIMES[_TIME_INDEX]
+            self._zombie_thread = None
+        else:
+            self._zombie_thread = Timer(interval, fn)
+
+    def start(self) -> None:
+        global _TIME_INDEX
+        _TIME_INDEX += 1
+        if _TIME_INDEX >= len(_FAKE_TIMES):
+            self._zombie_thread = Timer(self._interval, self._fn)
+            self._zombie_thread.start()
+            return
+
+        now = _FAKE_TIMES[_TIME_INDEX]
+        if (now - self._prev_start_time) >= self._interval:
+            self._fn()
+            self._prev_start_time = now
+        else:
+            self.start()
+
+    def is_alive(self) -> bool:
+        return self._zombie_thread.is_alive() if self._zombie_thread else True
+
+    def cancel(self) -> None:
+        if self._zombie_thread:
+            self._zombie_thread.cancel()
 
 
 def test_seconds_work() -> None:
@@ -16,8 +57,11 @@ def test_seconds_work() -> None:
             self.i += 1
 
     f = Foo()
-    t = FunctionTimer(Schedule(TimeGranularity.Second, 1), f.inc)
-    time.sleep(3)
+    global _FAKE_TIMES, _TIME_INDEX
+    _FAKE_TIMES = [0, 0.5, 1, 1.9, 2, 2.1, 3]
+    _TIME_INDEX = 0
+    t = FunctionTimer(Schedule(TimeGranularity.Second, 1), f.inc, FakeTimer)
+    # time.sleep(3)
     t.stop()
 
     assert f.i >= 3

--- a/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
+++ b/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
@@ -1,52 +1,14 @@
 from threading import Timer
 from typing import Callable, List
 
+import utils as u
+
 from whylogs.api.logger.experimental.multi_dataset_logger.time_util import (
     FunctionTimer,
     Schedule,
     TimeGranularity,
     truncate_time_ms,
 )
-
-# A sequence of timers get instantiated, so we need global state for them
-# to simulate universal time.
-
-_FAKE_TIMES: List[float] = []  # list of times (seconds) where the FakeTimer checks if it should execute
-_TIME_INDEX: int = 0  # where are we in the list of times
-
-
-class FakeTimer:
-    def __init__(self, interval: int, fn: Callable) -> None:
-        self._interval = interval
-        self._fn = fn
-        self._prev_start_time = 0
-        if _TIME_INDEX < len(_FAKE_TIMES):
-            self._prev_start_time = _FAKE_TIMES[_TIME_INDEX]
-            self._zombie_thread = None
-        else:
-            self._zombie_thread = Timer(interval, fn)
-
-    def start(self) -> None:
-        global _TIME_INDEX
-        _TIME_INDEX += 1
-        if _TIME_INDEX >= len(_FAKE_TIMES):
-            self._zombie_thread = Timer(self._interval, self._fn)
-            self._zombie_thread.start()
-            return
-
-        now = _FAKE_TIMES[_TIME_INDEX]
-        if (now - self._prev_start_time) >= self._interval:
-            self._fn()
-            self._prev_start_time = now
-        else:
-            self.start()
-
-    def is_alive(self) -> bool:
-        return self._zombie_thread.is_alive() if self._zombie_thread else True
-
-    def cancel(self) -> None:
-        if self._zombie_thread:
-            self._zombie_thread.cancel()
 
 
 def test_truncate_day() -> None:
@@ -82,11 +44,10 @@ def test_seconds_work() -> None:
             self.i += 1
 
     f = Foo()
-    global _FAKE_TIMES, _TIME_INDEX
-    _FAKE_TIMES = [0, 0.5, 1, 1.9, 2, 2.1, 3]
-    _TIME_INDEX = 0
-    t = FunctionTimer(Schedule(TimeGranularity.Second, 1), f.inc, FakeTimer)
-    # time.sleep(3)
+    # Simulate running for 3 seconds, so it should fire 3 times
+    u._FAKE_TIMES = [0, 0.5, 1, 1.9, 2, 2.1, 3]
+    u._TIME_INDEX = 0
+    t = FunctionTimer(Schedule(TimeGranularity.Second, 1), f.inc, u.FakeTimer)
     t.stop()
 
     assert f.i >= 3

--- a/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
+++ b/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
@@ -7,7 +7,7 @@ from whylogs.api.logger.experimental.multi_dataset_logger.time_util import (
     TimeGranularity,
 )
 
-# A sequence of times get instantiated, so we need global state for them
+# A sequence of timers get instantiated, so we need global state for them
 # to simulate universal time.
 
 _FAKE_TIMES: List[float] = []  # list of times (seconds) where the FakeTimer

--- a/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
+++ b/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
@@ -1,6 +1,3 @@
-from threading import Timer
-from typing import Callable, List
-
 import utils as u
 
 from whylogs.api.logger.experimental.multi_dataset_logger.time_util import (

--- a/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
+++ b/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
@@ -10,7 +10,7 @@ from whylogs.api.logger.experimental.multi_dataset_logger.time_util import (
 # A sequence of timers get instantiated, so we need global state for them
 # to simulate universal time.
 
-_FAKE_TIMES: List[float] = []  # list of times (seconds) where the FakeTimer
+_FAKE_TIMES: List[float] = []  # list of times (seconds) where the FakeTimer checks if it should execute
 _TIME_INDEX: int = 0  # where are we in the lsit of times
 
 

--- a/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
+++ b/python/tests/api/logger/experimental/multi_dataset_logger/test_time_util.py
@@ -11,7 +11,7 @@ from whylogs.api.logger.experimental.multi_dataset_logger.time_util import (
 # to simulate universal time.
 
 _FAKE_TIMES: List[float] = []  # list of times (seconds) where the FakeTimer checks if it should execute
-_TIME_INDEX: int = 0  # where are we in the lsit of times
+_TIME_INDEX: int = 0  # where are we in the list of times
 
 
 class FakeTimer:

--- a/python/tests/api/logger/test_rolling.py
+++ b/python/tests/api/logger/test_rolling.py
@@ -22,7 +22,7 @@ from whylogs.core.schema import DatasetSchema
 from whylogs.core.segmentation_partition import segment_on_column
 
 
-# A sequence of times get instantiated, so we need global state for them
+# A sequence of timers get instantiated, so we need global state for them
 # to simulate universal time.
 
 _FAKE_TIMES: List[float] = []  # list of times (seconds) where the FakeTimer

--- a/python/tests/api/logger/test_rolling.py
+++ b/python/tests/api/logger/test_rolling.py
@@ -1,11 +1,10 @@
 import functools
 import math
 import os
-
 from datetime import datetime, timezone
 from os import listdir
 from os.path import isfile
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Optional, Tuple
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -94,7 +93,9 @@ def test_rolling(tmp_path: Any) -> None:
     with why.logger(mode="rolling", interval=1, when="S", base_name="test_base_name") as logger:
         logger.append_writer(writer=TestWriter(base_dir=tmp_path))
         logger.log(df)
-        u._FAKE_TIMES = [x / 10.0 for x in range(16)]  # run for 1.5s, might fire 1 or 2 times depending on initial_run_after
+        u._FAKE_TIMES = [
+            x / 10.0 for x in range(16)
+        ]  # run for 1.5s, might fire 1 or 2 times depending on initial_run_after
         u._TIME_INDEX = 0
         logger._scheduler._timer.start()
 
@@ -102,7 +103,9 @@ def test_rolling(tmp_path: Any) -> None:
         elapsed = u._FAKE_TIMES[-1]
         assert math.floor(elapsed) <= count_files(tmp_path) <= math.ceil(elapsed)
 
-        u._FAKE_TIMES = [1.5 + x / 10.0 for x in range(17)]  # run another 1.5s, fires 1 or 2 times depending on alignment
+        u._FAKE_TIMES = [
+            1.5 + x / 10.0 for x in range(17)
+        ]  # run another 1.5s, fires 1 or 2 times depending on alignment
         u._TIME_INDEX = 0
         logger.log(df)
         logger._scheduler._timer.start()

--- a/python/tests/api/logger/test_rolling.py
+++ b/python/tests/api/logger/test_rolling.py
@@ -4,18 +4,106 @@ import time
 from datetime import datetime, timezone
 from os import listdir
 from os.path import isfile
-from typing import Any
+from threading import Timer
+from typing import Any, Callable, List, Optional, Tuple
 from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
 
 import whylogs as why
+from whylogs.api.logger.rolling import Scheduler
 from whylogs.api.store.local_store import LocalStore
 from whylogs.api.store.query import DatasetIdQuery
+from whylogs.api.writer.local import LocalWriter
+from whylogs.api.writer.writer import Writable
 from whylogs.core.errors import BadConfigError
 from whylogs.core.schema import DatasetSchema
 from whylogs.core.segmentation_partition import segment_on_column
+
+
+# A sequence of times get instantiated, so we need global state for them
+# to simulate universal time.
+
+_FAKE_TIMES: List[float] = []  # list of times (seconds) where the FakeTimer
+_TIME_INDEX: int = 0  # where are we in the lsit of times
+
+
+class FakeTimer:
+    """
+    Fake for threading.Timer, not threaded. Evaluates elapsed duration
+    at times in the _FAKE_TIME list.
+    """
+    def __init__(self, interval: float, fn: Callable) -> None:
+        self._interval = interval
+        self._fn = fn
+        self._prev_start_time = 0.0
+        if _TIME_INDEX < len(_FAKE_TIMES):
+            self._prev_start_time = _FAKE_TIMES[_TIME_INDEX]
+
+    def start(self) -> None:
+        global _TIME_INDEX
+        _TIME_INDEX += 1
+        if _TIME_INDEX >= len(_FAKE_TIMES):
+            return
+
+        now = _FAKE_TIMES[_TIME_INDEX]
+        if (now - self._prev_start_time) >= self._interval:
+            self._fn()
+            self._prev_start_time = now
+        else:
+            self.start()
+
+    def cancel(self) -> None:
+        global _TIME_INDEX
+        _TIME_INDEX = len(_FAKE_TIMES) + 1
+
+
+class TimerConext:
+    def __enter__(self) -> "TimerContext":
+        self._prev_timer = Scheduler._TIMER
+        Scheduler._TIMER = FakeTimer
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb) -> None:
+        Scheduler._TIMER = self._prev_timer
+
+
+import functools
+def use_fake_time(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        with TimerConext():
+            return f(*args, **kwargs)
+
+    return wrapper
+
+
+class TestWriter(LocalWriter):
+    """
+    The LocalWriter only has second resolution in its filenames, so
+    with time faked by the FakeTimer you'd end up with files overwritting
+    each other. So this appends a sequence number to the filename to
+    prevent collisions.
+    """
+    def __init__(self, base_dir: Optional[str] = None, base_name: Optional[str] = None) -> None:
+        super().__init__(base_dir, base_name)
+        self._counter = 1
+
+    def write(
+        self,
+        file: Writable,
+        dest: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Tuple[bool, str]:
+        dest = dest or self._base_name or file.get_default_path()  # type: ignore
+        dest += str(self._counter)
+        self._counter += 1
+        full_path = os.path.join(self._base_dir, dest)
+        file.write(full_path, **kwargs)
+        return True, full_path
+
+
 
 
 def test_closing(tmp_path: Any, lending_club_df: pd.DataFrame) -> None:
@@ -32,44 +120,66 @@ def test_closing(tmp_path: Any, lending_club_df: pd.DataFrame) -> None:
     assert f.startswith("test_base_name")
 
 
+@use_fake_time
 def test_rolling(tmp_path: Any) -> None:
     """This test is rather unstable so we can only assert the number of files in a range."""
 
     d = {"col1": [1, 2], "col2": [3.0, 4.0], "col3": ["a", "b"]}
     df = pd.DataFrame(data=d)
 
-    start = time.time()
+    global _FAKE_TIMES, _TIME_INDEX
+    _FAKE_TIMES = [0, 0.1]
+    _TIME_INDEX = 0
+
+    # start = time.time()
     with why.logger(mode="rolling", interval=1, when="S", base_name="test_base_name") as logger:
-        logger.append_writer("local", base_dir=tmp_path)
+        logger.append_writer(writer=TestWriter(base_dir=tmp_path))
         logger.log(df)
-        time.sleep(1.5)
+        _FAKE_TIMES = [x / 10.0 for x in range(16)]
+        _TIME_INDEX = 0
+        logger._scheduler._timer.start()
+        # time.sleep(1.5)
 
         # Note that the number of files generated is depend on the elapsed amount
-        elapsed = time.time() - start
+        elapsed = _FAKE_TIMES[-1]
+        # elapsed = time.time() - start
+
+        assert math.floor(elapsed) <= count_files(tmp_path) <= math.ceil(elapsed)
+
+        _FAKE_TIMES = [1.5 + x / 10.0 for x in range(17)]
+        _TIME_INDEX = 0
+        logger.log(df)
+        logger._scheduler._timer.start()
+        # time.sleep(1.5)
+        elapsed = _FAKE_TIMES[-1]
+        # elapsed = time.time() - start
         assert math.floor(elapsed) <= count_files(tmp_path) <= math.ceil(elapsed)
 
         logger.log(df)
-        time.sleep(1.5)
-        elapsed = time.time() - start
-        assert math.floor(elapsed) <= count_files(tmp_path) <= math.ceil(elapsed)
 
-        logger.log(df)
-
-    elapsed = time.time() - start
+    elapsed = _FAKE_TIMES[-1]
+    # elapsed = time.time() - start
     assert math.floor(elapsed) <= count_files(tmp_path) <= math.ceil(elapsed)
 
 
+@use_fake_time
 def test_rolling_with_callback(tmp_path: Any) -> None:
     rolling_callback = MagicMock()
     messages = [{"col1": i, "col2": i * i * 1.2, "col3": "a"} for i in range(10)]
 
+    global _FAKE_TIMES, _TIME_INDEX
+    _FAKE_TIMES = [0, 0]
+    _TIME_INDEX = 0
     rolling_logger = why.logger(
         mode="rolling", interval=1, when="S", base_name="test_base_name", callback=rolling_callback
     )
     rolling_logger.append_writer("local", base_dir=tmp_path)
     # process the 10 input messages, and wait a second to allow the rolling logger to hit an interval
     map(rolling_logger.log, messages)
-    time.sleep(1)
+    _FAKE_TIMES = [0, 1]
+    _TIME_INDEX = 0
+    rolling_logger._scheduler._timer.start()
+    # time.sleep(1)
 
     # without an explicit calls to rolling_logger.flush we expect that the elapsed time
     # is greater than 1s interval, so the callback should have been triggered at least once
@@ -82,16 +192,23 @@ def test_rolling_with_callback(tmp_path: Any) -> None:
     assert initial_callback_count < rolling_callback.call_count
 
 
+@use_fake_time
 def test_rolling_skip_empty(tmp_path: Any) -> None:
     """This test is rather unstable so we can only assert the number of files in a range."""
 
     d = {"col1": [1, 2], "col2": [3.0, 4.0], "col3": ["a", "b"]}
     df = pd.DataFrame(data=d)
 
+    global _FAKE_TIMES, _TIME_INDEX
+    _FAKE_TIMES = [0, 0]
+    _TIME_INDEX = 0
     with why.logger(mode="rolling", interval=1, when="S", base_name="test_base_name", skip_empty=True) as logger:
-        logger.append_writer("local", base_dir=tmp_path)
+        logger.append_writer(writer=TestWriter(base_dir=tmp_path))
         logger.log(df)
-        time.sleep(2.1)
+        _FAKE_TIMES = [0, 1, 2.1]
+        _TIME_INDEX = 0
+        logger._scheduler._timer.start()
+        # time.sleep(2.1)
 
         # Note we sleep for over 2 seconds and have rolling interval of 1 second, so we should see at
         # least two elapsed intervals, but have only one file with skip_empty true
@@ -99,7 +216,10 @@ def test_rolling_skip_empty(tmp_path: Any) -> None:
 
         # log one more time, but don't wait and rely on the lifecycle of exiting the above with clause
         # to trigger at least one more flush with some new data
+        _FAKE_TIMES = [2.1, 2.2]
+        _TIME_INDEX = 0
         logger.log(df)
+        logger._scheduler._timer.start()
     assert count_files(tmp_path) == 2
 
 
@@ -121,14 +241,19 @@ def count_files(tmp_path: Any) -> int:
     return len(only_files)
 
 
+@use_fake_time
 def test_rolling_with_local_store_writes() -> None:
     store = LocalStore()
     df = pd.DataFrame(data={"a": [1, 2, 3, 4]})
 
     with why.logger(mode="rolling", interval=1, when="S", base_name="test_base_name", skip_empty=True) as logger:
         logger.append_store(store=store)
+        global _FAKE_TIMES, _TIME_INDEX
+        _FAKE_TIMES = [0, 1.1]
+        _TIME_INDEX = 0
         logger.log(df)
-        time.sleep(1)
+        logger._scheduler._timer.start()
+        # time.sleep(1)
         assert len(store.list()) == 1
 
         query = DatasetIdQuery(dataset_id="test_base_name")

--- a/python/tests/api/logger/test_rolling.py
+++ b/python/tests/api/logger/test_rolling.py
@@ -1,10 +1,11 @@
+import functools
 import math
 import os
-import time
+
+# import time
 from datetime import datetime, timezone
 from os import listdir
 from os.path import isfile
-from threading import Timer
 from typing import Any, Callable, List, Optional, Tuple
 from unittest.mock import MagicMock
 
@@ -21,7 +22,6 @@ from whylogs.core.errors import BadConfigError
 from whylogs.core.schema import DatasetSchema
 from whylogs.core.segmentation_partition import segment_on_column
 
-
 # A sequence of timers get instantiated, so we need global state for them
 # to simulate universal time.
 
@@ -34,6 +34,7 @@ class FakeTimer:
     Fake for threading.Timer, not threaded. Evaluates elapsed duration
     at times in the _FAKE_TIME list.
     """
+
     def __init__(self, interval: float, fn: Callable) -> None:
         self._interval = interval
         self._fn = fn
@@ -59,7 +60,7 @@ class FakeTimer:
         _TIME_INDEX = len(_FAKE_TIMES) + 1
 
 
-class TimerConext:
+class TimerContext:
     def __enter__(self) -> "TimerContext":
         self._prev_timer = Scheduler._TIMER
         Scheduler._TIMER = FakeTimer
@@ -69,11 +70,10 @@ class TimerConext:
         Scheduler._TIMER = self._prev_timer
 
 
-import functools
 def use_fake_time(f):
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        with TimerConext():
+        with TimerContext():
             return f(*args, **kwargs)
 
     return wrapper
@@ -86,6 +86,7 @@ class TestWriter(LocalWriter):
     each other. So this appends a sequence number to the filename to
     prevent collisions.
     """
+
     def __init__(self, base_dir: Optional[str] = None, base_name: Optional[str] = None) -> None:
         super().__init__(base_dir, base_name)
         self._counter = 1
@@ -102,8 +103,6 @@ class TestWriter(LocalWriter):
         full_path = os.path.join(self._base_dir, dest)
         file.write(full_path, **kwargs)
         return True, full_path
-
-
 
 
 def test_closing(tmp_path: Any, lending_club_df: pd.DataFrame) -> None:

--- a/python/tests/api/logger/test_rolling.py
+++ b/python/tests/api/logger/test_rolling.py
@@ -25,7 +25,7 @@ from whylogs.core.segmentation_partition import segment_on_column
 # A sequence of timers get instantiated, so we need global state for them
 # to simulate universal time.
 
-_FAKE_TIMES: List[float] = []  # list of times (seconds) where the FakeTimer
+_FAKE_TIMES: List[float] = []  # list of times (seconds) where the FakeTimer checks if it should execute
 _TIME_INDEX: int = 0  # where are we in the lsit of times
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -3,8 +3,10 @@
 isort:skip_file
 """
 import os
+import sys
 
 os.environ["TELEMETRY_DEV"] = "1"  # noqa: E402
+sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
 
 import pandas as pd
 import pytest

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 os.environ["TELEMETRY_DEV"] = "1"  # noqa: E402
-sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
+sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
 
 import pandas as pd
 import pytest

--- a/python/tests/helpers/utils.py
+++ b/python/tests/helpers/utils.py
@@ -1,6 +1,5 @@
 from typing import Callable, List
 
-
 # A sequence of timers get instantiated, so we need global state for them
 # to simulate universal time.
 

--- a/python/tests/helpers/utils.py
+++ b/python/tests/helpers/utils.py
@@ -1,0 +1,42 @@
+from typing import Callable, List
+
+
+# A sequence of timers get instantiated, so we need global state for them
+# to simulate universal time.
+
+_FAKE_TIMES: List[float] = []  # list of times (seconds) where the FakeTimer checks if it should execute
+_TIME_INDEX: int = 0  # where are we in the list of times
+
+
+class FakeTimer:
+    """
+    Fake for threading.Timer, not threaded. Evaluates elapsed duration
+    at times in the _FAKE_TIME list.
+    """
+
+    def __init__(self, interval: float, fn: Callable) -> None:
+        self._interval = interval
+        self._fn = fn
+        self._prev_start_time = 0.0
+        if _TIME_INDEX < len(_FAKE_TIMES):
+            self._prev_start_time = _FAKE_TIMES[_TIME_INDEX]
+
+    def start(self) -> None:
+        global _TIME_INDEX
+        _TIME_INDEX += 1
+        if _TIME_INDEX >= len(_FAKE_TIMES):
+            return
+
+        now = _FAKE_TIMES[_TIME_INDEX]
+        if (now - self._prev_start_time) >= self._interval:
+            self._fn()
+            self._prev_start_time = now
+        else:
+            self.start()
+
+    def cancel(self) -> None:
+        global _TIME_INDEX
+        _TIME_INDEX = len(_FAKE_TIMES) + 1
+
+    def is_alive(self) -> bool:
+        return True

--- a/python/whylogs/api/logger/experimental/multi_dataset_logger/time_util.py
+++ b/python/whylogs/api/logger/experimental/multi_dataset_logger/time_util.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
 from threading import Timer
-from typing import Callable
+from typing import Callable, Type
 
 from dateutil import tz
 
@@ -50,17 +50,18 @@ class FunctionTimer:
     execute in five minutes, and then each hour after that.
     """
 
-    def __init__(self, schedule: Schedule, fn: Callable) -> None:
+    def __init__(self, schedule: Schedule, fn: Callable, timer_class: Type = Timer) -> None:
         self._logger = logging.getLogger(f"{type(self).__name__}_{id(self)}")
         self._fn = fn
         self._schedule = schedule
         self._running = True
+        self._timer_class = timer_class
         now = datetime.now(tz=tz.tzutc())
 
         # Convert each of the intervals into seconds
         if schedule.cadence == TimeGranularity.Second:
             self.repeat_interval = schedule.interval
-            next_second = (now + timedelta(minutes=self._schedule.interval)).replace(microsecond=0)
+            next_second = (now + timedelta(seconds=self._schedule.interval)).replace(microsecond=0)
             initial_interval = min(0, (next_second - now).seconds)
         elif schedule.cadence == TimeGranularity.Minute:
             self.repeat_interval = schedule.interval * 60
@@ -80,12 +81,12 @@ class FunctionTimer:
             raise Exception("Can't use Monthly schedule.")
 
         self._logger.debug(f"scheduled for {initial_interval} seconds from now")
-        self._timer = Timer(initial_interval, self._run)
+        self._timer = timer_class(initial_interval, self._run)
         self._timer.start()
 
     def _run(self) -> None:
         self._logger.debug(f"scheduled for {self.repeat_interval} seconds from now")
-        self._timer = Timer(self.repeat_interval, self._run)
+        self._timer = self._timer_class(self.repeat_interval, self._run)
         self._timer.start()
         self._fn()
 

--- a/python/whylogs/api/logger/rolling.py
+++ b/python/whylogs/api/logger/rolling.py
@@ -5,7 +5,7 @@ import os
 import time
 from datetime import datetime, timezone
 from threading import Timer
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Type
 
 from typing_extensions import Literal
 
@@ -27,7 +27,8 @@ class Scheduler(object):
     Schedule a function to be called repeatedly based on a schedule.
     """
 
-    _timer: Timer
+    _TIMER: Type = Timer
+    _timer: Any  # Timer
 
     def __init__(self, initial: float, interval: float, function: Callable, *args: Any, **kwargs: Any):
         self.initial = initial
@@ -50,7 +51,7 @@ class Scheduler(object):
             if not self._ran_initial:
                 interval = self.initial
                 self._ran_initial = True
-            self._timer = Timer(interval, self._run)
+            self._timer = Scheduler._TIMER(interval, self._run)
             self._timer.start()
             self.is_running = True
 


### PR DESCRIPTION
## Description

The rolling logger and a couple other tests used `time.sleep()`. This uses a faked `threading.Timer` that uses a simulated (single-threaded) schedule rather than real-time sleeping to speed up the tests. 

## Changes

- Use a fake timer instead of sleeping
- Adds a modified `LocalWriter` so profiles written in the same second don't collide


- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
