### PR TITLE
Adds check if cardinality metric exists when getting frequent stats

### DIFF
--- a/python/whylogs/viz/utils/frequent_items_calculations.py
+++ b/python/whylogs/viz/utils/frequent_items_calculations.py
@@ -34,6 +34,8 @@ def get_frequent_stats(column_view: ColumnProfileView, config: Optional[SummaryC
     target_cnt_metric = column_view.get_metric("counts")
     target_count = target_cnt_metric.n.value
     target_card_metric = column_view.get_metric("cardinality")
+    if not target_card_metric:
+        return None
     target_unique_count = int(target_card_metric.hll.value.get_estimate())
 
     target_frequent_stats: FrequentStats = {


### PR DESCRIPTION
## Description

When getting Frequent Stats for performing drift detection for categorical variables, an error is raised when Cardinality metric is absent. This PR adds a check that returns None for frequent stats when this case happens.

Closes https://github.com/whylabs/whylogs/issues/1148

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
