### PR TITLE
Fix whylabs segment writer method

### DIFF
--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -530,7 +530,7 @@ class WhyLabsWriter(Writer):
         upload_statuses = list()
         for view, url in zip(files, upload_urls):
             with tempfile.NamedTemporaryFile() as tmp_file:
-                if kwargs.get("use_v0") is None or kwargs.get("use_v0"):
+                if kwargs.get("use_v0") is not None or kwargs.get("use_v0"):
                     view.write(file=tmp_file, use_v0=True)
                 else:
                     view.write(file=tmp_file)


### PR DESCRIPTION
the verification for v0 profiles was redundant 

details:
It's always converting to be a v0 profile, so it needs a small fix.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
