### PR TITLE
change alias to None if empty string

### DIFF
--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -746,6 +746,8 @@ class WhyLabsWriter(Writer):
         dataset_timestamp: int, tags: Optional[dict] = None, alias: Optional[str] = None
     ) -> LogReferenceRequest:
         segments = list()
+        if not alias:
+            alias = None
         if tags is not None:
             for segment_tags in tags:
                 segments.append(Segment(tags=[SegmentTag(key=tag["key"], value=tag["value"]) for tag in segment_tags]))


### PR DESCRIPTION
## Description

When uploading a segmented reference profile to whylabs, if passing an empty string "" as alias, an error is raised. This changes an empty string to None to prevent the error and behave as intended - generating an alias in the format `ref-{timestamp}`

closes https://github.com/whylabs/whylogs/issues/1254

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
