### PR TITLE
Make ResolverSpec list optional in DeclarativeSchema ctor

### DIFF
--- a/python/tests/core/test_declarative_schema.py
+++ b/python/tests/core/test_declarative_schema.py
@@ -89,8 +89,10 @@ def test_declarative_schema() -> None:
 
 
 def test_default_resolver():
-    schema = DeclarativeSchema([])
+    schema = DeclarativeSchema()
     assert schema.resolvers._resolvers == DEFAULT_RESOLVER
+    schema = DeclarativeSchema([])
+    assert schema.resolvers._resolvers == []
 
 
 def test_declarative_schema_with_additional_resolvers(pandas_dataframe):

--- a/python/whylogs/core/schema.py
+++ b/python/whylogs/core/schema.py
@@ -238,7 +238,7 @@ class DeclarativeSchema(DatasetSchema):
 
     def __init__(
         self,
-        resolvers: List[ResolverSpec],
+        resolvers: Optional[List[ResolverSpec]] = None,
         types: Optional[Dict[str, Any]] = None,
         default_config: Optional[MetricConfig] = None,
         type_mapper: Optional[TypeMapper] = None,
@@ -247,7 +247,7 @@ class DeclarativeSchema(DatasetSchema):
         segments: Optional[Dict[str, SegmentationPartition]] = None,
         validators: Optional[Dict[str, List[Validator]]] = None,
     ) -> None:
-        if not resolvers:
+        if resolvers is None:
             resolvers = res.DEFAULT_RESOLVER
             logger.warning("No columns specified in DeclarativeSchema")
         resolver = DeclarativeResolver(resolvers, default_config)

--- a/python/whylogs/experimental/core/udf_schema.py
+++ b/python/whylogs/experimental/core/udf_schema.py
@@ -108,7 +108,7 @@ class UdfSchema(DeclarativeSchema):
 
     def __init__(
         self,
-        resolvers: List[ResolverSpec],
+        resolvers: Optional[List[ResolverSpec]] = None,
         types: Optional[Dict[str, Any]] = None,
         default_config: Optional[MetricConfig] = None,
         type_mapper: Optional[TypeMapper] = None,


### PR DESCRIPTION
## Description

Old behavior: `DeclrativeSchema([])` results in resolving according to the current setting of `DEFAULT_RESOLVER`

New behavior:
 * `DeclarativeSchema(None)` gives the `DEFAULT_RESOLVER`
 * `DeclarativeSchema([])` gives a schema that tracks NO metrics at all
 


- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
