### PR TITLE
Manually update version info

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.33
+current_version = 1.1.34
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 

--- a/python/Makefile
+++ b/python/Makefile
@@ -5,7 +5,7 @@ src.proto.dir := ../proto/src
 src.proto := $(shell find $(src.proto.dir) -type f -name "*.proto")
 src.proto.v0.dir := ../proto/v0
 src.proto.v0 := $(shell find $(src.proto.v0.dir) -type f -name "*.proto")
-version := 1.1.33
+version := 1.1.34
 
 dist.dir := dist
 egg.dir := .eggs

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -8,7 +8,7 @@ if shutil.which("pandoc") is None:
     print("Pandoc is required to build our documentation.")
     sys.exit(1)
 
-version = "1.1.33"
+version = "1.1.34"
 
 project = "whylogs"
 author = "whylogs developers"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "whylogs"
-version = "1.1.33"
+version = "1.1.34"
 description = "Profile and monitor your ML data pipeline end-to-end"
 authors = ["WhyLabs.ai <support@whylabs.ai>"]
 license = "Apache-2.0"

--- a/python/tests/smoketest.py
+++ b/python/tests/smoketest.py
@@ -12,7 +12,7 @@ intended to test the wheel in a production environment,
 not a development environment.
 """
 
-current_version = "1.1.33"
+current_version = "1.1.34"
 
 
 def test_package_version() -> None:


### PR DESCRIPTION
Last release failed to run bump_mainline, which should be fixed, but the package version info needs to be  updated to reflect the last release of 1.1.34, before we can release 1.1.35


- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
