### PR TITLE
UDF signature update & Python data types

### DIFF
--- a/python/tests/experimental/core/test_udf_schema.py
+++ b/python/tests/experimental/core/test_udf_schema.py
@@ -82,7 +82,7 @@ def test_decorator_row() -> None:
 
 @register_dataset_udf(["col1"], "annihilate_me", anti_metrics=[CardinalityMetric, DistributionMetric])
 def plus1(x: Union[Dict[str, List], pd.DataFrame]) -> Union[List, pd.Series]:
-    return x["col1"] + 1 if isinstance(x, pd.DataFrame) else [xx + 1 for xx in x["col1"]]
+    return x["col1"] + 1 if isinstance(x, pd.DataFrame) else map(lambda i: i + 1, x["col1"])
 
 
 def test_anti_resolver() -> None:

--- a/python/tests/experimental/core/test_udf_schema.py
+++ b/python/tests/experimental/core/test_udf_schema.py
@@ -46,11 +46,11 @@ def test_udf_pandas() -> None:
 
 @register_dataset_udf(["col1"])
 def add5(x):
-    return x["col1"] + 5
+    return [xx + 5 for xx in x["col1"]]
 
 
 def square(x):
-    return x["col1"] * x["col1"]
+    return x["col1"] * x["col1"] if isinstance(x, (pd.Series, pd.DataFrame)) else [xx * xx for xx in x["col1"]]
 
 
 def test_decorator_pandas() -> None:
@@ -80,7 +80,7 @@ def test_decorator_row() -> None:
 
 @register_dataset_udf(["col1"], "annihilate_me", anti_metrics=[CardinalityMetric, DistributionMetric])
 def plus1(x):
-    return x["col1"] + 1
+    return x["col1"] + 1 if isinstance(x, pd.DataFrame) else [xx + 1 for xx in x["col1"]]
 
 
 def test_anti_resolver() -> None:
@@ -120,12 +120,12 @@ def test_namespace() -> None:
 
 @register_dataset_udf(["col1", "col2"], "product")
 def times(x):
-    return x["col1"] * x["col2"]
+    return [xx * yy for xx, yy in zip(x["col1"], x["col2"])]
 
 
 @register_dataset_udf(["col1", "col3"], metrics=[MetricSpec(StandardMetric.distribution.value)])
 def ratio(x):
-    return x["col1"] / x["col3"]
+    return [xx / yy for xx, yy in zip(x["col1"], x["col3"])]
 
 
 def test_multicolumn_udf_pandas() -> None:
@@ -329,7 +329,7 @@ def rob(x):
 
 @register_dataset_udf(["schema.col1"], "add5")
 def fob(x):
-    return x["schema.col1"] + 5
+    return x["schema.col1"] + 5 if isinstance(x, pd.DataFrame) else [xx + 5 for xx in x["schema.col1"]]
 
 
 def test_schema_name() -> None:
@@ -390,8 +390,8 @@ def test_direct_udfs() -> None:
 
 
 @register_type_udf(Fractional)
-def square_type(x) -> float:
-    return x * x
+def square_type(x):
+    return x * x if isinstance(x, pd.Series) else [xx * xx for xx in x]
 
 
 def test_type_udf_row() -> None:
@@ -410,6 +410,21 @@ def test_type_udf_dataframe() -> None:
     results = why.log(data, schema=schema).view()
     assert "col1.square_type" in results.get_columns().keys()
     summary = results.get_column("col1.square_type").to_summary_dict()
+    assert summary["counts/n"] == 2
+    assert summary["types/fractional"] == 2
+
+
+@register_type_udf(float)
+def square_python_type(x):
+    return x * x if isinstance(x, pd.Series) else [xx * xx for xx in x]
+
+
+def test_python_type_udf() -> None:
+    schema = udf_schema()
+    data = pd.DataFrame({"col1": [3.14, 42.0]})
+    results = why.log(data, schema=schema).view()
+    assert "col1.square_python_type" in results.get_columns().keys()
+    summary = results.get_column("col1.square_python_type").to_summary_dict()
     assert summary["counts/n"] == 2
     assert summary["types/fractional"] == 2
 

--- a/python/tests/experimental/core/test_udf_schema.py
+++ b/python/tests/experimental/core/test_udf_schema.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, List, Union
+
 import pandas as pd
 
 import whylogs as why
@@ -45,11 +47,11 @@ def test_udf_pandas() -> None:
 
 
 @register_dataset_udf(["col1"])
-def add5(x):
+def add5(x: Union[Dict[str, List], pd.DataFrame]) -> Union[List, pd.Series]:
     return [xx + 5 for xx in x["col1"]]
 
 
-def square(x):
+def square(x: Union[Dict[str, List], pd.DataFrame]) -> Union[List, pd.Series]:
     return x["col1"] * x["col1"] if isinstance(x, (pd.Series, pd.DataFrame)) else [xx * xx for xx in x["col1"]]
 
 
@@ -79,7 +81,7 @@ def test_decorator_row() -> None:
 
 
 @register_dataset_udf(["col1"], "annihilate_me", anti_metrics=[CardinalityMetric, DistributionMetric])
-def plus1(x):
+def plus1(x: Union[Dict[str, List], pd.DataFrame]) -> Union[List, pd.Series]:
     return x["col1"] + 1 if isinstance(x, pd.DataFrame) else [xx + 1 for xx in x["col1"]]
 
 
@@ -103,12 +105,12 @@ def test_anti_resolver() -> None:
 
 
 @register_dataset_udf(["col1"], "colliding_name", namespace="pluto")
-def a_function(x):
+def a_function(x: Union[Dict[str, List], pd.DataFrame]) -> Union[List, pd.Series]:
     return x["col1"]
 
 
 @register_dataset_udf(["col1"], "colliding_name", namespace="neptune")
