### PR TITLE
Dataset-ish UDFs by column type

### DIFF
--- a/python/tests/experimental/core/test_udf_schema.py
+++ b/python/tests/experimental/core/test_udf_schema.py
@@ -11,6 +11,7 @@ from whylogs.experimental.core.udf_schema import (
     UdfSchema,
     UdfSpec,
     register_dataset_udf,
+    register_type_udf,
     udf_schema,
 )
 
@@ -386,3 +387,26 @@ def test_direct_udfs() -> None:
     result = why.log(more_data, schema=schema).view()
     more_columns = set(result.get_columns())
     assert more_columns == profile_columns
+
+
+@register_type_udf(Fractional)
+def square_type(x) -> float:
+    return x * x
+
+
+def test_type_udf_row() -> None:
+    schema = udf_schema()
+    data = {"col1": 3.14}
+    print(schema.apply_udfs(row=data))
+    results = why.log(row=data, schema=schema).view()
+    print(results._columns.keys())
+    assert "col1.square_type" in results.get_columns().keys()
+
+
+def test_type_udf_dataframe() -> None:
+    schema = udf_schema()
+    data = pd.DataFrame({"col1": [3.14, 42.0]})
+    print(schema.apply_udfs(pandas=data))
+    results = why.log(data, schema=schema).view()
+    print(results._columns.keys())
+    assert "col1.square_type" in results.get_columns().keys()

--- a/python/tests/experimental/core/test_udf_schema.py
+++ b/python/tests/experimental/core/test_udf_schema.py
@@ -397,16 +397,12 @@ def square_type(x) -> float:
 def test_type_udf_row() -> None:
     schema = udf_schema()
     data = {"col1": 3.14}
-    print(schema.apply_udfs(row=data))
     results = why.log(row=data, schema=schema).view()
-    print(results._columns.keys())
     assert "col1.square_type" in results.get_columns().keys()
 
 
 def test_type_udf_dataframe() -> None:
     schema = udf_schema()
     data = pd.DataFrame({"col1": [3.14, 42.0]})
-    print(schema.apply_udfs(pandas=data))
     results = why.log(data, schema=schema).view()
-    print(results._columns.keys())
     assert "col1.square_type" in results.get_columns().keys()

--- a/python/tests/experimental/core/test_udf_schema.py
+++ b/python/tests/experimental/core/test_udf_schema.py
@@ -399,6 +399,9 @@ def test_type_udf_row() -> None:
     data = {"col1": 3.14}
     results = why.log(row=data, schema=schema).view()
     assert "col1.square_type" in results.get_columns().keys()
+    summary = results.get_column("col1.square_type").to_summary_dict()
+    assert summary["counts/n"] == 1
+    assert summary["types/fractional"] == 1
 
 
 def test_type_udf_dataframe() -> None:
@@ -406,3 +409,6 @@ def test_type_udf_dataframe() -> None:
     data = pd.DataFrame({"col1": [3.14, 42.0]})
     results = why.log(data, schema=schema).view()
     assert "col1.square_type" in results.get_columns().keys()
+    summary = results.get_column("col1.square_type").to_summary_dict()
+    assert summary["counts/n"] == 2
+    assert summary["types/fractional"] == 2

--- a/python/whylogs/experimental/core/udf_schema.py
+++ b/python/whylogs/experimental/core/udf_schema.py
@@ -232,22 +232,14 @@ def register_dataset_udf(
 def register_type_udf(
     col_type: DataType,
     udf_name: Optional[str] = None,
-    metrics: Optional[List[MetricSpec]] = None,
     namespace: Optional[str] = None,
     schema_name: str = "",
-    anti_metrics: Optional[List[Metric]] = None,
 ) -> Callable[[Any], Any]:
     def decorator_register(func):
         global _multicolumn_udfs, _resolver_specs
         name = udf_name or func.__name__
         name = f"{namespace}.{name}" if namespace else name
         _multicolumn_udfs[schema_name].append(UdfSpec(None, {name: func}, col_type))
-        if metrics:
-            _resolver_specs[schema_name].append(ResolverSpec(None, col_type, deepcopy(metrics)))
-        if anti_metrics:
-            _resolver_specs[schema_name].append(
-                ResolverSpec(None, col_type, [MetricSpec(m) for m in anti_metrics], True)
-            )
 
         return func
 

--- a/python/whylogs/experimental/core/udf_schema.py
+++ b/python/whylogs/experimental/core/udf_schema.py
@@ -262,6 +262,7 @@ def register_type_udf(
     it will be registered to the defualt schema.
 
     """
+
     def decorator_register(func):
         global _multicolumn_udfs, _resolver_specs
         name = udf_name or func.__name__


### PR DESCRIPTION
## Description

Attach UDFs by column type. Output column name is `{input_column_name}.{UDF name}`.

Such UDFs get the value/column as input rather than a dictionary/data frame, more like a metric UDF.

```
@register_type_udf(Fractional)
def square_type(x) -> float:
    return x * x

def test_type_udf_row() -> None:
    schema = udf_schema()
    data = {"col1": 3.14}
    results = why.log(row=data, schema=schema).view()
    assert "col1.square_type" in results.get_columns().keys()
```

## Changes

- `UdfSpec` can optionally match by type
- adds `@register_type_udf()`  (better name suggestions?)

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
