### PR TITLE
Add CardinalityMetric to embeddings submetrics

### DIFF
--- a/python/tests/experimental/extras/test_embedding_metric.py
+++ b/python/tests/experimental/extras/test_embedding_metric.py
@@ -32,8 +32,11 @@ def test_embedding_metric_row() -> None:
     assert summary["embedding/B_distance:counts/n"] == 3
     assert summary["embedding/A_distance:distribution/mean"] > 0
     assert summary["embedding/B_distance:distribution/mean"] > 0
+    assert summary["embedding/A_distance:cardinality/est"] > 0
+    assert summary["embedding/B_distance:cardinality/est"] > 0
     assert summary["embedding/closest:counts/n"] == 3
     assert summary["embedding/closest:frequent_items/frequent_strings"] != []
+    assert summary["embedding/closest:cardinality/est"] > 0
 
 
 def test_embedding_metric_pandas() -> None:

--- a/python/whylogs/experimental/extras/embedding_metric.py
+++ b/python/whylogs/experimental/extras/embedding_metric.py
@@ -71,6 +71,7 @@ class EmbeddingMetric(MultiMetric):
                 "distribution": StandardMetric.distribution.zero(),
                 "counts": StandardMetric.counts.zero(),
                 "types": StandardMetric.types.zero(),
+                "cardinality": StandardMetric.cardinality.zero(),
             }
             for label in self.labels
         }
@@ -80,6 +81,7 @@ class EmbeddingMetric(MultiMetric):
                     "frequent_items": StandardMetric.frequent_items.zero(),
                     "counts": StandardMetric.counts.zero(),
                     "types": StandardMetric.types.zero(),
+                    "cardinality": StandardMetric.cardinality.zero(),
                 }
             }
         )


### PR DESCRIPTION
## Description

Submetrics require CardinalityMetric for WhyLabs and visualization.

## Changes

Adds cardinality to all embeddings submetrics



- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
