### PR TITLE
Fix back compat deserializing nan/inf counts in ColumnCountsMetric

### DIFF
--- a/python/tests/core/metrics/test_column_metrics.py
+++ b/python/tests/core/metrics/test_column_metrics.py
@@ -92,3 +92,23 @@ def test_type_counts_with_and_without_tensor_field():
     assert full_type_counts.tensor.value == 6
     merged_counts = full_type_counts.merge(type_counts)
     assert merged_counts.tensor.value == 7
+
+
+def test_column_counts_with_and_without_nan_field():
+    column_counts = ColumnCountsMetric(
+        n=IntegralComponent(1),
+        null=IntegralComponent(2),
+    )
+    assert column_counts.nan.value == 0
+    assert column_counts.inf.value == 0
+    column_counts.nan.set(1)
+    assert column_counts.nan.value == 1
+    assert column_counts.null.value == 2
+    full_column_counts = ColumnCountsMetric(
+        n=IntegralComponent(1),
+        null=IntegralComponent(2),
+        nan=IntegralComponent(3),
+        inf=IntegralComponent(4),
+    )
+    assert full_column_counts.nan.value == 3
+    assert full_column_counts.inf.value == 4

--- a/python/whylogs/core/metrics/column_metrics.py
+++ b/python/whylogs/core/metrics/column_metrics.py
@@ -111,8 +111,8 @@ class TypeCountersMetric(Metric):
 class ColumnCountsMetric(Metric):
     n: IntegralComponent
     null: IntegralComponent
-    nan: IntegralComponent
-    inf: IntegralComponent
+    nan: IntegralComponent = field(default_factory=lambda: IntegralComponent(0))
+    inf: IntegralComponent = field(default_factory=lambda: IntegralComponent(0))
 
     @property
     def namespace(self) -> str:


### PR DESCRIPTION
## Description

fixes #1184 

Fix back compat deserializing nan/inf counts in ColumnCountsMetric to avoid error like:

`TypeError: __init__() missing 2 required positional arguments: 'nan' and 'inf'`

## Changes

- Add default values for nan/inf fields in ColumnCountsMetric
- Add test to cover instantiating the ColumnCountsMetric with and without nan/inf fields.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
