### PR TITLE
Support segmentation on dataset UDF output

### DIFF
--- a/python/tests/experimental/core/metrics/test_udf_metric.py
+++ b/python/tests/experimental/core/metrics/test_udf_metric.py
@@ -157,7 +157,6 @@ def test_decorator() -> None:
     assert "udf/square:cardinality/est" in col2_summary
 
     col4_summary = col4_view.to_summary_dict()
-    print(col4_summary)
     assert "udf/upper:counts/n" in col4_summary
     assert "udf/upper:types/integral" in col4_summary
     assert "udf/upper:distribution/n" in col4_summary

--- a/python/tests/experimental/core/test_udf_schema.py
+++ b/python/tests/experimental/core/test_udf_schema.py
@@ -5,6 +5,7 @@ from whylogs.core.dataset_profile import DatasetProfile
 from whylogs.core.datatypes import Fractional, Integral, String
 from whylogs.core.metrics import StandardMetric
 from whylogs.core.resolvers import STANDARD_RESOLVER, MetricSpec, ResolverSpec
+from whylogs.core.segmentation_partition import segment_on_column
 from whylogs.experimental.core.metrics.udf_metric import register_metric_udf
 from whylogs.experimental.core.udf_schema import (
     UdfSchema,
@@ -12,7 +13,6 @@ from whylogs.experimental.core.udf_schema import (
     register_dataset_udf,
     udf_schema,
 )
-from whylogs.core.segmentation_partition import segment_on_column
 
 
 def test_udf_row() -> None:
@@ -200,7 +200,7 @@ def test_udf_metric_resolving() -> None:
 
 def test_udf_segmentation_pandas() -> None:
     column_segments = segment_on_column("product")
-    segmented_schema=udf_schema(segments=column_segments)
+    segmented_schema = udf_schema(segments=column_segments)
     data = pd.DataFrame({"col1": [42, 12, 7], "col2": [2, 3, 4], "col3": [2, 3, 4]})
     results = why.log(pandas=data, schema=segmented_schema)
     assert len(results.segments()) == 3
@@ -208,7 +208,7 @@ def test_udf_segmentation_pandas() -> None:
 
 def test_udf_segmentation_row() -> None:
     column_segments = segment_on_column("product")
-    segmented_schema=udf_schema(segments=column_segments)
+    segmented_schema = udf_schema(segments=column_segments)
     data = {"col1": 42, "col2": 2, "col3": 2}
     results = why.log(row=data, schema=segmented_schema)
     assert len(results.segments()) == 1
@@ -216,14 +216,14 @@ def test_udf_segmentation_row() -> None:
 
 def test_udf_segmentation_obj() -> None:
     column_segments = segment_on_column("product")
-    segmented_schema=udf_schema(segments=column_segments)
+    segmented_schema = udf_schema(segments=column_segments)
     data = {"col1": 42, "col2": 2, "col3": 2}
     results = why.log(data, schema=segmented_schema)
     assert len(results.segments()) == 1
 
 
 def test_udf_track() -> None:
-    schema=udf_schema()
+    schema = udf_schema()
     prof = DatasetProfile(schema)
     data = pd.DataFrame({"col1": [42, 12, 7], "col2": [2, 3, 4], "col3": [2, 3, 4]})
     prof.track(data)

--- a/python/tests/experimental/core/test_udf_schema.py
+++ b/python/tests/experimental/core/test_udf_schema.py
@@ -11,6 +11,7 @@ from whylogs.experimental.core.udf_schema import (
     register_dataset_udf,
     udf_schema,
 )
+from whylogs.core.segmentation_partition import segment_on_column
 
 
 def test_udf_row() -> None:
@@ -192,3 +193,11 @@ def test_udf_metric_resolving() -> None:
     assert "add5" in results.get_columns()
     foo_summary = results.get_column("foo").to_summary_dict()
     assert "udf/bar:counts/n" in foo_summary
+
+
+def test_udf_segmentation() -> None:
+    column_segments = segment_on_column("product")
+    segmented_schema=udf_schema(segments=column_segments)
+    data = pd.DataFrame({"col1": [42, 12, 7], "col2": [2, 3, 4], "col3": [2, 3, 4]})
+    results = why.log(pandas=data, schema=segmented_schema)
+    assert len(results.segments()) == 3

--- a/python/whylogs/api/logger/logger.py
+++ b/python/whylogs/api/logger/logger.py
@@ -85,6 +85,8 @@ class Logger(ABC):
             raise LoggingError("log() was called without passing in any input!")
 
         active_schema = schema or self._schema
+        if active_schema:
+            pandas, row = active_schema._run_udfs(pandas, row)
 
         # If segments are defined use segment_processing to return a SegmentedResultSet
         if active_schema and active_schema.segments:

--- a/python/whylogs/api/logger/logger.py
+++ b/python/whylogs/api/logger/logger.py
@@ -98,7 +98,7 @@ class Logger(ABC):
         profiles = self._get_matching_profiles(obj, pandas=pandas, row=row, schema=active_schema)
 
         for prof in profiles:
-            prof.track(obj, pandas=pandas, row=row)
+            prof.track(obj, pandas=pandas, row=row, execute_udfs=False)
 
         return ProfileResultSet(profiles[0])
 

--- a/python/whylogs/api/logger/logger.py
+++ b/python/whylogs/api/logger/logger.py
@@ -9,6 +9,7 @@ from whylogs.api.store import ProfileStore
 from whylogs.api.writer import Writer, Writers
 from whylogs.core import DatasetProfile, DatasetSchema
 from whylogs.core.errors import LoggingError
+from whylogs.core.input_resolver import _pandas_or_dict
 from whylogs.core.stubs import pd
 
 logger = logging.getLogger(__name__)
@@ -86,6 +87,8 @@ class Logger(ABC):
 
         active_schema = schema or self._schema
         if active_schema:
+            pandas, row = _pandas_or_dict(obj, pandas, row)
+            obj = None
             pandas, row = active_schema._run_udfs(pandas, row)
 
         # If segments are defined use segment_processing to return a SegmentedResultSet

--- a/python/whylogs/api/logger/segment_processing.py
+++ b/python/whylogs/api/logger/segment_processing.py
@@ -29,7 +29,7 @@ def _process_segment(
     if profile is None:
         profile = DatasetProfile(schema)
 
-    profile.track(segmented_data)
+    profile.track(segmented_data, execute_udfs=False)
     segments[segment_key] = profile
 
 

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -123,7 +123,6 @@ class DatasetProfile(Writable):
         row: Optional[Mapping[str, Any]] = None,
     ) -> None:
         pandas, row = _pandas_or_dict(obj, pandas, row)
-        pandas, row = self._schema._run_udfs(pandas, row)
         col_id = getattr(self._schema.default_configs, "identity_column", None)
 
         # TODO: do this less frequently when operating at row level

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -107,11 +107,12 @@ class DatasetProfile(Writable):
         *,
         pandas: Optional[pd.DataFrame] = None,
         row: Optional[Mapping[str, Any]] = None,
+        execute_udfs: bool = True,
     ) -> None:
         try:
             self._is_active = True
             self._track_count += 1
