### PR TITLE
Alternate configurable MetricConfig defaults

### DIFF
--- a/python/tests/core/metrics/test_metrics.py
+++ b/python/tests/core/metrics/test_metrics.py
@@ -5,7 +5,9 @@ import pandas as pd
 import pytest
 
 import whylogs as why
+import whylogs.core.configs as cfg
 from whylogs.core import ColumnProfileView, DatasetSchema
+from whylogs.core.datatypes import Integral
 from whylogs.core.metrics.maths import VarianceM2Result, parallel_variance_m2
 from whylogs.core.metrics.metrics import (
     CardinalityMetric,
@@ -13,6 +15,8 @@ from whylogs.core.metrics.metrics import (
     MetricConfig,
 )
 from whylogs.core.preprocessing import PreprocessedColumn
+from whylogs.core.resolvers import StandardResolver
+from whylogs.core.schema import ColumnSchema
 
 TEST_LOGGER = getLogger(__name__)
 
@@ -262,3 +266,16 @@ def test_cardinality_metric_booleans_all_false() -> None:
     col_prof = why.log(df).view().get_column("b")
     cardinality: CardinalityMetric = col_prof.get_metric("cardinality")
     assert cardinality.estimate == pytest.approx(1, 0.1)
+
+
+def test_configure_MetricConfig_defaults():
+    c0 = MetricConfig()
+    assert c0.kll_k == cfg.kll_k
+    assert not c0.fi_disabled
+    assert "frequent_items" in StandardResolver().resolve("", Integral(), ColumnSchema(Integral, c0))
+    cfg.fi_disabled = True
+    c1 = MetricConfig()
+    assert c1.fi_disabled
+    assert not c0.fi_disabled
+    assert "frequent_items" not in StandardResolver().resolve("", Integral(), ColumnSchema(Integral, c1))
+    cfg.fi_disabled = False

--- a/python/tests/core/test_performance.py
+++ b/python/tests/core/test_performance.py
@@ -31,7 +31,7 @@ _TEST_RESOLVERS = [HistogramCountingTrackingResolver(), LimitedTrackingResolver(
 @dataclass
 class CustomHistogramMetric:
     histogram: ds.kll_floats_sketch = field(
-        default=ds.kll_floats_sketch(MetricConfig.kll_k),
+        default=ds.kll_floats_sketch(MetricConfig().kll_k),
     )
 
     def track(self, val: Any) -> "CustomHistogramMetric":

--- a/python/whylogs/core/configs.py
+++ b/python/whylogs/core/configs.py
@@ -1,8 +1,31 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List
+from typing import Dict, List, Optional, Tuple
 
 import whylogs_sketching as ds  # type: ignore
+
+# MetricConfig default values
+
+hll_lg_k: int = 12
+kll_k: int = 256
+fi_lg_max_k: int = 10  # 128 entries
+fi_disabled: bool = False
+track_unicode_ranges: bool = False
+large_kll_k: bool = True
+kll_k_large: int = 1024
+unicode_ranges: Dict[str, Tuple[int, int]] = {
+    "emoticon": (0x1F600, 0x1F64F),
+    "control": (0x00, 0x1F),
+    "digits": (0x30, 0x39),
+    "latin-upper": (0x41, 0x5A),
+    "latin-lower": (0x61, 0x7A),
+    "basic-latin": (0x00, 0x7F),
+    "extended-latin": (0x0080, 0x02AF),
+}
+lower_case: bool = True  # Convert Unicode characters to lower-case before counting Unicode ranges
+normalize: bool = True  # Unicode normalize strings before counting Unicode ranges
+max_frequent_item_size: int = 128
+identity_column: Optional[str] = None
 
 
 class FrequentItemsErrorType(int, Enum):

--- a/python/whylogs/core/metrics/metrics.py
+++ b/python/whylogs/core/metrics/metrics.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 import whylogs_sketching as ds  # type: ignore
 from google.protobuf.struct_pb2 import Struct
 
-from whylogs.core.configs import SummaryConfig
+import whylogs.core.configs as conf
 from whylogs.core.metrics.maths import (
     VarianceM2Result,
     parallel_variance_m2,
@@ -37,28 +37,18 @@ METRIC = TypeVar("METRIC", bound="Metric")
 
 @dataclass(frozen=True)
 class MetricConfig:
-    hll_lg_k: int = 12
-    kll_k: int = 256
-    fi_lg_max_k: int = 10  # 128 entries
-    fi_disabled: bool = False
-    track_unicode_ranges: bool = False
-    large_kll_k: bool = True
-    kll_k_large: int = 1024
-    unicode_ranges: Dict[str, Tuple[int, int]] = field(
-        default_factory=lambda: {
-            "emoticon": (0x1F600, 0x1F64F),
-            "control": (0x00, 0x1F),
-            "digits": (0x30, 0x39),
-            "latin-upper": (0x41, 0x5A),
-            "latin-lower": (0x61, 0x7A),
-            "basic-latin": (0x00, 0x7F),
-            "extended-latin": (0x0080, 0x02AF),
-        }
-    )
-    lower_case: bool = True  # Convert Unicode characters to lower-case before counting Unicode ranges
-    normalize: bool = True  # Unicode normalize strings before counting Unicode ranges
-    max_frequent_item_size: int = 128
-    identity_column: Optional[str] = None
+    hll_lg_k: int = field(default_factory=lambda: conf.hll_lg_k)
+    kll_k: int = field(default_factory=lambda: conf.kll_k)
+    fi_lg_max_k: int = field(default_factory=lambda: conf.fi_lg_max_k)
+    fi_disabled: bool = field(default_factory=lambda: conf.fi_disabled)
+    track_unicode_ranges: bool = field(default_factory=lambda: conf.track_unicode_ranges)
+    large_kll_k: bool = field(default_factory=lambda: conf.large_kll_k)
+    kll_k_large: int = field(default_factory=lambda: conf.kll_k_large)
+    unicode_ranges: Dict[str, Tuple[int, int]] = field(default_factory=lambda: dict(conf.unicode_ranges))
+    lower_case: bool = field(default_factory=lambda: conf.lower_case)
+    normalize: bool = field(default_factory=lambda: conf.normalize)
+    max_frequent_item_size: int = field(default_factory=lambda: conf.max_frequent_item_size)
+    identity_column: Optional[str] = field(default_factory=lambda: conf.identity_column)
 
 
 _METRIC_DESERIALIZER_REGISTRY: Dict[str, Type[METRIC]] = {}  # type: ignore
@@ -132,7 +122,7 @@ class Metric(ABC):
         return res
 
     @abstractmethod
-    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[conf.SummaryConfig] = None) -> Dict[str, Any]:
         raise NotImplementedError
 
     @abstractmethod
@@ -202,7 +192,7 @@ class IntsMetric(Metric):
     def zero(cls, config: Optional[MetricConfig] = None) -> "IntsMetric":
         return IntsMetric(max=MaxIntegralComponent(-sys.maxsize), min=MinIntegralComponent(sys.maxsize))
 
-    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Union[int, float, str, None]]:
+    def to_summary_dict(self, cfg: Optional[conf.SummaryConfig] = None) -> Dict[str, Union[int, float, str, None]]:
         return {"max": self.maximum, "min": self.minimum}
 
     @property
@@ -227,7 +217,7 @@ class DistributionMetric(Metric):
     def namespace(self) -> str:
         return "distribution"
 
-    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Union[int, float, str, None]]:
+    def to_summary_dict(self, cfg: Optional[conf.SummaryConfig] = None) -> Dict[str, Union[int, float, str, None]]:
         if self.n == 0:
             quantiles = [None, None, None, None, None, None, None, None, None]
         else:
@@ -471,8 +461,8 @@ class FrequentItemsMetric(Metric):
 
         return OperationResult(successes=successes, failures=failures)
 
-    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Any]:
-        cfg = cfg or SummaryConfig()
+    def to_summary_dict(self, cfg: Optional[conf.SummaryConfig] = None) -> Dict[str, Any]:
+        cfg = cfg or conf.SummaryConfig()
         all_freq_items = self.frequent_strings.value.get_frequent_items(
             cfg.frequent_items_error_type.to_datasketches_type()
         )
