### PR TITLE
Add optional name parameter to log methods

### DIFF
--- a/python/tests/core/view/test_dataset_profile.py
+++ b/python/tests/core/view/test_dataset_profile.py
@@ -108,3 +108,26 @@ def test_default_dataset_timestamp() -> None:
 
     # the time in seconds between DatasetProfile creation and t1 assignment should be relatively small
     assert timestamp_delta < 30
+
+
+def test_dataset_profile_name() -> None:
+    import whylogs as why
+
+    test_row = {"a": 1, "b": "hello", "c": 2.34}
+    dataset_name = "my_dataset"
+    result_with_name = why.log(test_row, name=dataset_name)
+    result = why.log(test_row)
+
+    named_prof = result_with_name.profile()
+    unnamed_prof = result.profile()
+
+    assert named_prof._metadata is not None
+    assert "name" in named_prof._metadata
+    assert named_prof._metadata["name"] == dataset_name
+
+    named_view = named_prof.view()
+    assert named_view._metadata is not None
+    assert "name" in named_view._metadata
+    assert named_view._metadata["name"] == dataset_name
+
+    assert unnamed_prof._metadata is None

--- a/python/whylogs/api/logger/__init__.py
+++ b/python/whylogs/api/logger/__init__.py
@@ -32,8 +32,9 @@ def log(
     pandas: Optional[pd.DataFrame] = None,
     row: Optional[Dict[str, Any]] = None,
     schema: Optional[DatasetSchema] = None,
+    name: Optional[str] = None,
 ) -> ResultSet:
-    return TransientLogger(schema=schema).log(obj, pandas=pandas, row=row)
+    return TransientLogger(schema=schema).log(obj, pandas=pandas, row=row, name=name)
 
 
 def _log_with_metrics(

--- a/python/whylogs/api/logger/logger.py
+++ b/python/whylogs/api/logger/logger.py
@@ -34,6 +34,7 @@ class Logger(ABC):
         atexit.register(self.close)
         self._store_list: List[ProfileStore] = []
         self._segment_cache = None
+        self._metadata = None
 
     def check_writer(self, _: Writer) -> None:
         """Checks if a writer is configured correctly for this class"""
@@ -72,6 +73,7 @@ class Logger(ABC):
         row: Optional[Dict[str, Any]] = None,
         schema: Optional[DatasetSchema] = None,
         timestamp_ms: Optional[int] = None,  # Not the dataset timestamp, but the timestamp of the data
+        name: Optional[str] = None,
     ) -> ResultSet:
         """
         Args:
@@ -84,7 +86,10 @@ class Logger(ABC):
         if obj is None and pandas is None and row is None:
             # TODO: check for shell environment and emit more verbose error string to let user know how to correct.
             raise LoggingError("log() was called without passing in any input!")
-
+        if name is not None:
+            if self._metadata is None:
+                self._metadata = dict()
+            self._metadata["name"] = name
         active_schema = schema or self._schema
         if active_schema:
             pandas, row = _pandas_or_dict(obj, pandas, row)
@@ -99,8 +104,14 @@ class Logger(ABC):
 
         for prof in profiles:
             prof.track(obj, pandas=pandas, row=row, execute_udfs=False)
+            prof._metadata
 
-        return ProfileResultSet(profiles[0])
+        first_profile = profiles[0]
+        if name is not None:
+            if first_profile._metadata is None:
+                first_profile._metadata = dict()
+            first_profile._metadata["name"] = name
+        return ProfileResultSet(first_profile)
 
     def close(self) -> None:
         self._is_closed = True

--- a/python/whylogs/api/logger/logger.py
+++ b/python/whylogs/api/logger/logger.py
@@ -34,7 +34,7 @@ class Logger(ABC):
         atexit.register(self.close)
         self._store_list: List[ProfileStore] = []
         self._segment_cache = None
-        self._metadata = None
+        self._metadata: Optional[Dict[str, str]] = None
 
     def check_writer(self, _: Writer) -> None:
         """Checks if a writer is configured correctly for this class"""

--- a/python/whylogs/api/logger/rolling.py
+++ b/python/whylogs/api/logger/rolling.py
@@ -76,6 +76,7 @@ class TimedRollingLogger(Logger):
         fork: bool = False,
         skip_empty: bool = False,
         callback: Optional[Callable[[Writer, DatasetProfileView, str], None]] = None,
+        metadata: Optional[Dict[str, str]] = None,
     ):
         super().__init__(schema)
         if base_name is None:
@@ -88,6 +89,7 @@ class TimedRollingLogger(Logger):
         self.aligned = aligned
         self.fork = fork
         self.skip_empty = skip_empty
+        self._metadatay = metadata
 
         # base on TimedRotatingFileHandler
         self.when = when.upper()
@@ -114,6 +116,7 @@ class TimedRollingLogger(Logger):
         self._current_profile: DatasetProfile = DatasetProfile(
             schema=schema,
             dataset_timestamp=datetime.fromtimestamp(self._current_batch_timestamp, timezone.utc),
+            metadata=self._metadata,
         )
 
         initial_run_after = (self._current_batch_timestamp + self.interval) - now
@@ -169,8 +172,7 @@ class TimedRollingLogger(Logger):
         old_profile = self._current_profile
 
         self._current_profile = DatasetProfile(
-            schema=self._schema,
-            dataset_timestamp=dataset_timestamp,
+            schema=self._schema, dataset_timestamp=dataset_timestamp, metadata=self._metadata
         )
 
         while old_profile.is_active:

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -46,6 +46,7 @@ class DatasetProfile(Writable):
         dataset_timestamp: Optional[datetime] = None,
         creation_timestamp: Optional[datetime] = None,
         metrics: Optional[Dict[str, Union[Metric, Any]]] = None,
+        metadata: Optional[Dict[str, str]] = None,
     ):
         if schema is None:
             schema = DatasetSchema()
@@ -59,6 +60,7 @@ class DatasetProfile(Writable):
         new_cols = schema.get_col_names()
         self._initialize_new_columns(new_cols)
         self._metrics: Dict[str, Union[Metric, Any]] = metrics or dict()
+        self._metadata = metadata
 
     @property
     def creation_timestamp(self) -> datetime:
@@ -261,6 +263,7 @@ class DatasetProfile(Writable):
             dataset_timestamp=self.dataset_timestamp,
             creation_timestamp=self.creation_timestamp,
             metrics=self._metrics,
+            metadata=self._metadata,
         )
 
     def flush(self) -> None:


### PR DESCRIPTION
## Description

We have metadata that flows through profile serialization now, and could be useful for debugging individual profile files. The 'name' parameter is optional, and will be used by some of the upcoming onboarding flow when there are anonymous sessions active.

## Changes

- Add optional name parameter that creates metadata field if needed on the profile/view.
- Allow specifying metadata when instantiating rolling logger, that initializes new profiles with the given metadata.
- Simple test for adding and then reading the name parameter.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
