### PR TITLE
Direct invocation of dataset UDFs

### DIFF
--- a/python/tests/experimental/core/test_udf_schema.py
+++ b/python/tests/experimental/core/test_udf_schema.py
@@ -371,3 +371,18 @@ def test_schema_list() -> None:
     assert "add5" not in result.get_columns()
     assert "bob" in result.get_columns()
     assert "udf" in result.get_column("schema.col1").get_metric_names()
+
+
+def test_direct_udfs() -> None:
+    schema = udf_schema(schema_name=["", "bob"])
+    data = pd.DataFrame({"col1": [42, 12, 7]})
+    more_data, _ = schema.apply_udfs(data)
+    udf_columns = set(more_data.keys())
+
+    result = why.log(data, schema=schema).view()
+    profile_columns = set(result.get_columns())
+    assert udf_columns == profile_columns
+
+    result = why.log(more_data, schema=schema).view()
+    more_columns = set(result.get_columns())
+    assert more_columns == profile_columns


### PR DESCRIPTION
## Description

Allows users to apply registered dataset UDFs directly without logging.

## Changes

```
schema = udf_schema()
original_dataframe = ...
augmented_dataframe, _ = schema.apply_udfs(original_dataframe)  # adds dataset UDF output columns

why.log(original_dataframe, schema=schema)  # this will recompute UDFs
why.log(augmented_dataframe, schema=schema)  # this skips computing UDFs already present
```


- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