@@ -553,8 +543,8 @@ class CardinalityMetric(Metric):
             failures = len(view.list.objs)
         return OperationResult(successes=successes, failures=failures)
 
-    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Any]:
-        cfg = cfg or SummaryConfig()
+    def to_summary_dict(self, cfg: Optional[conf.SummaryConfig] = None) -> Dict[str, Any]:
+        cfg = cfg or conf.SummaryConfig()
         return {
             "est": self.hll.value.get_estimate(),
             f"upper_{cfg.hll_stddev}": self.hll.value.get_upper_bound(cfg.hll_stddev),
@@ -621,7 +611,7 @@ class CustomMetricBase(Metric, ABC):
     def get_component_paths(self) -> List[str]:
         return [_STRUCT_NAME]  # Assumes everything to be serde'd will be in the Struct
 
-    def to_summary_dict(self, cfg: Optional[SummaryConfig] = None) -> Dict[str, Any]:
+    def to_summary_dict(self, cfg: Optional[conf.SummaryConfig] = None) -> Dict[str, Any]:
         return asdict(self, dict_factory=_drop_private_fields)
 
     def to_protobuf(self) -> MetricMessage:

--- a/python/whylogs/core/resolvers.py
+++ b/python/whylogs/core/resolvers.py
@@ -37,7 +37,8 @@ class StandardResolver(Resolver):
             metrics.append(StandardMetric.distribution)
             metrics.append(StandardMetric.ints)
             metrics.append(StandardMetric.cardinality)
-            metrics.append(StandardMetric.frequent_items)
+            if not column_schema.cfg.fi_disabled:
+                metrics.append(StandardMetric.frequent_items)
         elif isinstance(why_type, Fractional):
             metrics.append(StandardMetric.cardinality)
             metrics.append(StandardMetric.distribution)
@@ -46,10 +47,8 @@ class StandardResolver(Resolver):
             if column_schema.cfg.track_unicode_ranges:
                 metrics.append(StandardMetric.unicode_range)
             metrics.append(StandardMetric.distribution)  # 'object' columns can contain Decimal
-            metrics.append(StandardMetric.frequent_items)
-
-        if column_schema.cfg.fi_disabled:
-            metrics.remove(StandardMetric.frequent_items)
+            if not column_schema.cfg.fi_disabled:
+                metrics.append(StandardMetric.frequent_items)
 
         result: Dict[str, Metric] = {}
         for m in metrics:


### PR DESCRIPTION
## Description

Alternative to #1246 

Lets users change globals in whylogs/core/configs.py to set the default values for MetricConfig.

[clickup](https://app.clickup.com/t/866ab6rhg)

## Changes

- Default `MetricConfig` values are now globals in `configs.py`
- `MetricConfig` fields all get default factories that use the value of the corresponding global in `configs.py`
- Also fixes a couple of minor related bugs

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
