### PR TITLE
Upload segmented reference profile API

### DIFF
--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -1766,6 +1766,7 @@ category = "main"
 optional = true
 python-versions = ">=3.7"
 files = [
+    {file = "mlflow-skinny-1.30.1.tar.gz", hash = "sha256:54610fc33513b35d58870e9bcab307cd6043ed99e543f93c1f54e7c3b4591553"},
     {file = "mlflow_skinny-1.30.1-py3-none-any.whl", hash = "sha256:6eafa2505c244b6f95258eb555cc720bf7d4898d806e18a84757ac5b28ecc34c"},
 ]
 
@@ -4227,14 +4228,14 @@ watchdog = ["watchdog"]
 
 [[package]]
 name = "whylabs-client"
-version = "0.5.0"
+version = "0.5.1"
 description = "WhyLabs API client"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "whylabs-client-0.5.0.tar.gz", hash = "sha256:cc55b4ce8b62d9945c3cb3dedeac21f1345b178c2f6b71b0dd6a2f0a0a0dbdb8"},
-    {file = "whylabs_client-0.5.0-py3-none-any.whl", hash = "sha256:8de5a24f6b1b96d78002645288fccff5e84d13311fdab69ce8cd6197e611bc24"},
+    {file = "whylabs-client-0.5.1.tar.gz", hash = "sha256:f7aacfab7d176812c2eb4cdeb8c52521eed0d30bc2a0836399798197a513cf04"},
+    {file = "whylabs_client-0.5.1-py3-none-any.whl", hash = "sha256:dc6958d5bb390f1057fe6f513cbce55c4e71d5f8a1461a7c93eb73814089de33"},
 ]
 
 [package.dependencies]
