### PR TITLE
Support setting timestamps on ViewResultSet

### DIFF
--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -254,6 +254,14 @@ class ViewResultSet(ResultSet):
             logger.warning(f"Merging potentially incompatible ViewResultSet and {type(other)}")
         return ViewResultSet(lhs_view.merge(other.view()))
 
+    def set_dataset_timestamp(self, dataset_timestamp: datetime) -> None:
+        ensure_timezone(dataset_timestamp)
+        view = self.view()
+        if view is None:
+            raise ValueError("Cannot set timestamp on a view result set without a view!")
+        else:
+            view.set_dataset_timestamp(dataset_timestamp)
+
 
 class ProfileResultSet(ResultSet):
     def __init__(self, profile: DatasetProfile) -> None:


### PR DESCRIPTION
## Description

Usability improvement, since the base class of ResultSet contains a set_dataset_timestamp method that operates on a contained profile, we can make this method work in a ViewResultSet by overriding it.

## Changes

- Implement set_dataset_timestamp on ViewResultSet to update the contained view's timestamp

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
