### PR TITLE
make resultsets/estimation result writables

### DIFF
--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from datetime import datetime
 from logging import getLogger
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -161,7 +161,7 @@ class ResultSetReader:
         return self._reader.read(**kwargs)
 
 
-class ResultSet(ABC):
+class ResultSet(Writable):
     """
     A holder object for profiling results.
 
@@ -269,6 +269,13 @@ class ViewResultSet(ResultSet):
         else:
             view.set_dataset_timestamp(dataset_timestamp)
 
+    def write(self, path: Optional[str] = None, **kwargs: Any) -> Tuple[bool, str]:
+        return self._view.write(path=path, **kwargs)
+
+    @staticmethod
+    def get_default_path(self) -> str:
+        return self._view.get_default_path()
+
 
 class ProfileResultSet(ResultSet):
     def __init__(self, profile: DatasetProfile) -> None:
@@ -292,6 +299,13 @@ class ProfileResultSet(ResultSet):
         if not isinstance(other, (ProfileResultSet, ViewResultSet)):
             logger.error(f"Merging potentially incompatible ProfileResultSet and {type(other)}")
         return ViewResultSet(lhs_profile.merge(other.view()))
+
+    def write(self, path: Optional[str] = None, **kwargs: Any) -> Tuple[bool, str]:
+        return self._profile.write(path=path, **kwargs)
+
+    @staticmethod
+    def get_default_path(self) -> str:
+        return self._profile.get_default_path()
 
 
 class SegmentedResultSet(ResultSet):
@@ -495,3 +509,9 @@ class SegmentedResultSet(ResultSet):
             return SegmentedResultSet(merged_segments, merged_partitions, metrics=merged_metrics, properties=properties)
         else:
             raise ValueError(f"Cannot merge incompatible SegmentedResultSet and {type(other)}")
+
+    def get_default_path(self) -> str:
+        return ""
+
+    def write(self, path: Optional[str] = None, **kwargs: Any) -> Tuple[bool, str]:
+        return (False, "write() not implemented for SegmentedResultSet, use with supported writers.")

--- a/python/whylogs/api/writer/gcs.py
+++ b/python/whylogs/api/writer/gcs.py
@@ -65,7 +65,9 @@ class GCSWriter(Writer):
         blob = bucket.blob(self.object_name)
         try:
             with tempfile.NamedTemporaryFile() as tmp_file:
-                file.write(path=tmp_file.name)  # type: ignore
+                result = file.write(path=tmp_file.name)  # type: ignore
+                if result[0] is False:
+                    return result
                 tmp_file.flush()
                 blob.upload_from_filename(tmp_file.name)
         except exceptions.Forbidden as e:

--- a/python/whylogs/api/writer/local.py
+++ b/python/whylogs/api/writer/local.py
@@ -25,7 +25,9 @@ class LocalWriter(Writer):
     ) -> Tuple[bool, str]:
         dest = dest or self._base_name or file.get_default_path()  # type: ignore
         full_path = os.path.join(self._base_dir, dest)
-        file.write(full_path, **kwargs)
+        res = file.write(full_path, **kwargs)
+        if not res[0]:
+            return res
         return True, full_path
 
     def option(self, base_dir: Optional[str] = None, base_name: Optional[str] = None) -> "LocalWriter":  # type: ignore

--- a/python/whylogs/api/writer/s3.py
+++ b/python/whylogs/api/writer/s3.py
@@ -75,8 +75,10 @@ class S3Writer(Writer):
             self.object_name = dest
         try:
             with tempfile.NamedTemporaryFile() as tmp_file:
-                file.write(path=tmp_file.name)  # type: ignore
+                result = file.write(path=tmp_file.name)  # type: ignore
                 tmp_file.flush()
+                if not result[0]:
+                    return result
                 self.s3_client.upload_file(tmp_file.name, self.bucket_name, self.object_name)
         except ClientError as e:
             logging.error(e)

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -585,11 +585,13 @@ class WhyLabsWriter(Writer):
             # so we default to sending them as v0 profiles if the override `use_v0` is not defined,
             # if `use_v0` is defined then pass that through to control the serialization format.
             if has_segments and (kwargs.get("use_v0") is None or kwargs.get("use_v0")):
-                view.write(file=tmp_file, use_v0=True)
+                result = view.write(file=tmp_file, use_v0=True)
             else:
-                view.write(file=tmp_file)
+                result = view.write(file=tmp_file)
             tmp_file.flush()
             tmp_file.seek(0)
+            if not result[0]:
+                return result
             utc_now = datetime.datetime.now(datetime.timezone.utc)
             dataset_timestamp = view.dataset_timestamp or utc_now
             stamp = dataset_timestamp.timestamp()
@@ -746,6 +748,8 @@ class WhyLabsWriter(Writer):
         dataset_timestamp: int, tags: Optional[dict] = None, alias: Optional[str] = None
     ) -> LogReferenceRequest:
         segments = list()
+        if not alias:
+            alias = None
         if tags is not None:
             for segment_tags in tags:
                 segments.append(Segment(tags=[SegmentTag(key=tag["key"], value=tag["value"]) for tag in segment_tags]))

--- a/python/whylogs/experimental/performance_estimation/estimation_results.py
+++ b/python/whylogs/experimental/performance_estimation/estimation_results.py
@@ -1,13 +1,14 @@
 from datetime import datetime
 from logging import getLogger
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
 from whylogs.api.writer import Writer, Writers
+from whylogs.api.writer.writer import Writable
 
 logger = getLogger(__name__)
 
 
-class EstimationResult:
+class EstimationResult(Writable):
     """
     The result of a performance estimation.
     accuracy: The estimated accuracy.
@@ -32,6 +33,12 @@ class EstimationResult:
             raise ValueError("Only whylabs writer is currently supported")
         writer = Writers.get(name)
         return EstimationResultWriter(results=self, writer=writer)
+
+    def get_default_path(self) -> str:
+        return ""
+
+    def write(self, path: Optional[str] = None, **kwargs: Any) -> Tuple[bool, str]:
+        return (False, "write() not implemented for EstimationResult, use with supported writers.")
 
 
 class EstimationResultWriter:

--- a/python/whylogs/viz/extensions/reports/html_report.py
+++ b/python/whylogs/viz/extensions/reports/html_report.py
@@ -1,6 +1,6 @@
 import html
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
 from IPython.core.display import HTML  # type: ignore
 
@@ -37,7 +37,7 @@ class HTMLReport(Writable, ABC):
     def report(self) -> HTML:
         pass
 
-    def write(self, path: Optional[str] = None, **kwargs: Any) -> None:
+    def write(self, path: Optional[str] = None, **kwargs: Any) -> Tuple[bool, str]:
         """Create HTML file for a given report.
 
         Parameters
@@ -61,6 +61,7 @@ class HTMLReport(Writable, ABC):
         _rendered_html = _html.data
         with self._safe_open_write(path) as file:
             file.write(_rendered_html)
+        return True, path
 
     def option(self):
         return self


### PR DESCRIPTION
## Description

Currently, non-Writable objects were being passed to WhyLabs Writers, which expected a ]Writable object. This PR:

- Makes all ResultSets Writables
- Makes Performance Estimation Result a Writable
- Added checks for write results in some of the writers
- Fixed signature and return for HTML Report

Even though Estimation Result and Segmented Result Set are Writables, the `write` method is not implemented and will return a write status with a message suggesting the use of supported writers.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
