### PR TITLE
Single value line for double_histogram viz

### DIFF
--- a/python/whylogs/viz/html/templates/index-hbs-cdn-all-in-jupyter-distribution-chart.html
+++ b/python/whylogs/viz/html/templates/index-hbs-cdn-all-in-jupyter-distribution-chart.html
@@ -278,6 +278,18 @@
         return data
       }
 
+      function verticalLine(column) {
+        const line_data = [];
+        if (column?.vertical_line) {
+            line_data.push({
+              axisX: column?.vertical_line || 0,
+            });
+
+        }
+
+        return line_data
+      }
+
       function generateDoubleHistogramChart(targetData, referenceData) {
         let histogramData = [],
             overlappedHistogramData = [];
@@ -285,6 +297,7 @@
 
         histogramData = chartData(targetData)
         overlappedHistogramData = chartData(referenceData)
+        lineData = verticalLine(targetData)
 
         const sizes = new GenerateChartParams($(window).height()-80, $(window).width(), histogramData, overlappedHistogramData)
         const {
@@ -315,6 +328,29 @@
               .attr("y", 10)
               .attr("fill", "currentColor")
               .attr("text-anchor", "start"))
+
+        svgEl.append("line")
+          .attr("transform", `translate(${MARGIN.LEFT}, ${MARGIN.BOTTOM})`)
+          .data(lineData)
+          .attr("x1", (d) => xScale(d.axisX))
+          .attr("y1", MARGIN.TOP + MARGIN.TOP)
+          .attr("x2", (d) => xScale(d.axisX))
+          .attr("y2", CHART_HEIGHT + MARGIN.TOP)
+          .style("stroke-width", 2)
+          .style("stroke", "#44C0E7")
+          .style("stroke-dasharray", (3,3))
+          .style("fill", "none");
+
+        svgEl.append("text")
+          .attr("transform", "rotate(-90)")
+          .data(lineData)
+          .attr("y", (d) => xScale(d.axisX) + MARGIN.LEFT)
+          .attr("x", 0 - (SVG_HEIGHT / 2))
+          .attr("dy", "1em")
+          .style("text-anchor", "middle")
+          .text("single value")
+          .style("font-size", "15")
+          .style("opacity", "0.6")
 
         svgEl.append("text")
           .attr("transform",

--- a/python/whylogs/viz/notebook_profile_viz.py
+++ b/python/whylogs/viz/notebook_profile_viz.py
@@ -192,6 +192,10 @@ class NotebookProfileVisualizer:
 
             ref_features[feature_name]["histogram"] = ref_histogram
             target_features[feature_name]["histogram"] = target_histogram
+            if target_histogram["n"] == 1:
+                # in the degenerate case when the target is a single value, it will be hidden
+                # so here we draw a vertical line, using the max (which is the observed value)
+                target_features[feature_name]["vertical_line"] = target_histogram["max"]
             histogram_chart = template(
                 {
                     "profile_from_whylogs": json.dumps(target_features),


### PR DESCRIPTION
## Description

When there is only one bin with a single value the histogram chart and the reference profile has counts larger than 10, the single value won't be visible. This add a dashed line to show where on the x axis the single value falls. This can be useful when comparing a single row's feature when comparing to a reference profile for that feature.

With this change, here is what the `double_histogram` chart looks like. Without this change, the target profile has a single value that is too small to really see in this chart.

![double histogram single value treatment](https://user-images.githubusercontent.com/88007022/230650748-3faca4b2-74f8-4619-bf8c-27db11204fc0.png)


- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
