### PR TITLE
Support condition validators for rows

### DIFF
--- a/python/tests/core/validators/test_condition_validator.py
+++ b/python/tests/core/validators/test_condition_validator.py
@@ -95,13 +95,12 @@ def numbers():
 
 def test_condition_validator(credit_card_validator, transcriptions) -> None:
     for data in [transcriptions, np.array(transcriptions), pd.Series(transcriptions)]:
-        col = PreprocessedColumn.apply(data)
         credit_card_validator = ConditionValidator(
             name="transcription_doesnt_contain_credit_card",
             conditions=regex_conditions,
             actions=[do_something_important],
         )
-        credit_card_validator.columnar_validate(col)
+        credit_card_validator.columnar_validate(data)
         summary = credit_card_validator.to_summary_dict()
         assert summary["total_evaluations"] == 4
         assert summary["noCreditCard"] == 1

--- a/python/tests/core/validators/test_condition_validator.py
+++ b/python/tests/core/validators/test_condition_validator.py
@@ -7,6 +7,7 @@ import pytest
 
 import whylogs as why
 from whylogs.core.metrics import MetricConfig
+from whylogs.core.preprocessing import PreprocessedColumn
 from whylogs.core.relations import Not, Predicate
 from whylogs.core.schema import DatasetSchema
 from whylogs.core.validators import ConditionValidator
@@ -94,15 +95,30 @@ def numbers():
 
 def test_condition_validator(credit_card_validator, transcriptions) -> None:
     for data in [transcriptions, np.array(transcriptions), pd.Series(transcriptions)]:
+        col = PreprocessedColumn.apply(data)
         credit_card_validator = ConditionValidator(
             name="transcription_doesnt_contain_credit_card",
             conditions=regex_conditions,
             actions=[do_something_important],
         )
-        credit_card_validator.columnar_validate(data)
+        credit_card_validator.columnar_validate(col)
         summary = credit_card_validator.to_summary_dict()
         assert summary["total_evaluations"] == 4
         assert summary["noCreditCard"] == 1
+
+
+def test_row_condition_validator(credit_card_validator, transcriptions) -> None:
+    transcription = transcriptions[0]
+    col = PreprocessedColumn._process_scalar_value(transcription)
+    credit_card_validator = ConditionValidator(
+        name="transcription_doesnt_contain_credit_card",
+        conditions=regex_conditions,
+        actions=[do_something_important],
+    )
+    credit_card_validator.columnar_validate(col)
+    summary = credit_card_validator.to_summary_dict()
+    assert summary["total_evaluations"] == 1
+    assert summary["noCreditCard"] == 1
 
 
 @pytest.mark.parametrize("identity,sampling", [(True, True), (False, True), (True, False), (False, False)])

--- a/python/whylogs/core/column_profile.py
+++ b/python/whylogs/core/column_profile.py
@@ -56,17 +56,25 @@ class ColumnProfile(object):
             self._success_count += res.successes
 
     def track_column(self, series: Any, identity_values: Any = None) -> None:
-        for validator in self._column_validators:
-            validator.columnar_validate(series, identity_values=identity_values)
         ex_col = PreprocessedColumn.apply(series)
+        id_col = None
+        if identity_values is not None:
+            id_col = PreprocessedColumn.apply(identity_values)
+        for validator in self._column_validators:
+            validator.columnar_validate(ex_col, id_col)
         self._process_extracted_column(ex_col)
 
     def _track_homogeneous_column(self, series: Any) -> None:
         ex_col = PreprocessedColumn._process_homogeneous_column(series)
         self._process_extracted_column(ex_col)
 
-    def _track_datum(self, value: Any) -> None:
+    def _track_datum(self, value: Any, identity_values: Any = None) -> None:
         ex_col = PreprocessedColumn._process_scalar_value(value)
+        id_col = None
+        if identity_values is not None:
+            id_col = PreprocessedColumn._process_scalar_value(identity_values)
+        for validator in self._column_validators:
+            validator.columnar_validate(ex_col, id_col)
         self._process_extracted_column(ex_col)
 
     def to_protobuf(self) -> ColumnMessage:

--- a/python/whylogs/core/column_profile.py
+++ b/python/whylogs/core/column_profile.py
@@ -56,12 +56,9 @@ class ColumnProfile(object):
             self._success_count += res.successes
 
     def track_column(self, series: Any, identity_values: Any = None) -> None:
-        ex_col = PreprocessedColumn.apply(series)
-        id_col = None
-        if identity_values is not None:
-            id_col = PreprocessedColumn.apply(identity_values)
         for validator in self._column_validators:
-            validator.columnar_validate(ex_col, id_col)
+            validator.columnar_validate(series, identity_values=identity_values)
+        ex_col = PreprocessedColumn.apply(series)
         self._process_extracted_column(ex_col)
 
     def _track_homogeneous_column(self, series: Any) -> None:

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -130,7 +130,7 @@ class DatasetProfile(Writable):
         if execute_udfs:
             pandas, row = self._schema._run_udfs(pandas, row)
 
-        col_id = getattr(self._schema.default_configs, "identity_column", None)
+        col_id: Optional[str] = getattr(self._schema.default_configs, "identity_column", None)
 
         # TODO: do this less frequently when operating at row level
         dirty = self._schema.resolve(pandas=pandas, row=row)
@@ -140,13 +140,11 @@ class DatasetProfile(Writable):
             self._initialize_new_columns(tuple(new_cols))
 
         if row is not None:
-            if col_id is not None:
-                logger.warning(
-                    "validation with identity column is not supported for row level tracking.\
-                    Validation will be performed without identity column"
-                )
             for k in row.keys():
-                self._columns[k]._track_datum(row[k])
+                if col_id:
+                    self._columns[k]._track_datum(row[k], row.get(col_id))
+                else:
+                    self._columns[k]._track_datum(row[k])
             return
         elif pandas is not None:
             # TODO: iterating over each column in order assumes single column metrics


### PR DESCRIPTION
## Description

Currently, condition validators is implemented only for Pandas dfs. In this PR:

- Condition Validators now expect a PreProcessedColumn instead of a Pandas Series
- columnar_validate is called from both Column Profile's `track_column` and  `track_datum` 
- updated test

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
