### PR TITLE
Add warning in multi_dataset_logger when there is no write schedule

### DIFF
--- a/python/whylogs/api/logger/experimental/multi_dataset_logger/multi_dataset_rolling_logger.py
+++ b/python/whylogs/api/logger/experimental/multi_dataset_logger/multi_dataset_rolling_logger.py
@@ -232,6 +232,11 @@ class MultiDatasetRollingLogger(MessageProcessor[LoggerMessage]):
                 raise Exception("Minimum write schedule is five minutes.")
 
             self._timer = FunctionTimer(write_schedule, self.flush)
+        else:
+            self._logger.warning(
+                "No write schedule defined for logger. Profiles will only be written after calls to flush()."
+            )
+
         super().__init__()
 
     def _process_message(self, message: Union[LoggerMessage, CloseMessage]) -> None:


### PR DESCRIPTION
Just a small warning in case people mistakenly disable write schedules.