### PR TITLE
Stub out scikit-learn in embeddings metric

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -144,7 +144,8 @@ fugue = [
   "fugue",
 ]
 embeddings = [
-  "scikit-learn"
+  "numpy",
+  "scikit-learn",
 ]
 all = [
   "scikit-learn",

--- a/python/whylogs/core/stubs.py
+++ b/python/whylogs/core/stubs.py
@@ -68,7 +68,7 @@ class ScikitLearnStub:
 
 
 def is_not_stub(stubbed_class: Any) -> bool:
-    if stubbed_class and stubbed_class is not _StubClass and not isinstance(stubbed_class, (PandasStub, NumpyStub)):
+    if stubbed_class and stubbed_class is not _StubClass and not isinstance(stubbed_class, (PandasStub, NumpyStub, ScipyStub, ScikitLearnStub)):
         return True
     return False
 

--- a/python/whylogs/core/stubs.py
+++ b/python/whylogs/core/stubs.py
@@ -21,6 +21,15 @@ try:
 except ImportError:  # noqa
     _sp = None  # type: ignore
 
+try:
+    import sklearn.cluster as _sklc
+    import sklearn.decomposition as _skld
+    import sklearn.metrics.pairwise as _sklp
+except ImportError:  # noqa
+    _sklp = None  # type: ignore
+    _sklc = None  # type: ignore
+    _skld = None  # type: ignore
+
 
 class _StubClass:
     pass
@@ -50,6 +59,14 @@ class ScipyStub:
     sparse: type = _StubClass
 
 
+@dataclass(frozen=True)
+class ScikitLearnStub:
+    cosine_distances: type = _StubClass
+    euclidean_distances: type = _StubClass
+    KMeans: type = _StubClass
+    PCA: type = _StubClass
+
+
 def is_not_stub(stubbed_class: Any) -> bool:
     if stubbed_class and stubbed_class is not _StubClass and not isinstance(stubbed_class, (PandasStub, NumpyStub)):
         return True
@@ -65,6 +82,19 @@ if _pd is None:
 if _sp is None:
     _sp = ScipyStub()
 
+if _sklp is None:
+    _sklp = ScikitLearnStub()
+
+if _sklc is None:
+    _skld = ScikitLearnStub()
+
+if _skld is None:
+    _skld = ScikitLearnStub()
+
+
 np = _np
 pd = _pd
 sp = _sp
+sklp = _sklp
+sklc = _sklc
+skld = _skld

--- a/python/whylogs/core/stubs.py
+++ b/python/whylogs/core/stubs.py
@@ -68,7 +68,11 @@ class ScikitLearnStub:
 
 
 def is_not_stub(stubbed_class: Any) -> bool:
-    if stubbed_class and stubbed_class is not _StubClass and not isinstance(stubbed_class, (PandasStub, NumpyStub, ScipyStub, ScikitLearnStub)):
+    if (
+        stubbed_class
+        and stubbed_class is not _StubClass
+        and not isinstance(stubbed_class, (PandasStub, NumpyStub, ScipyStub, ScikitLearnStub))
+    ):
         return True
     return False
 

--- a/python/whylogs/core/stubs.py
+++ b/python/whylogs/core/stubs.py
@@ -86,7 +86,7 @@ if _sklp is None:
     _sklp = ScikitLearnStub()
 
 if _sklc is None:
-    _skld = ScikitLearnStub()
+    _sklc = ScikitLearnStub()
 
 if _skld is None:
     _skld = ScikitLearnStub()

--- a/python/whylogs/experimental/extras/embedding_metric.py
+++ b/python/whylogs/experimental/extras/embedding_metric.py
@@ -4,22 +4,20 @@ from enum import Enum
 from itertools import chain
 from typing import List, Optional
 
-from sklearn.metrics.pairwise import cosine_distances, euclidean_distances
-
 from whylogs.core.metrics import StandardMetric
 from whylogs.core.metrics.metrics import MetricConfig, OperationResult, register_metric
 from whylogs.core.metrics.multimetric import MultiMetric
 from whylogs.core.preprocessing import PreprocessedColumn
 from whylogs.core.proto import MetricMessage
-from whylogs.core.stubs import np
+from whylogs.core.stubs import np, sklp
 from whylogs.experimental.extras.matrix_component import MatrixComponent
 
 logger = logging.getLogger(__name__)
 
 
 class DistanceFunction(Enum):
-    euclidean = euclidean_distances
-    cosine = cosine_distances
+    euclidean = sklp.euclidean_distances
+    cosine = sklp.cosine_distances
 
 
 @dataclass(frozen=True)

--- a/python/whylogs/experimental/preprocess/embeddings/selectors.py
+++ b/python/whylogs/experimental/preprocess/embeddings/selectors.py
@@ -2,9 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import List, Optional, Tuple, Union
 
-import numpy as np
-from sklearn.cluster import KMeans
-from sklearn.decomposition import PCA
+from whylogs.core.stubs import np, sklc, skld
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +33,7 @@ class PCACentroidsSelector(ReferenceSelector):
             raise ValueError("PCACentroidSelector requires labels")
 
         # Fit PCA
-        pca = PCA(n_components=self.n_components)
+        pca = skld.PCA(n_components=self.n_components)
         X_pca = pca.fit_transform(X)
 
         # Find centroids for each label in PCA space
@@ -75,7 +73,7 @@ class KMeansSelector(ReferenceSelector):
         self.ref_labels = list(range(self.n_clusters))
 
         # Find k-means clusters
-        kmeans = KMeans(n_clusters=self.n_clusters, **self.kmeans_kwargs)
+        kmeans = sklc.KMeans(n_clusters=self.n_clusters, **self.kmeans_kwargs)
         kmeans.fit(X)
         refs = kmeans.cluster_centers_
         return refs, self.ref_labels
@@ -85,7 +83,7 @@ class PCAKMeansSelector(ReferenceSelector):
     def __init__(self, n_clusters: int = 8, n_components: int = 2, kmeans_kwargs={}):
         super().__init__()
         self.n_components = n_components
-        self.kmeanie = KMeansSelector(n_clusters, kmeans_kwargs)
+        self.kmeanie = sklc.KMeansSelector(n_clusters, kmeans_kwargs)
 
     def calculate_references(
         self, X: np.ndarray, y: Optional[np.ndarray] = None
@@ -94,7 +92,7 @@ class PCAKMeansSelector(ReferenceSelector):
             logger.warn("PCAKMeansSelector is unsupervised; ignoring labels")
 
         # Fit PCA first
-        pca = PCA(n_components=self.n_components)
+        pca = skld.PCA(n_components=self.n_components)
         X_pca = pca.fit_transform(X)
 
         # Find k-means clusters

--- a/python/whylogs/experimental/preprocess/embeddings/selectors.py
+++ b/python/whylogs/experimental/preprocess/embeddings/selectors.py
@@ -83,7 +83,7 @@ class PCAKMeansSelector(ReferenceSelector):
     def __init__(self, n_clusters: int = 8, n_components: int = 2, kmeans_kwargs={}):
         super().__init__()
         self.n_components = n_components
-        self.kmeanie = sklc.KMeansSelector(n_clusters, kmeans_kwargs)
+        self.kmeanie = KMeansSelector(n_clusters, kmeans_kwargs)
 
     def calculate_references(
         self, X: np.ndarray, y: Optional[np.ndarray] = None


### PR DESCRIPTION
## Description

Stub out scikit-learn for `EmbeddingMetric` when it is not installed so the rest of whylogs doesn't break.

## Changes

Adds stubs for the few scikit-learn functions used by embeddings. Also fixes a couple other minor stub bugs.

Tested by uninstalling scikit-learn. Only embeddings tests failed. Reinstalled and all tests pass.


- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
