### PR TITLE
Allow hiding condition count metrics from profile

### DIFF
--- a/python/whylogs/core/metrics/condition_count_metric.py
+++ b/python/whylogs/core/metrics/condition_count_metric.py
@@ -67,6 +67,7 @@ class Condition:
 @dataclass(frozen=True)
 class ConditionCountConfig(MetricConfig):
     conditions: Dict[str, Condition] = field(default_factory=dict)
+    hide_from_profile: bool = False
 
 
 @dataclass(frozen=True)
@@ -74,6 +75,7 @@ class ConditionCountMetric(Metric):
     conditions: Dict[str, Condition]
     total: IntegralComponent
     matches: Dict[str, IntegralComponent] = field(default_factory=dict)
+    hide_from_profile: bool = False
 
     @property
     def namespace(self) -> str:
@@ -152,8 +154,7 @@ class ConditionCountMetric(Metric):
             raise ValueError("ConditionCountMetric.zero() requires ConditionCountConfig argument")
 
         return ConditionCountMetric(
-            conditions=copy(config.conditions),
-            total=IntegralComponent(0),
+            conditions=copy(config.conditions), total=IntegralComponent(0), hide_from_profile=config.hide_from_profile
         )
 
     def to_protobuf(self) -> MetricMessage:

--- a/python/whylogs/migration/uncompound.py
+++ b/python/whylogs/migration/uncompound.py
@@ -114,7 +114,7 @@ def _uncompound_multimetric(col_name: str, metric_name: str, metric: MultiMetric
 def _uncompound_condition_count(
     col_name: str, metric_name: str, metric: ConditionCountMetric, flags: Optional[FeatureFlags] = None
 ) -> Dict[str, ColumnProfileView]:
-    if not _uncompound_condition_count_feature_flag(flags):
+    if metric.hide_from_profile or not _uncompound_condition_count_feature_flag(flags):
         return dict()
 
     result: Dict[str, ColumnProfileView] = dict()


### PR DESCRIPTION
## Description

Adds metric config option to turn off uncompounding a condition count metric instance so we can deprecate validators.
