### PR TITLE
Configurable default resolvers

### DIFF
--- a/python/tests/core/test_declarative_schema.py
+++ b/python/tests/core/test_declarative_schema.py
@@ -239,7 +239,7 @@ def test_default_resolvers(reference_resolver, default_resolver) -> None:
     res.DEFAULT_RESOLVER = default_resolver
     default_results = why.log(row=data).view()
 
-    for column in ["column_1", "column_2", "column_3", "column_4"]:
+    for column in data.keys():
         reference_metrics = set(reference_results.get_column(column).get_metric_names())
         default_metrics = set(default_results.get_column(column).get_metric_names())
         assert reference_metrics == default_metrics

--- a/python/tests/core/test_declarative_schema.py
+++ b/python/tests/core/test_declarative_schema.py
@@ -212,7 +212,7 @@ def test_resolvers(reference_resolver, declarative_resolver) -> None:
     declarative_standard_schema = DeclarativeSchema(declarative_resolver)
     declarative_results = why.log(row=data, schema=declarative_standard_schema).view()
 
-    for column in ["column_1", "column_2", "column_3", "column_4"]:
+    for column in data.keys():
         reference_metrics = set(reference_results.get_column(column).get_metric_names())
         declarative_metrics = set(declarative_results.get_column(column).get_metric_names())
         assert reference_metrics == declarative_metrics

--- a/python/tests/core/test_declarative_schema.py
+++ b/python/tests/core/test_declarative_schema.py
@@ -1,6 +1,7 @@
 import pytest
 
 import whylogs as why
+import whylogs.core.resolvers as res
 from whylogs.core import DatasetSchema
 from whylogs.core.datatypes import Fractional, String
 from whylogs.core.metrics import MetricConfig, StandardMetric
@@ -189,27 +190,58 @@ def test_invalid_config() -> None:
         assert e.value.args[0] == "MetricSpec: must supply a Metric subclass to MetricSpec"
 
 
-def test_resolvers() -> None:
+@pytest.mark.parametrize(
+    "reference_resolver,declarative_resolver",
+    [
+        (StandardResolver(), STANDARD_RESOLVER),
+        (LimitedTrackingResolver(), LIMITED_TRACKING_RESOLVER),
+        (HistogramCountingTrackingResolver(), HISTOGRAM_COUNTING_TRACKING_RESOLVER),
+    ],
+)
+def test_resolvers(reference_resolver, declarative_resolver) -> None:
     """
     Verify DeclarativeSchema(RESOLVER) is equivalent to DatasetSchema()
     for different RESOLVERS (Standard, Limited Tracking, HistogramCounting)
     """
-    params = [
-        (StandardResolver(), STANDARD_RESOLVER),
-        (LimitedTrackingResolver(), LIMITED_TRACKING_RESOLVER),
-        (HistogramCountingTrackingResolver(), HISTOGRAM_COUNTING_TRACKING_RESOLVER),
-    ]
 
     class UnknownType:
         pass
 
     data = {"column_1": 3.14, "column_2": "lmno", "column_3": 42, "column_4": UnknownType()}
-    for reference_resolver, declarative_resolver in params:
-        reference_results = why.log(row=data, schema=DatasetSchema(resolvers=reference_resolver)).view()
-        declarative_standard_schema = DeclarativeSchema(declarative_resolver)
-        declarative_results = why.log(row=data, schema=declarative_standard_schema).view()
+    reference_results = why.log(row=data, schema=DatasetSchema(resolvers=reference_resolver)).view()
+    declarative_standard_schema = DeclarativeSchema(declarative_resolver)
+    declarative_results = why.log(row=data, schema=declarative_standard_schema).view()
 