@@ -4412,4 +4413,4 @@ whylabs = ["requests"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.1, <4"
-content-hash = "801b4be1a9f6e85d4e2c3bfe4f4a65a1bd75a95fb0c73554f425960667d8c0e6"
+content-hash = "78ebfb37657415cbc27d85b5abf79da1ff5861adeab8173f1e196d99d87c5846"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -16,7 +16,7 @@ whylogs-sketching = ">=3.4.1.dev3"
 protobuf = ">=3.19.4"
 importlib-metadata = { version = "<4.3", python = "<3.8" }
 typing-extensions = {version = ">=3.10", markers = "python_version < \"4\""}
-whylabs-client = {version = ">=0.4.4, <1"}
+whylabs-client = {version = ">=0.5.1, <1"}
 
 # viz module. Everything after this should be optional
 pybars3 = { version = "^0.9", optional = true }

--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
 from logging import getLogger
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from whylogs.api.reader import Reader, Readers
 from whylogs.api.writer import Writer, Writers
@@ -129,19 +129,23 @@ class ResultSetWriter:
     def write(self, **kwargs: Any) -> List:
         # multi-profile writer
         files = self._result_set.get_writables()
-        statuses = list()
+        statuses: List[Tuple[bool, str]] = list()
         if not files:
             logger.warning("Attempt to write a result set with no writables returned, nothing written!")
-        elif self._writer._reference_profile_name is not None:
-            response = self._writer.write(file=self._result_set, **kwargs)
-            statuses.append(response)
-        else:
-            logger.debug(f"About to write {len(files)} files:")
-            # TODO: special handling of large number of files, handle throttling
-            for view in files:
-                response = self._writer.write(file=view, **kwargs)
+            return statuses
+        if hasattr(self._writer, "_reference_profile_name"):
+            if self._writer._reference_profile_name is not None:
+                # a segmented reference profile name needs to have access to the complete result set
+                response = self._writer.write(file=self._result_set, **kwargs)
                 statuses.append(response)
-            logger.debug(f"Completed writing {len(files)} files!")
+                return statuses
+        logger.debug(f"About to write {len(files)} files:")
+        # TODO: special handling of large number of files, handle throttling
+        for view in files:
+            response = self._writer.write(file=view, **kwargs)
+            statuses.append(response)
+        logger.debug(f"Completed writing {len(files)} files!")
+
         return statuses
 
 

--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -132,6 +132,9 @@ class ResultSetWriter:
         statuses = list()
         if not files:
             logger.warning("Attempt to write a result set with no writables returned, nothing written!")
+        elif self._writer._reference_profile_name is not None:
+            response = self._writer.write(file=self._result_set, **kwargs)
+            statuses.append(response)
         else:
             logger.debug(f"About to write {len(files)} files:")
             # TODO: special handling of large number of files, handle throttling

--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -134,7 +134,7 @@ class ResultSetWriter:
             logger.warning("Attempt to write a result set with no writables returned, nothing written!")
             return statuses
         if hasattr(self._writer, "_reference_profile_name"):
-            if self._writer._reference_profile_name is not None:
+            if self._writer._reference_profile_name is not None and isinstance(self._result_set, SegmentedResultSet):
                 # a segmented reference profile name needs to have access to the complete result set
                 response = self._writer.write(file=self._result_set, **kwargs)
                 statuses.append(response)

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -484,7 +484,7 @@ class WhyLabsWriter(Writer):
             self._dataset_id = kwargs.get("dataset_id")
 
         result = self._do_get_feature_weights()
-        feature_weights_set = result.get("segmentWeights")
+        feature_weights_set = result.get("segment_weights")
         metadata = result.get("metadata")
         if feature_weights_set and isinstance(feature_weights_set, list):
             feature_weights = FeatureWeights(weights=feature_weights_set[0]["weights"], metadata=metadata)

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -491,7 +491,7 @@ class WhyLabsWriter(Writer):
             return feature_weights
         return None
 
-    def write_segmented_reference_result_set(self, file: SegmentedResultSet, **kwargs: Any) -> Tuple[bool, str]:
+    def _write_segmented_reference_result_set(self, file: SegmentedResultSet, **kwargs: Any) -> Tuple[bool, str]:
         """Put segmented reference result set for the specified dataset.
 
         Parameters
@@ -556,7 +556,7 @@ class WhyLabsWriter(Writer):
         elif isinstance(file, EstimationResult):
             return self.write_estimation_result(file, **kwargs)
         elif isinstance(file, SegmentedResultSet) and self._reference_profile_name is not None:
-            return self.write_segmented_reference_result_set(file, **kwargs)
+            return self._write_segmented_reference_result_set(file, **kwargs)
         view = file.view() if isinstance(file, DatasetProfile) else file
         has_segments = isinstance(view, SegmentedDatasetProfileView)
 

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -11,6 +11,7 @@ import requests  # type: ignore
 import whylabs_client  # type: ignore
 from urllib3 import PoolManager, ProxyManager
 from whylabs_client import ApiClient, Configuration  # type: ignore
+from whylabs_client.api.dataset_profile_api import DatasetProfileApi
 from whylabs_client.api.feature_weights_api import FeatureWeightsApi
 from whylabs_client.api.log_api import AsyncLogResponse  # type: ignore
 from whylabs_client.api.log_api import (
@@ -21,10 +22,16 @@ from whylabs_client.api.log_api import (
 )
 from whylabs_client.api.models_api import ModelsApi
 from whylabs_client.model.column_schema import ColumnSchema
+from whylabs_client.model.create_reference_profile_request import (
+    CreateReferenceProfileRequest,
+)
+from whylabs_client.model.segment import Segment
+from whylabs_client.model.segment_tag import SegmentTag
 from whylabs_client.rest import ForbiddenException  # type: ignore
 
 from whylogs import __version__ as _version
 from whylogs.api.logger import log
+from whylogs.api.logger.result_set import SegmentedResultSet
 from whylogs.api.writer import Writer
 from whylogs.api.writer.writer import Writable
 from whylogs.core import DatasetProfileView
@@ -36,6 +43,7 @@ from whylogs.core.view.segmented_dataset_profile_view import SegmentedDatasetPro
 from whylogs.experimental.performance_estimation.estimation_results import (
     EstimationResult,
 )
+from whylogs.migration.converters import _generate_segment_tags_metadata
 from whylogs.migration.uncompound import (
     FeatureFlags,
     _uncompound_dataset_profile,
@@ -483,13 +491,62 @@ class WhyLabsWriter(Writer):
             return feature_weights
         return None
 
+    def write_segmented_reference_result_set(self, file: SegmentedResultSet, **kwargs: Any):
+        utc_now = datetime.datetime.now(datetime.timezone.utc)
+
+        files = file.get_writables()
+        partitions = file.partitions
+        if len(partitions) > 1:
+            logger.warning(
+                "SegmentedResultSet contains more than one partition. Only the first partition will be uploaded. "
+            )
+        partition = partitions[0]
+        whylabs_tags = list()
+        for view in files:
+            view_tags = list()
+            dataset_timestamp = view.dataset_timestamp or utc_now
+            if view.partition.id != partition.id:
+                continue
+            _, segment_tags, _ = _generate_segment_tags_metadata(view.segment, view.partition)
+            for segment_tag in segment_tags:
+                tag_key = segment_tag.key.replace("whylogs.tag.", "")
+                tag_value = segment_tag.value
+                view_tags.append({"key": tag_key, "value": tag_value})
+            whylabs_tags.append(view_tags)
+        stamp = dataset_timestamp.timestamp()
+        dataset_timestamp_epoch = int(stamp * 1000)
+        res = self._get_upload_urls_segmented_reference(whylabs_tags, dataset_timestamp_epoch)
+        profile_id = res["id"]
+        upload_statuses = list()
+        for view, url in zip(files, res["upload_urls"]):
+            with tempfile.NamedTemporaryFile() as tmp_file:
+                if kwargs.get("use_v0") is None or kwargs.get("use_v0"):
+                    view.write(file=tmp_file, use_v0=True)
+                else:
+                    view.write(file=tmp_file)
+                tmp_file.flush()
+                tmp_file.seek(0)
+
+                upload_res = self._do_upload(
+                    dataset_timestamp=dataset_timestamp_epoch,
+                    upload_url=url,
+                    profile_id=profile_id,
+                    profile_file=tmp_file,
+                )
+                upload_statuses.append(upload_res)
+        if all([status[0] for status in upload_statuses]):
+            return upload_statuses[0]
+        else:
+            return False, "Failed to upload all segments"
+
     @deprecated_alias(profile="file")
     def write(self, file: Writable, **kwargs: Any) -> Tuple[bool, str]:
         if isinstance(file, FeatureWeights):
             return self.write_feature_weights(file, **kwargs)
         elif isinstance(file, EstimationResult):
             return self.write_estimation_result(file, **kwargs)
-
+        elif isinstance(file, SegmentedResultSet) and self._reference_profile_name is not None:
+            return self.write_segmented_reference_result_set(file, **kwargs)
         view = file.view() if isinstance(file, DatasetProfile) else file
         has_segments = isinstance(view, SegmentedDatasetProfileView)
 
@@ -553,8 +610,12 @@ class WhyLabsWriter(Writer):
                 )
 
             dataset_timestamp_epoch = int(stamp * 1000)
+            logger.debug("Generating the upload URL")
+            upload_url, profile_id = self._get_upload_url(dataset_timestamp=dataset_timestamp_epoch)
             response = self._do_upload(
                 dataset_timestamp=dataset_timestamp_epoch,
+                upload_url=upload_url,
+                profile_id=profile_id,
                 profile_file=tmp_file,
             )
         # TODO: retry
@@ -619,13 +680,18 @@ class WhyLabsWriter(Writer):
         return is_successful, response.reason
 
     def _do_upload(
-        self, dataset_timestamp: int, profile_path: Optional[str] = None, profile_file: Optional[IO[bytes]] = None
+        self,
+        dataset_timestamp: int,
+        upload_url: str,
+        profile_id: str,
+        profile_path: Optional[str] = None,
+        profile_file: Optional[IO[bytes]] = None,
     ) -> Tuple[bool, str]:
         assert profile_path or profile_file, "Either a file or file path must be specified when uploading profiles"
         self._validate_org_and_dataset()
 
-        logger.debug("Generating the upload URL")
-        upload_url, profile_id = self._get_upload_url(dataset_timestamp=dataset_timestamp)
+        # logger.debug("Generating the upload URL")
+        # upload_url, profile_id = self._get_upload_url(dataset_timestamp=dataset_timestamp)
         try:
             if profile_file:
                 status, reason = self._put_file(profile_file, upload_url, dataset_timestamp)
@@ -653,6 +719,9 @@ class WhyLabsWriter(Writer):
     def _get_or_create_api_log_client(self) -> LogApi:
         return LogApi(self._api_client)
 
+    def _get_or_create_api_dataset_client(self) -> DatasetProfileApi:
+        return DatasetProfileApi(self._api_client)
+
     @staticmethod
     def _build_log_async_request(dataset_timestamp: int) -> LogAsyncRequest:
         return LogAsyncRequest(dataset_timestamp=dataset_timestamp, segment_tags=[])
@@ -660,6 +729,15 @@ class WhyLabsWriter(Writer):
     @staticmethod
     def _build_log_reference_request(dataset_timestamp: int, alias: Optional[str] = None) -> LogReferenceRequest:
         return LogReferenceRequest(dataset_timestamp=dataset_timestamp, alias=alias)
+
+    @staticmethod
+    def _build_log_segmented_reference_request(
+        dataset_timestamp: int, tags: Optional[dict], alias: Optional[str] = None
+    ) -> LogReferenceRequest:
+        segments = list()
+        for segment_tags in tags:
+            segments.append(Segment(tags=[SegmentTag(key=tag["key"], value=tag["value"]) for tag in segment_tags]))
+        return CreateReferenceProfileRequest(alias=alias, dataset_timestamp=dataset_timestamp, segments=segments)
 
     def _get_column_weights(self):
         feature_weight_api = self._get_or_create_feature_weights_client()
@@ -762,6 +840,33 @@ class WhyLabsWriter(Writer):
         log_api = self._get_or_create_api_log_client()
         try:
             result = log_api.log_async(org_id=self._org_id, dataset_id=self._dataset_id, log_async_request=request)
+            return result
+        except ForbiddenException as e:
+            logger.exception(
+                f"Failed to upload {self._org_id}/{self._dataset_id}/{dataset_timestamp} to "
+                f"{self.whylabs_api_endpoint}"
+                f" with API token ID: {self.key_id}"
+            )
+            raise e
+
+    def _get_upload_urls_segmented_reference(self, whylabs_tags, dataset_timestamp: int):
+        request = self._build_log_segmented_reference_request(
+            dataset_timestamp, tags=whylabs_tags, alias=self._reference_profile_name
+        )
+        res = self._post_log_segmented_reference(request=request, dataset_timestamp=dataset_timestamp)
+        return res
+
+    def _post_log_segmented_reference(self, request: LogAsyncRequest, dataset_timestamp: int) -> LogReferenceResponse:
+        dataset_api = self._get_or_create_api_dataset_client()
+        try:
+            async_result = dataset_api.create_reference_profile(
+                org_id=self._org_id,
+                dataset_id=self._dataset_id,
+                create_reference_profile_request=request,
+                async_req=True,
+            )
+
+            result = async_result.get()
             return result
         except ForbiddenException as e:
             logger.exception(


### PR DESCRIPTION
## Description

Enables uploading segmented reference profiles.
Usage: just as you'd upload regular reference profiles, but instead, pass a SegmentedResultSet to it (see `test_whylabs.py`)

Since, to generate the URLs, we need the complete ResultSet, a SegmentedResultSet is passed to `write`. In the whylabs writer, if a `SegmentedResultSet` is passed along with a `reference_profile_name`, `the write_segmented_reference_profile is called`.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
