### PR TITLE
whylabs writer - tag column as custom performance metric

### DIFF
--- a/python/tests/api/writer/test_whylabs.py
+++ b/python/tests/api/writer/test_whylabs.py
@@ -156,6 +156,16 @@ class TestWhylabsWriter(object):
         assert result == get_result
         assert isinstance(result, FeatureWeights)
 
+    def test_flag_column_as_custom_performance_metric(self):
+        writer = WhyLabsWriter()
+        column_name = "col_name"
+        label = "customMetric"
+        default_metric = "mean"
+        flag_result = (True, "{'request_id': '0dfe61f9-36c4-46b0-b176-a62f4f3c85e0'}")
+        writer.tag_custom_performance_column = MagicMock(return_value=flag_result)
+        result = writer.tag_custom_performance_column(column = column_name, label = label, default_metric = default_metric)
+        assert result == flag_result
+
     def test_option_will_overwrite_defaults(self) -> None:
         writer = WhyLabsWriter()
         writer.option(

--- a/python/tests/api/writer/test_whylabs.py
+++ b/python/tests/api/writer/test_whylabs.py
@@ -163,7 +163,7 @@ class TestWhylabsWriter(object):
         default_metric = "mean"
         flag_result = (True, "{'request_id': '0dfe61f9-36c4-46b0-b176-a62f4f3c85e0'}")
         writer.tag_custom_performance_column = MagicMock(return_value=flag_result)
-        result = writer.tag_custom_performance_column(column = column_name, label = label, default_metric = default_metric)
+        result = writer.tag_custom_performance_column(column=column_name, label=label, default_metric=default_metric)
         assert result == flag_result
 
     def test_option_will_overwrite_defaults(self) -> None:

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -447,7 +447,9 @@ class WhyLabsWriter(Writer):
 
         return self._tag_columns(columns, "input")
 
-    def tag_custom_performance_column(self, column: str, label: Optional[str] = None, default_metric: str = 'mean') -> Tuple[bool, str]:
+    def tag_custom_performance_column(
+        self, column: str, label: Optional[str] = None, default_metric: str = "mean"
+    ) -> Tuple[bool, str]:
         """Sets the column as a custom performance metric for the specified dataset and org id.
         The default metric will be displayed in the Performance tab in WhyLabs.
 

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -460,15 +460,15 @@ class WhyLabsWriter(Writer):
         default_metric : str
             The default metric that will be displayed in the Performance tab in WhyLabs.
             For example, "mean", "median", "max", or "min".
-        
+
         Note: the resulting custom performance metric is considered an unmergeable metric.
-        
+
         """
         api_instance = ModelsApi(self._api_client)
         metric_schema = MetricSchema(
-                label=label,
-                column=column,
-                default_metric=default_metric,
+            label=label,
+            column=column,
+            default_metric=default_metric,
         )
         self._validate_org_and_dataset()
         try:

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -447,7 +447,7 @@ class WhyLabsWriter(Writer):
 
         return self._tag_columns(columns, "input")
 
-    def tag_custom_performance_column(self, column: str, label: str, default_metric: str) -> Tuple[bool, str]:
+    def tag_custom_performance_column(self, column: str, label: Optional[str] = None, default_metric: str = 'mean') -> Tuple[bool, str]:
         """Sets the column as a custom performance metric for the specified dataset and org id.
         The default metric will be displayed in the Performance tab in WhyLabs.
 
@@ -456,14 +456,17 @@ class WhyLabsWriter(Writer):
         column : str
             The column name in the whylogs profile you want to tag as a custom performance metric.
         label : str
-            The label that will be displayed in WhyLabs UI.
+            The label that will be displayed in WhyLabs UI. If none is passed, defaults to column name.
         default_metric : str
             The default metric that will be displayed in the Performance tab in WhyLabs.
             For example, "mean", "median", "max", or "min".
+            If none is passed, defaults to "mean".
 
         Note: the resulting custom performance metric is considered an unmergeable metric.
 
         """
+        if not label:
+            label = column
         api_instance = ModelsApi(self._api_client)
         metric_schema = MetricSchema(
             label=label,


### PR DESCRIPTION
## Description

adds a method to WhyLabsWriter to tag a column as custom performance metrics to be shown in the Performance tab in WhyLabs UI

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
