### PR TITLE
Return whylabs profile id on upload

### DIFF
--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -126,17 +126,20 @@ class ResultSetWriter:
         self._writer.option(**kwargs)
         return self
 
-    def write(self, **kwargs: Any) -> None:
+    def write(self, **kwargs: Any) -> List:
         # multi-profile writer
         files = self._result_set.get_writables()
+        statuses = list()
         if not files:
             logger.warning("Attempt to write a result set with no writables returned, nothing written!")
         else:
             logger.debug(f"About to write {len(files)} files:")
             # TODO: special handling of large number of files, handle throttling
             for view in files:
-                self._writer.write(file=view, **kwargs)
+                response = self._writer.write(file=view, **kwargs)
+                statuses.append(response)
             logger.debug(f"Completed writing {len(files)} files!")
+        return statuses
 
 
 class ResultSetReader:


### PR DESCRIPTION
## Description

When uploading to WhyLabs we get back a returned reference id for the uploaded profile, but whylogs ignores it. This change fixes the result set writer to return back a list of the responses, and updates the whylabs writer to return the reference id when upload is successful in the existing response Tuple(bool, str) for the str message.

For the success case, this will replace the string 'OK' for the whylabs writer's returned status message, and instead you would get something like:

```
from whylogs.api.writer.whylabs import WhyLabsWriter

writer = WhyLabsWriter()
status = writer.write(results.view())
print(status)
```
outputs:
```
(True, 'log-rlnMCbmflpBI38Hc')
```

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
