### PR TITLE
Fix: add support for pandas 2.x

### DIFF
--- a/python/whylogs/api/pyspark/experimental/profiler.py
+++ b/python/whylogs/api/pyspark/experimental/profiler.py
@@ -37,7 +37,7 @@ def whylogs_pandas_map_profiler(
                 COL_PROFILE_FIELD: [col_profile.to_protobuf().SerializeToString()],
             }
             df_temp = pd.DataFrame(data=d)
-            res_df = res_df.append(df_temp)
+            res_df = pd.concat([res_df, df_temp])
         yield res_df
 
 


### PR DESCRIPTION
## Description

`collect_dataset_profile_view` is broken for users with pandas>=2.0

`pandas>=2.0` no longer supports `DataFrame.append()` method, as it does not happen inplace, so it's not the same as Python's list.append changing pyspark's api call to `pd.concat` makes it compatible with 1.x and 2.x

https://stackoverflow.com/questions/75956209/dataframe-object-has-no-attribute-append

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
