### PR TITLE
Avoid irrelevant constraints generation when column only has null values

### DIFF
--- a/python/whylogs/core/utils/stats_calculations.py
+++ b/python/whylogs/core/utils/stats_calculations.py
@@ -45,5 +45,17 @@ def get_cardinality_estimate(column_profile: ColumnProfileView) -> CardinalityEs
     if cardinality is not None and counts is not None:
         n_value = counts.to_summary_dict().get("n", None) - counts.to_summary_dict().get("null", None)
         if n_value is not None and est_value is not None:
-            est_ratio = est_value / n_value
+            try:
+                est_ratio = est_value / n_value
+            except ZeroDivisionError:
+                est_ratio = None
     return CardinalityEstimate(est=est_value, unique_pct=est_ratio)
+
+
+def only_null_values(column_profile: ColumnProfileView) -> bool:
+    counts = column_profile.get_metric("counts")
+    if counts is not None:
+        counts_summary = counts.to_summary_dict()
+        if counts_summary.get("n", None) == counts_summary.get("null", None):
+            return True
+    return False

--- a/python/whylogs/experimental/constraints_generation/multi_metrics.py
+++ b/python/whylogs/experimental/constraints_generation/multi_metrics.py
@@ -3,8 +3,8 @@ from typing import List
 from whylogs.core.constraints.factories import column_is_probably_unique
 from whylogs.core.constraints.metric_constraints import MetricConstraint
 from whylogs.core.utils import is_probably_unique
-from whylogs.core.view.column_profile_view import ColumnProfileView
 from whylogs.core.utils.stats_calculations import only_null_values
+from whylogs.core.view.column_profile_view import ColumnProfileView
 
 
 def generate_column_multi_metrics_constraints(

--- a/python/whylogs/experimental/constraints_generation/multi_metrics.py
+++ b/python/whylogs/experimental/constraints_generation/multi_metrics.py
@@ -4,12 +4,13 @@ from whylogs.core.constraints.factories import column_is_probably_unique
 from whylogs.core.constraints.metric_constraints import MetricConstraint
 from whylogs.core.utils import is_probably_unique
 from whylogs.core.view.column_profile_view import ColumnProfileView
+from whylogs.core.utils.stats_calculations import only_null_values
 
 
 def generate_column_multi_metrics_constraints(
     column_name: str, column_profile: ColumnProfileView
 ) -> List[MetricConstraint]:
     constraints = []
-    if is_probably_unique(column_profile):
+    if is_probably_unique(column_profile) and not only_null_values(column_profile):
         constraints.append(column_is_probably_unique(column_name))
     return constraints

--- a/python/whylogs/experimental/constraints_generation/types_metrics.py
+++ b/python/whylogs/experimental/constraints_generation/types_metrics.py
@@ -21,5 +21,6 @@ def generate_column_types_constraints(column_name: str, column_profile: ColumnPr
     for key, component in vars(types_metric).items():
         if component.value == 0:
             zero_empty_types.append(key)
-    constraints.append(column_has_zero_count_types(column_name=column_name, types_list=zero_empty_types))
+    if zero_empty_types:
+        constraints.append(column_has_zero_count_types(column_name=column_name, types_list=zero_empty_types))
     return constraints


### PR DESCRIPTION
If a column only has null values, constraints generation hits a `ZeroDivisionError` when getting Cardinality Estimates.

It also generates irrelevant constraints, such as ` column_has_zero_count_types` for an empty list and `is_probably_unique`.

This PR avoids the error and prevents irrelevant constraints from being generated.

closes #1218 

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
