### PR TITLE
Improved generate UDF schema

### DIFF
--- a/python/tests/experimental/core/metrics/test_udf_metric.py
+++ b/python/tests/experimental/core/metrics/test_udf_metric.py
@@ -3,12 +3,11 @@ import pandas as pd
 import whylogs as why
 from whylogs.core.datatypes import String
 from whylogs.core.preprocessing import PreprocessedColumn
-from whylogs.core.resolvers import STANDARD_RESOLVER
 from whylogs.core.schema import DeclarativeSchema
 from whylogs.experimental.core.metrics.udf_metric import (
     UdfMetric,
     UdfMetricConfig,
-    generate_udf_schema,
+    generate_udf_metric_schema,
     register_metric_udf,
 )
 
@@ -98,7 +97,7 @@ def upper(x):
 
 
 def test_decorator() -> None:
-    schema = DeclarativeSchema(STANDARD_RESOLVER + generate_udf_schema())
+    schema = DeclarativeSchema(generate_udf_metric_schema())
     data = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6], "col3": [7, 8, 9], "col4": ["a", "b", "c"]})
     view = why.log(data, schema=schema).profile().view()
     col1_view = view.get_column("col1")

--- a/python/tests/experimental/core/metrics/test_udf_metric.py
+++ b/python/tests/experimental/core/metrics/test_udf_metric.py
@@ -3,7 +3,6 @@ import pandas as pd
 import whylogs as why
 from whylogs.core.datatypes import String
 from whylogs.core.preprocessing import PreprocessedColumn
-from whylogs.core.schema import DeclarativeSchema
 from whylogs.experimental.core.metrics.udf_metric import (
     UdfMetric,
     UdfMetricConfig,
@@ -97,9 +96,8 @@ def upper(x):
 
 
 def test_decorator() -> None:
-    schema = DeclarativeSchema(generate_udf_metric_schema())
     data = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6], "col3": [7, 8, 9], "col4": ["a", "b", "c"]})
-    view = why.log(data, schema=schema).profile().view()
+    view = why.log(data, schema=generate_udf_metric_schema()).profile().view()
     col1_view = view.get_column("col1")
     col2_view = view.get_column("col2")
     col3_view = view.get_column("col3")

--- a/python/tests/experimental/core/metrics/test_udf_metric.py
+++ b/python/tests/experimental/core/metrics/test_udf_metric.py
@@ -6,8 +6,8 @@ from whylogs.core.preprocessing import PreprocessedColumn
 from whylogs.experimental.core.metrics.udf_metric import (
     UdfMetric,
     UdfMetricConfig,
-    generate_udf_metric_schema,
     register_metric_udf,
+    udf_metric_schema,
 )
 
 
@@ -97,7 +97,7 @@ def upper(x):
 
 def test_decorator() -> None:
     data = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6], "col3": [7, 8, 9], "col4": ["a", "b", "c"]})
-    view = why.log(data, schema=generate_udf_metric_schema()).profile().view()
+    view = why.log(data, schema=udf_metric_schema()).profile().view()
     col1_view = view.get_column("col1")
     col2_view = view.get_column("col2")
     col3_view = view.get_column("col3")

