### PR TITLE
Fix UDF deserialization in column profiles to support UDFs on pyspark

### DIFF
--- a/python/tests/api/logger/test_segments.py
+++ b/python/tests/api/logger/test_segments.py
@@ -2,6 +2,7 @@ import os
 import pickle
 import tempfile
 from glob import glob
+from logging import getLogger
 from typing import Any
 
 import numpy as np
@@ -25,6 +26,8 @@ from whylogs.core.segmentation_partition import (
 )
 from whylogs.core.view.dataset_profile_view import DatasetProfileView
 from whylogs.migration.converters import read_v0_to_view
+
+TEST_LOGGER = getLogger(__name__)
 
 
 def test_single_row_segment() -> None:
@@ -282,8 +285,8 @@ def test_multi_column_segment_serialization_roundtrip_v0(tmp_path: Any) -> None:
     for file_path in paths:
         roundtrip_profiles.append(read_v0_to_view(file_path))
     assert len(roundtrip_profiles) == input_rows
-    print(roundtrip_profiles)
-    print(roundtrip_profiles[15])
+    TEST_LOGGER.info(roundtrip_profiles)
+    TEST_LOGGER.info(roundtrip_profiles[15])
 
     post_deserialization_view = roundtrip_profiles[15]
     assert post_deserialization_view is not None

--- a/python/tests/api/pyspark/experimental/test_profiler_function.py
+++ b/python/tests/api/pyspark/experimental/test_profiler_function.py
@@ -186,10 +186,8 @@ class TestPySpark(object):
         def frob(x):
             return x * x
 
-        register_metric_udf(col_type=Fractional, submetric_name="square")(frob)
-        spark_message = f"detected spark envrionment: {'SPARK_HOME' in os.environ or 'SPARK_CONF_DIR' in os.environ}"
-        print(spark_message)
-        test_schema = DeclarativeSchema(resolvers=generate_udf_resolvers())
+        register_metric_udf(col_type=Fractional, submetric_name="square", schema_name="pyspark_test")(frob)
+        test_schema = DeclarativeSchema(resolvers=generate_udf_resolvers(schema_name="pyspark_test"))
         profile_view = collect_dataset_profile_view(input_df=input_df, schema=test_schema)
 
         assert isinstance(profile_view, DatasetProfileView)

--- a/python/tests/api/pyspark/experimental/test_profiler_function.py
+++ b/python/tests/api/pyspark/experimental/test_profiler_function.py
@@ -175,8 +175,6 @@ class TestPySpark(object):
         assert profile_view.get_column("3").get_metric_names() == []
 
     def test_collect_dataset_profile_view_with_udf_schema(self, input_df):