-        for column in ["column_1", "column_2", "column_3", "column_4"]:
-            reference_metrics = set(reference_results.get_column(column).get_metric_names())
-            declarative_metrics = set(declarative_results.get_column(column).get_metric_names())
-            assert reference_metrics == declarative_metrics
+    for column in ["column_1", "column_2", "column_3", "column_4"]:
+        reference_metrics = set(reference_results.get_column(column).get_metric_names())
+        declarative_metrics = set(declarative_results.get_column(column).get_metric_names())
+        assert reference_metrics == declarative_metrics
+
+
+@pytest.mark.parametrize(
+    "reference_resolver,default_resolver",
+    [
+        (StandardResolver(), STANDARD_RESOLVER),
+        (LimitedTrackingResolver(), LIMITED_TRACKING_RESOLVER),
+        (HistogramCountingTrackingResolver(), HISTOGRAM_COUNTING_TRACKING_RESOLVER),
+    ],
+)
+def test_default_resolvers(reference_resolver, default_resolver) -> None:
+    """
+    Verify default schema obeys DEFAULT_RESOLVER
+    """
+
+    class UnknownType:
+        pass
+
+    data = {"column_1": 3.14, "column_2": "lmno", "column_3": 42, "column_4": UnknownType()}
+    reference_results = why.log(row=data, schema=DatasetSchema(resolvers=reference_resolver)).view()
+    res.DEFAULT_RESOLVER = default_resolver
+    default_results = why.log(row=data).view()
+
+    for column in ["column_1", "column_2", "column_3", "column_4"]:
+        reference_metrics = set(reference_results.get_column(column).get_metric_names())
+        default_metrics = set(default_results.get_column(column).get_metric_names())
+        assert reference_metrics == default_metrics
+
+    res.DEFAULT_RESOLVER = STANDARD_RESOLVER

--- a/python/tests/experimental/core/metrics/test_udf_metric.py
+++ b/python/tests/experimental/core/metrics/test_udf_metric.py
@@ -3,8 +3,10 @@ from logging import getLogger
 import pandas as pd
 
 import whylogs as why
+import whylogs.experimental.core.metrics.udf_metric as udfm
 from whylogs.core.datatypes import String
 from whylogs.core.preprocessing import PreprocessedColumn