--- a/python/whylogs/experimental/core/metrics/udf_metric.py
+++ b/python/whylogs/experimental/core/metrics/udf_metric.py
@@ -188,7 +188,7 @@ def register_metric_udf(
     input columns of the specified type. The decorated function will automatically
     be a UDF in the UdfMetric.
 
-    Specify submetric_name to give the output of the UDf a name. submetric_name
+    Specify submetric_name to give the output of the UDF a name. submetric_name
     defautls to the name of the decorated function. Note that all lambdas are
     named "lambda" so omitting submetric_name on more than one lambda will result
     in name collisions.

--- a/python/whylogs/experimental/core/metrics/udf_metric.py
+++ b/python/whylogs/experimental/core/metrics/udf_metric.py
@@ -236,12 +236,12 @@ def register_metric_udf(
     return decorator_register
 
 
-def generate_udf_schema() -> List[ResolverSpec]:
+def generate_udf_metric_schema(non_udf_resolvers: List[ResolverSpec] = STANDARD_RESOLVER) -> List[ResolverSpec]:
     """
     Generates a list of ResolverSpecs that implement the UdfMetrics specified
-    by the @register_metric_ud decorators. The result only includes the UdfMetric,
-    so you may want to append it to a list of ResolverSpecs defining the other
-    metrics you wish to track.
+    by the @register_metric_ud decorators (in additon to any non_udf_resolvers
+    passed in). The result only includes the UdfMetric, so you may want to append
+    it to a list of ResolverSpecs defining the other metrics you wish to track.
 
     For example:
 
@@ -253,7 +253,7 @@ def generate_udf_schema() -> List[ResolverSpec]:
     def upper(x):
         return x.upper()
 
-    schema = DeclarativeSchema(STANDARD_RESOLVER + generate_udf_schema())
+    schema = DeclarativeSchema(generate_udf_metric_schema())
     why.log(data, schema=schema)
 
     This will attach a UdfMetric to column "col1" that will include a submetric
@@ -287,4 +287,4 @@ def generate_udf_schema() -> List[ResolverSpec]:
         )
         resolvers.append(ResolverSpec(None, col_type, [MetricSpec(UdfMetric, config)]))
 
-    return resolvers
+    return non_udf_resolvers + resolvers

--- a/python/whylogs/experimental/core/metrics/udf_metric.py
+++ b/python/whylogs/experimental/core/metrics/udf_metric.py
@@ -202,6 +202,7 @@ def register_metric_udf(
 
     def decorator_register(func):
         global _col_name_submetrics, _col_name_submetric_schema, _col_name_type_mapper
+        global _col_type_submetrics, _col_type_submetric_schema, _col_type_type_mapper
 
         if col_name is not None and col_type is not None:
             raise ValueError("Only specify one of column name or type")

--- a/python/whylogs/experimental/core/metrics/udf_metric.py
+++ b/python/whylogs/experimental/core/metrics/udf_metric.py
@@ -19,6 +19,7 @@ from whylogs.core.resolvers import (
     ResolverSpec,
     _allowed_metric,
 )
+from whylogs.core.schema import DeclarativeSchema
 
 logger = logging.getLogger(__name__)
 
@@ -237,13 +238,11 @@ def register_metric_udf(
     return decorator_register
 
 
-def generate_udf_metric_schema(non_udf_resolvers: List[ResolverSpec] = STANDARD_RESOLVER) -> List[ResolverSpec]:
+def generate_udf_metric_schema(non_udf_resolvers: List[ResolverSpec] = STANDARD_RESOLVER) -> DeclarativeSchema:
     """
-    Generates a list of ResolverSpecs that implement the UdfMetrics specified
+    Generates a DeclarativeSchema that implement the UdfMetrics specified
     by the @register_metric_udf decorators (in additon to any non_udf_resolvers
-    passed in). The result only includes the UdfMetric, so you may want to pass
-    a list of ResolverSpecs in non_udf_resolvers defining the other metrics you
-    wish to track.
+    passed in).
 
     For example:
 
@@ -255,8 +254,7 @@ def generate_udf_metric_schema(non_udf_resolvers: List[ResolverSpec] = STANDARD_
     def upper(x):
         return x.upper()
 
-    schema = DeclarativeSchema(generate_udf_metric_schema())
-    why.log(data, schema=schema)
+    why.log(data, schema=generate_udf_metric_schema())
 
     This will attach a UdfMetric to column "col1" that will include a submetric
     named "add5" tracking the values in "col1" incremented by 5, and a UdfMetric
@@ -289,4 +287,4 @@ def generate_udf_metric_schema(non_udf_resolvers: List[ResolverSpec] = STANDARD_
         )
         resolvers.append(ResolverSpec(None, col_type, [MetricSpec(UdfMetric, config)]))
 
-    return non_udf_resolvers + resolvers
+    return DeclarativeSchema(non_udf_resolvers + resolvers)

--- a/python/whylogs/experimental/core/metrics/udf_metric.py
+++ b/python/whylogs/experimental/core/metrics/udf_metric.py
@@ -240,9 +240,10 @@ def register_metric_udf(
 def generate_udf_metric_schema(non_udf_resolvers: List[ResolverSpec] = STANDARD_RESOLVER) -> List[ResolverSpec]:
     """
     Generates a list of ResolverSpecs that implement the UdfMetrics specified
-    by the @register_metric_ud decorators (in additon to any non_udf_resolvers
-    passed in). The result only includes the UdfMetric, so you may want to append
-    it to a list of ResolverSpecs defining the other metrics you wish to track.
+    by the @register_metric_udf decorators (in additon to any non_udf_resolvers
+    passed in). The result only includes the UdfMetric, so you may want to pass
+    a list of ResolverSpecs in non_udf_resolvers defining the other metrics you
+    wish to track.
 
     For example:
 


### PR DESCRIPTION
## Description

`s/generate_udf_schema/generate_udf_metric_schema/` in case we need to add `generate_udf_dataset_schema()`.
Adds `non_udf_resolvers` argument with default `STANDARD_RESOLVER` for convenience.

