### PR TITLE
Replace AntiResolver with field in ResolverSpec

### DIFF
--- a/python/tests/core/test_declarative_schema.py
+++ b/python/tests/core/test_declarative_schema.py
@@ -16,7 +16,6 @@ from whylogs.core.resolvers import (
     HISTOGRAM_COUNTING_TRACKING_RESOLVER,
     LIMITED_TRACKING_RESOLVER,
     STANDARD_RESOLVER,
-    AntiResolver,
     HistogramCountingTrackingResolver,
     LimitedTrackingResolver,
     MetricSpec,
@@ -218,8 +217,8 @@ def test_resolvers() -> None:
 
 def test_anti_resolvers(pandas_dataframe) -> None:
     anti_resolvers = [
-        AntiResolver("legs", None, [MetricSpec(StandardMetric.distribution.value)]),
-        AntiResolver(None, String, [MetricSpec(StandardMetric.frequent_items.value)]),
+        ResolverSpec("legs", None, [MetricSpec(StandardMetric.distribution.value)], True),
+        ResolverSpec(None, String, [MetricSpec(StandardMetric.frequent_items.value)], True),
     ]
     schema = DeclarativeSchema(STANDARD_RESOLVER + anti_resolvers)
     results = why.log(pandas_dataframe, schema=schema).view()

--- a/python/whylogs/experimental/core/udf_schema.py
+++ b/python/whylogs/experimental/core/udf_schema.py
@@ -6,12 +6,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from whylogs.core.datatypes import TypeMapper
 from whylogs.core.metrics.metrics import Metric, MetricConfig
-from whylogs.core.resolvers import (
-    UDF_BASE_RESOLVER,
-    AntiResolver,
-    MetricSpec,
-    ResolverSpec,
-)
+from whylogs.core.resolvers import UDF_BASE_RESOLVER, MetricSpec, ResolverSpec
 from whylogs.core.schema import DatasetSchema, DeclarativeSchema
 from whylogs.core.segmentation_partition import SegmentationPartition
 from whylogs.core.stubs import pd
@@ -169,7 +164,7 @@ def register_dataset_udf(
         if metrics:
             _resolver_specs[schema_name].append(ResolverSpec(name, None, deepcopy(metrics)))
         if anti_metrics:
-            _resolver_specs[schema_name].append(AntiResolver(name, None, [MetricSpec(m) for m in anti_metrics]))
+            _resolver_specs[schema_name].append(ResolverSpec(name, None, [MetricSpec(m) for m in anti_metrics], True))
 
         return func
 


### PR DESCRIPTION
## Description

Adds a boolean field to `ResolverSpec` to exclude a metric rather than add it.



- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