-        import os
-
         from whylogs.core.datatypes import Fractional
         from whylogs.experimental.core.metrics.udf_metric import (
             generate_udf_resolvers,

--- a/python/tests/api/pyspark/experimental/test_profiler_function.py
+++ b/python/tests/api/pyspark/experimental/test_profiler_function.py
@@ -174,6 +174,28 @@ class TestPySpark(object):
         assert profile_view.get_column("2").get_metric_names() == []
         assert profile_view.get_column("3").get_metric_names() == []
 
+    def test_collect_dataset_profile_view_with_udf_schema(self, input_df):
+        import os
+
+        from whylogs.core.datatypes import Fractional
+        from whylogs.experimental.core.metrics.udf_metric import (
+            generate_udf_resolvers,
+            register_metric_udf,
+        )
+
+        def frob(x):
+            return x * x
+
+        register_metric_udf(col_type=Fractional, submetric_name="square")(frob)
+        spark_message = f"detected spark envrionment: {'SPARK_HOME' in os.environ or 'SPARK_CONF_DIR' in os.environ}"
+        print(spark_message)
+        test_schema = DeclarativeSchema(resolvers=generate_udf_resolvers())
+        profile_view = collect_dataset_profile_view(input_df=input_df, schema=test_schema)
+
+        assert isinstance(profile_view, DatasetProfileView)
+        assert len(profile_view.get_columns()) > 0
+        assert "udf" in profile_view.get_column("0").get_metric_names()
+
     def test_map_vectors(self, embeddings_df):
         from pyspark.ml.functions import vector_to_array
 

--- a/python/tests/core/view/test_dataset_profile_view.py
+++ b/python/tests/core/view/test_dataset_profile_view.py
@@ -233,10 +233,10 @@ def test_segmented_round_trip_metadata(tmp_path: str) -> None:
     segment_column = "A"
     results = why.log(df, schema=DatasetSchema(segments=segment_on_column(segment_column)))
     status = results.writer("local").write(dest=output_file)
-    TEST_LOGGER.info("serialized segmented profile to {output_file}" f" has status: {status}")
+    TEST_LOGGER.info(f"serialized segmented profile to {output_file} has status: {status}")
 
     view = DatasetProfileView.read(output_file)
-    TEST_LOGGER.info("round trip serialized and deserialized segmented profile" f" has metadata: {view._metadata}")
+    TEST_LOGGER.info(f"round trip serialized and deserialized segmented profile has metadata: {view._metadata}")
     assert view._metadata is not None
     segment_tag_metadata_key = _TAG_PREFIX + segment_column
     assert segment_tag_metadata_key in view._metadata

--- a/python/tests/experimental/core/test_udf_schema.py
+++ b/python/tests/experimental/core/test_udf_schema.py
@@ -135,7 +135,9 @@ def test_multicolumn_udf_pandas() -> None:
     assert "counts/n" in sqr_summary
     div_summary = results.get_column("ratio").to_summary_dict()
     assert div_summary["distribution/n"] == 3
-    assert len(results.get_column("ratio").get_metrics()) == 2  # Integral -> counts plus registered distribution
+    # Integral -> counts plus registered distribution
+    assert results.get_column("ratio").get_metric("counts") is not None
+    assert results.get_column("ratio").get_metric("distribution") is not None
 
 
 def test_multicolumn_udf_row() -> None:
@@ -172,7 +174,9 @@ def test_multicolumn_udf_row() -> None:
     assert "counts/n" in sqr_summary
     div_summary = results.get_column("ratio").to_summary_dict()
     assert div_summary["distribution/n"] == 1
-    assert len(results.get_column("ratio").get_metrics()) == 2  # Integral -> counts plus registered distribution
+    # Integral -> counts plus registered distribution
+    assert results.get_column("ratio").get_metric("counts") is not None
+    assert results.get_column("ratio").get_metric("distribution") is not None
 
 
 n: int = 0

--- a/python/whylogs/core/view/column_profile_view.py
+++ b/python/whylogs/core/view/column_profile_view.py
@@ -129,7 +129,6 @@ class ColumnProfileView(object):
 
             c_key = full_path[len(metric_name) + 1 :]
             metric_components[c_key] = c_msg
-
         for m_name, metric_components in metric_messages.items():
             m_enum = StandardMetric.__members__.get(m_name)
             if m_enum is None:
@@ -142,9 +141,11 @@ class ColumnProfileView(object):
 
             m_msg = MetricMessage(metric_components=metric_components)
             try:
-                result_metrics[m_name] = metric_class.from_protobuf(m_msg)
-            except:  # noqa
-                raise DeserializationError(f"Failed to deserialize metric: {m_name}")
+                deserialized_metric = metric_class.from_protobuf(m_msg)
+                result_metrics[m_name] = deserialized_metric
+            except Exception as error:  # noqa
+                raise DeserializationError(f"Failed to deserialize metric: {m_name}:{error}")
+
         return ColumnProfileView(metrics=result_metrics)
 
     @classmethod

--- a/python/whylogs/experimental/core/metrics/udf_metric.py
+++ b/python/whylogs/experimental/core/metrics/udf_metric.py
@@ -103,14 +103,15 @@ class UdfMetric(MultiMetric):
 
     def __init__(
         self,
-        udfs: Dict[str, Callable[[Any], Any]],
+        submetrics: Dict[str, Dict[str, Metric]],
+        udfs: Optional[Dict[str, Callable[[Any], Any]]] = None,
         # discover these with resolver  submetrics: Dict[str, Dict[str, Metric]],  # feature name -> (namespace -> metric)
         submetric_schema: Optional[SubmetricSchema] = None,
         type_mapper: Optional[TypeMapper] = None,
         fi_disabled: bool = False,
     ):
-        super().__init__(dict())  # submetrics)
-        self._udfs = udfs
+        super().__init__(submetrics)
+        self._udfs = udfs or dict()
         self._submetric_schema = submetric_schema or default_schema()
         self._type_mapper = type_mapper or StandardTypeMapper()
         self._fi_disabled = fi_disabled
@@ -120,7 +121,7 @@ class UdfMetric(MultiMetric):
         return "udf"
 
     def merge(self, other: "UdfMetric") -> "UdfMetric":
-        merged = UdfMetric(self._udfs, self._submetric_schema, self._type_mapper, self._fi_disabled)
+        merged = UdfMetric(self.submetrics, self._udfs, self._submetric_schema, self._type_mapper, self._fi_disabled)
         merged.submetrics = self.merge_submetrics(other)
         return merged
 
@@ -166,10 +167,11 @@ class UdfMetric(MultiMetric):
             config = UdfMetricConfig()
 
         return UdfMetric(
-            config.udfs,
-            config.submetric_schema,
-            config.type_mapper,
-            config.fi_disabled,
+            dict(),
+            udfs=config.udfs,
+            submetric_schema=config.submetric_schema,
+            type_mapper=config.type_mapper,
+            fi_disabled=config.fi_disabled,
         )
 
 


### PR DESCRIPTION
## Description

udf metrics are multimetrics but have a different init signature which leads to problems in deserializing them in pyspark. We need to have a consistent construction that preserves the udfs submetrics on deserialization, and works in the pyspark where a column profile is deserialized from bytes.

## Changes

- support multimetric init shape in udf metric
- add tests to cover missing deserialization path

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