-            self._do_track(obj, pandas=pandas, row=row)
+            self._do_track(obj, pandas=pandas, row=row, execute_udfs=execute_udfs)
         finally:
             self._is_active = False
 
@@ -121,8 +122,12 @@ class DatasetProfile(Writable):
         *,
         pandas: Optional[pd.DataFrame] = None,
         row: Optional[Mapping[str, Any]] = None,
+        execute_udfs: bool = True,
     ) -> None:
         pandas, row = _pandas_or_dict(obj, pandas, row)
+        if execute_udfs:
+            pandas, rows = self._schema._run_udfs(pandas, row)
+
         col_id = getattr(self._schema.default_configs, "identity_column", None)
 
         # TODO: do this less frequently when operating at row level

--- a/python/whylogs/experimental/core/udf_schema.py
+++ b/python/whylogs/experimental/core/udf_schema.py
@@ -91,7 +91,7 @@ class UdfSchema(DeclarativeSchema):
     def _run_udfs_on_row(self, row: Mapping[str, Any], new_columns: Dict[str, Any]) -> None:
         for spec in self.multicolumn_udfs:
             if set(spec.column_names).issubset(set(row.keys())):
-                _apply_udfs_on_dataframe(row, spec.udfs, new_columns)
+                _apply_udfs_on_row(row, spec.udfs, new_columns)
 
     def _run_udfs_on_dataframe(self, pandas: pd.DataFrame, new_df: pd.DataFrame) -> None:
         for spec in self.multicolumn_udfs:


### PR DESCRIPTION
## Description

Move UDF evaluation from `DatasetProfile::track()` to `Logger::log()` to support segmentation on UDF output.

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
