### PR TITLE
Avoid empty ints series cast errors on timestamps

### DIFF
--- a/python/tests/core/test_preprocessing.py
+++ b/python/tests/core/test_preprocessing.py
@@ -614,6 +614,13 @@ def test_apply_nontensorable_series(column: Any) -> None:
     assert_list_view_is_empty(res.list)
 
 
+def test_pandas_split_timestamps() -> None:
+    row_count = 10
+    df_test = pd.DataFrame({"dt": pd.date_range(start="2022-01-01", periods=row_count, freq="H", tz=None)})
+    res = why.log(df_test)
+    assert res.view().get_column("dt").get_metric("counts").n.value == row_count
+
+
 @pytest.mark.parametrize(
     "column",
     [

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -174,7 +174,10 @@ class PreprocessedColumn:
         )
 
         floats = non_null_series[float_mask]
-        ints = non_null_series[int_mask].astype(int)
+        if non_null_series[int_mask].empty:
+            ints = pd.Series(dtype=int)
+        else:
+            ints = non_null_series[int_mask].astype(int)
         bool_count = non_null_series[bool_mask].count()
         bool_count_where_true = non_null_series[bool_mask_where_true].count()
         strings = non_null_series[str_mask]


### PR DESCRIPTION
## Description

On some platforms converting an empty pandas series raises a TypeError, specifically this can hit with Timestamp values, to avoid errors profiling columns we do not process, we can check if the series is empty and avoid converting the types.

## Changes

- Check for series empty and if so return an empty pandas series of the int type rather than converting the empty series.
- Add test that hits this TypeError on windows.

## Related

Fixes #1262

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
