### PR TITLE
Add schema namespaces for UDFs

### DIFF
--- a/python/tests/experimental/core/test_udf_schema.py
+++ b/python/tests/experimental/core/test_udf_schema.py
@@ -284,3 +284,34 @@ def test_udf_track() -> None:
     assert prod_summary["counts/n"] == 3
     div_summary = results.get_column("ratio").to_summary_dict()
     assert div_summary["distribution/n"] == 3
+
+
+@register_dataset_udf(["schema.col1"], schema_name="bob")
+def bob(x):
+    return x["schema.col1"]
+
+
+@register_metric_udf("schema.col1", schema_name="bob")
+def rob(x):
+    return x
+
+
+@register_dataset_udf(["schema.col1"], "add5")
+def fob(x):
+    return x["schema.col1"] + 5
+
+
+def test_schema_name() -> None:
+    default_schema = udf_schema()
+    data = pd.DataFrame({"schema.col1": [42, 12, 7]})
+    default_view = why.log(data, schema=default_schema).view()
+    assert "add5" in default_view.get_columns()
+    assert "bob" not in default_view.get_columns()
+    assert "udf" not in default_view.get_column("schema.col1").get_metric_names()
+
+    bob_schema = udf_schema(schema_name="bob")
+    data = pd.DataFrame({"schema.col1": [42, 12, 7]})
+    bob_view = why.log(data, schema=bob_schema).view()
+    assert "add5" not in bob_view.get_columns()
+    assert "bob" in bob_view.get_columns()
+    assert "udf" in bob_view.get_column("schema.col1").get_metric_names()

--- a/python/whylogs/experimental/core/metrics/udf_metric.py
+++ b/python/whylogs/experimental/core/metrics/udf_metric.py
@@ -177,11 +177,15 @@ class UdfMetric(MultiMetric):
 register_metric(UdfMetric)
 
 
-_col_name_submetrics: Dict[str, Dict[str, List[Tuple[str, Callable[[Any], Any]]]]] = defaultdict(lambda: defaultdict(list))
+_col_name_submetrics: Dict[str, Dict[str, List[Tuple[str, Callable[[Any], Any]]]]] = defaultdict(
+    lambda: defaultdict(list)
+)
 _col_name_submetric_schema: Dict[str, Dict[str, SubmetricSchema]] = defaultdict(dict)
 _col_name_type_mapper: Dict[str, Dict[str, TypeMapper]] = defaultdict(dict)
 
-_col_type_submetrics: Dict[str, Dict[DataType, List[Tuple[str, Callable[[Any], Any]]]]] = defaultdict(lambda: defaultdict(list))
+_col_type_submetrics: Dict[str, Dict[DataType, List[Tuple[str, Callable[[Any], Any]]]]] = defaultdict(
+    lambda: defaultdict(list)
+)
 _col_type_submetric_schema: Dict[str, Dict[DataType, SubmetricSchema]] = defaultdict(dict)
 _col_type_type_mapper: Dict[str, Dict[DataType, TypeMapper]] = defaultdict(dict)
 

--- a/python/whylogs/experimental/core/udf_schema.py
+++ b/python/whylogs/experimental/core/udf_schema.py
@@ -155,10 +155,7 @@ def register_dataset_udf(
     return decorator_register
 
 
-def generate_udf_specs(
-    other_udf_specs: Optional[List[UdfSpec]] = None,
-    schema_name: str = ""
-) -> List[UdfSpec]:
+def generate_udf_specs(other_udf_specs: Optional[List[UdfSpec]] = None, schema_name: str = "") -> List[UdfSpec]:
     """
     Generates a list UdfSpecs that implement the UDFs specified
     by the @register_dataset_udf decorators. You can provide a list of


### PR DESCRIPTION
## Description

Allows dataset and metric UDFs to be registered in specific schema namespaces

```
@register_dataset_udf(["col1"], schema_name="bob")
def bob(x):
    return x["col1"]

@register_metric_udf("col1", schema_name="bob")
def rob(x):
    return x

@register_dataset_udf(["col1"], "add5")
def fob(x):
    return x["col1"] + 5

default_schema = udf_schema()
data = pd.DataFrame({"col1": [42, 12, 7]})
default_view = why.log(data, schema=default_schema).view()  # no bob or rob

bob_schema = udf_schema(schema_name="bob")
data = pd.DataFrame({"col1": [42, 12, 7]})  # original data frame stomped on by previous log() UDFs
bob_view = why.log(data, schema=bob_schema).view()  # bob & rob, but no add5
```

## Related

Relates to whylabs/whylogs#1263

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes [clickup task](https://app.clickup.com/t/866ab6rqn)


- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
