### PR TITLE
type handling - add np.integer to int types

### DIFF
--- a/python/tests/experimental/core/metrics/test_udf_metric.py
+++ b/python/tests/experimental/core/metrics/test_udf_metric.py
@@ -254,7 +254,7 @@ def test_decorator() -> None:
     assert "udf/add5:distribution/n" in col1_summary
     assert "udf/add5:ints/max" in col1_summary
     assert "udf/add5:cardinality/est" in col1_summary
-    assert col1_summary['udf/add5:distribution/mean'] == 7.0
+    assert col1_summary["udf/add5:distribution/mean"] == 7.0
     assert "udf/tostr:counts/n" in col1_summary
     assert "udf/tostr:types/integral" in col1_summary
     assert "udf/tostr:distribution/n" in col1_summary

--- a/python/tests/experimental/core/metrics/test_udf_metric.py
+++ b/python/tests/experimental/core/metrics/test_udf_metric.py
@@ -254,7 +254,7 @@ def test_decorator() -> None:
     assert "udf/add5:distribution/n" in col1_summary
     assert "udf/add5:ints/max" in col1_summary
     assert "udf/add5:cardinality/est" in col1_summary
-
+    assert col1_summary['udf/add5:distribution/mean'] == 7.0
     assert "udf/tostr:counts/n" in col1_summary
     assert "udf/tostr:types/integral" in col1_summary
     assert "udf/tostr:distribution/n" in col1_summary

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -217,7 +217,8 @@ class PreprocessedColumn:
         string_list = []
         tensor_list = []
         obj_list = []
-        if isinstance(value, int):
+        int_types = (int, np.integer) if is_not_stub(np.integer) else int
+        if isinstance(value, int_types):
             if isinstance(value, bool):
                 result.bool_count = 1
                 if value:

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
 from math import isinf, isnan
-from typing import Any, Iterable, Iterator, List, Optional, Union
+from typing import Any, Iterable, Iterator, List, Optional, Tuple, Union
 
 from whylogs.core.stubs import is_not_stub, np, pd
 
@@ -217,7 +217,7 @@ class PreprocessedColumn:
         string_list = []
         tensor_list = []
         obj_list = []
-        int_types = (int, np.integer) if is_not_stub(np.integer) else int
+        int_types: Union[type, Tuple[type, type]] = (int, np.integer) if is_not_stub(np.integer) else int
         if isinstance(value, int_types):
             if isinstance(value, bool):
                 result.bool_count = 1

--- a/python/whylogs/core/stubs.py
+++ b/python/whylogs/core/stubs.py
@@ -46,6 +46,7 @@ class NumpyStub:
     datetime64: type = _StubClass
     unicode_: type = _StubClass
     issubdtype: type = _StubClass
+    integer: type = _StubClass
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Description

The motivation for this change is that the following code snippet would output empty distribution metrics for `udf/add5`:

```python
@register_metric_udf(col_name="col1")
def add5(x):
    return x + 5

df = pd.DataFrame({"col1": [1, 2, 3, 4, 5]})

profile = why.log(df,schema=udf_schema()).view()
```

because the values were of type `np.int64`, which evaluated to false when doing `isinstance(value,int)`

This pr:

- adds `np.integer` to the integer check when processing the scalar values
- creates stub for `np.integer`
- adds test to check for this case

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