-def another_function(x):
+def another_function(x: Union[Dict[str, List], pd.DataFrame]) -> Union[List, pd.Series]:
     return x["col1"]
 
 
@@ -119,12 +121,12 @@ def test_namespace() -> None:
 
 
 @register_dataset_udf(["col1", "col2"], "product")
-def times(x):
+def times(x: Union[Dict[str, List], pd.DataFrame]) -> Union[List, pd.Series]:
     return [xx * yy for xx, yy in zip(x["col1"], x["col2"])]
 
 
 @register_dataset_udf(["col1", "col3"], metrics=[MetricSpec(StandardMetric.distribution.value)])
-def ratio(x):
+def ratio(x: Union[Dict[str, List], pd.DataFrame]) -> Union[List, pd.Series]:
     return [xx / yy for xx, yy in zip(x["col1"], x["col3"])]
 
 
@@ -210,7 +212,7 @@ n: int = 0
 
 
 @register_dataset_udf(["oops"])
-def exothermic(x):
+def exothermic(x: Union[Dict[str, List], pd.DataFrame]) -> Union[List, pd.Series]:
     global n
     n += 1
     if n < 3:
@@ -258,7 +260,7 @@ def test_udf_throws_row() -> None:
 
 
 @register_metric_udf("foo")
-def bar(x):
+def bar(x: Any) -> Any:
     return x
 
 
@@ -318,17 +320,17 @@ def test_udf_track() -> None:
 
 
 @register_dataset_udf(["schema.col1"], schema_name="bob")
-def bob(x):
+def bob(x: Union[Dict[str, List], pd.DataFrame]) -> Union[List, pd.Series]:
     return x["schema.col1"]
 
 
 @register_metric_udf("schema.col1", schema_name="bob")
-def rob(x):
+def rob(x: Any) -> Any:
     return x
 
 
 @register_dataset_udf(["schema.col1"], "add5")
-def fob(x):
+def fob(x: Union[Dict[str, List], pd.DataFrame]) -> Union[List, pd.Series]:
     return x["schema.col1"] + 5 if isinstance(x, pd.DataFrame) else [xx + 5 for xx in x["schema.col1"]]
 
 
@@ -390,7 +392,7 @@ def test_direct_udfs() -> None:
 
 
 @register_type_udf(Fractional)
-def square_type(x):
+def square_type(x: Union[List, pd.Series]) -> Union[List, pd.Series]:
     return x * x if isinstance(x, pd.Series) else [xx * xx for xx in x]
 
 
@@ -415,7 +417,7 @@ def test_type_udf_dataframe() -> None:
 
 
 @register_type_udf(float)
-def square_python_type(x):
+def square_python_type(x: Union[List, pd.Series]) -> Union[List, pd.Series]:
     return x * x if isinstance(x, pd.Series) else [xx * xx for xx in x]
 
 

--- a/python/whylogs/core/datatypes.py
+++ b/python/whylogs/core/datatypes.py
@@ -124,6 +124,9 @@ class TypeMapper(ABC):
     def __call__(self, dtype_or_type: Any) -> DataType:
         raise NotImplementedError
 
+    def __eq__(self, other):  # just here for unit testing purposes
+        return type(self) == type(other)
+
 
 class StandardTypeMapper(TypeMapper):
     """Map a dtype (Pandas) or a Python type to a data type."""

--- a/python/whylogs/core/resolvers.py
+++ b/python/whylogs/core/resolvers.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from typing_extensions import TypeAlias
 
@@ -118,7 +118,7 @@ class ResolverSpec:
     """
 
     column_name: Optional[str] = None  # TODO: maybe make this a regex
-    column_type: Optional[Union[DataType, Type]] = None
+    column_type: Optional[Type] = None
     metrics: List[MetricSpec] = field(default_factory=list)
     exclude: bool = False
     type_mapper: TypeMapper = field(default_factory=StandardTypeMapper)

--- a/python/whylogs/experimental/core/udf_schema.py
+++ b/python/whylogs/experimental/core/udf_schema.py
@@ -246,7 +246,7 @@ def register_dataset_udf(
 
 
 def register_type_udf(
-    col_type: Union[DataType, Type],
+    col_type: Type,
     udf_name: Optional[str] = None,
     namespace: Optional[str] = None,
     schema_name: str = "",
@@ -268,9 +268,12 @@ def register_type_udf(
     it will be registered to the defualt schema.
 
     """
-    if not issubclass(col_type, DataType):
-        type_mapper = type_mapper or StandardTypeMapper()
-        col_type = type(type_mapper(col_type))
+    try:
+        if not issubclass(col_type, DataType):
+            type_mapper = type_mapper or StandardTypeMapper()
+            col_type = type(type_mapper(col_type))
+    except:  # noqa
+        raise ValueError("Column type must be a DataType or Python type mapable to one")
 
     def decorator_register(func):
         global _multicolumn_udfs, _resolver_specs


### PR DESCRIPTION
## Description

Changes dataset and type UDF signatures so that they can be coded to ignore whether they're called with a row or `DataFrame`. Also allows type-matching `ResolverSpec`s to use Python types rather than whylogs `DataType`.

## Changes

- Dataset UDF signature is `udf(x: Union[Dict[str, List], pd.DataFrame]) -> Union[List, pd.Series]`
- Type UDF signature is `udf(x: Union[List, pd.Series]) -> Union[List, pd.Series]`
- UNCHANGED: metric UDF signature remains `udf(x: Any) -> Any`, where the Anys are single values in a row.
- `UdfSpec` and `ResolverSpec` matching by type can now use native Python types via a `TypeMapper` in addition to the whylogs `DataType`


- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