+from whylogs.core.resolvers import NO_FI_RESOLVER, STANDARD_RESOLVER
 from whylogs.experimental.core.metrics.udf_metric import (
     UdfMetric,
     UdfMetricConfig,
@@ -72,6 +74,36 @@ def test_udf_metric_from_to_protobuf() -> None:
     assert summary["foo:types/string"] == 1
     assert summary["foo:cardinality/est"] == 1
     assert "foo:frequent_items/frequent_strings" in summary
+
+
+def test_obeys_default_submetric_schema() -> None:
+    udfm.DEFAULT_UDF_RESOLVER = NO_FI_RESOLVER
+    config = UdfMetricConfig(
+        udfs={
+            "fortytwo": lambda x: 42,
+            "foo": lambda x: "bar",
+        },
+    )
+    metric = UdfMetric.zero(config)
+    metric.columnar_update(PreprocessedColumn.apply([0]))
+    summary = metric.to_summary_dict()
+
+    assert summary["fortytwo:counts/n"] == 1
+    assert summary["fortytwo:types/integral"] == 1
+    assert summary["fortytwo:types/string"] == 0
+    assert summary["fortytwo:cardinality/est"] == 1
+    assert summary["fortytwo:distribution/n"] == 1
+    assert summary["fortytwo:distribution/mean"] == 42
+    assert summary["fortytwo:ints/max"] == 42
+    assert summary["fortytwo:ints/min"] == 42
+    assert "fortytwo:frequent_items/frequent_strings" not in summary
+
+    assert summary["foo:counts/n"] == 1
+    assert summary["foo:types/integral"] == 0
+    assert summary["foo:types/string"] == 1
+    assert summary["foo:cardinality/est"] == 1
+    assert "foo:frequent_items/frequent_strings" not in summary
+    udfm.DEFAULT_UDF_RESOLVER = STANDARD_RESOLVER
 
 
 def test_udf_throws() -> None:

--- a/python/whylogs/experimental/core/metrics/udf_metric.py
+++ b/python/whylogs/experimental/core/metrics/udf_metric.py
@@ -14,8 +14,8 @@ from whylogs.core.metrics.metrics import (
 from whylogs.core.metrics.multimetric import MultiMetric, SubmetricSchema
 from whylogs.core.preprocessing import PreprocessedColumn
 from whylogs.core.resolvers import (
+    DEFAULT_RESOLVER,
     STANDARD_RESOLVER,
-    UDF_BASE_RESOLVER,
     MetricSpec,
     ResolverSpec,
     _allowed_metric,
@@ -60,8 +60,11 @@ class DeclarativeSubmetricSchema(SubmetricSchema):
         return result
 
 
+DEFAULT_UDF_RESOLVER: List[ResolverSpec] = STANDARD_RESOLVER
+
+
 def default_schema() -> DeclarativeSubmetricSchema:
-    return DeclarativeSubmetricSchema(STANDARD_RESOLVER)
+    return DeclarativeSubmetricSchema(DEFAULT_UDF_RESOLVER)
 
 
 @dataclass(frozen=True)
@@ -356,7 +359,7 @@ def udf_metric_schema(
     """
 
     resolvers = generate_udf_resolvers(schema_name)
-    non_udf_resolvers = non_udf_resolvers if non_udf_resolvers is not None else UDF_BASE_RESOLVER
+    non_udf_resolvers = non_udf_resolvers if non_udf_resolvers is not None else DEFAULT_RESOLVER
 
     return DeclarativeSchema(
         non_udf_resolvers + resolvers,

--- a/python/whylogs/experimental/core/udf_schema.py
+++ b/python/whylogs/experimental/core/udf_schema.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from whylogs.core.datatypes import TypeMapper
 from whylogs.core.metrics.metrics import MetricConfig
-from whylogs.core.resolvers import UDF_BASE_RESOLVER, MetricSpec, ResolverSpec
+from whylogs.core.resolvers import DEFAULT_RESOLVER, MetricSpec, ResolverSpec
 from whylogs.core.schema import DatasetSchema, DeclarativeSchema
 from whylogs.core.segmentation_partition import SegmentationPartition
 from whylogs.core.stubs import pd
@@ -201,7 +201,8 @@ def udf_schema(
     if resolvers is not None:
         resolver_specs = resolvers + _resolver_specs[schema_name]
     else:
-        resolver_specs = UDF_BASE_RESOLVER + _resolver_specs[schema_name]
+        resolver_specs = DEFAULT_RESOLVER + _resolver_specs[schema_name]
+
     resolver_specs += generate_udf_resolvers(schema_name)
     return UdfSchema(
         resolver_specs,

--- a/python/whylogs/experimental/extras/nlp_metric.py
+++ b/python/whylogs/experimental/extras/nlp_metric.py
@@ -16,7 +16,7 @@ from whylogs.core.metrics.metrics import Metric, MetricConfig, OperationResult
 from whylogs.core.metrics.multimetric import MultiMetric
 from whylogs.core.preprocessing import ListView, PreprocessedColumn
 from whylogs.core.proto import MetricMessage
-from whylogs.core.resolvers import Resolver, StandardResolver
+from whylogs.core.resolvers import DeclarativeResolver, Resolver
 from whylogs.core.schema import ColumnSchema
 from whylogs.core.stubs import np, sp
 from whylogs.experimental.extras.matrix_component import MatrixComponent
@@ -395,7 +395,7 @@ class NlpLogger:
             schema = DatasetSchema(
                 types=datatypes,
                 default_configs=NlpConfig(svd=self._svd_metric),
-                resolvers=ResolverWrapper(StandardResolver()),
+                resolvers=ResolverWrapper(DeclarativeResolver()),
             )
 
         self._profile = DatasetProfile(schema=schema)


### PR DESCRIPTION
## Description

Allows you to set `DEFAULT_RESOLVER` and `DEFAULT_UDF_RESOLVER` global variables to specify the default resolvers for dataset schemas and `UdfMetric` submetric schemas respectively.

If one wanted the standard resolver without frequent items for all columns/UDF submetrics, one would:
```
import whylogs.core.resolvers as r
import whylogs.experimental.core.metrics.udf_metric as udfm

r.DEFAULT_RESOLVER = r.NO_FI_RESOLVER
udfm.DEFAULT_UDF_RESOLVER = r.NO_FI_RESOLVER
```
Then all default dataset schema and submetric schema would exclude frequent items.  

## Changes

- Adds `DEFAULT_RESOLVER` and `DEFAULT_UDF_RESOLVER` globals to define default {dataset,submetrc} schema
- Renames `UDF_BASE_RESOLVER` to `NO_FI_RESOLVER`

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
