### PR TITLE
Add rolling logger to end of Writing_to_WhyLabs example notebook

### DIFF
--- a/python/examples/integrations/writers/Writing_to_WhyLabs.ipynb
+++ b/python/examples/integrations/writers/Writing_to_WhyLabs.ipynb
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,20 +96,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Enter your WhyLabs Org ID\n",
-      "Enter your WhyLabs Dataset ID\n",
-      "Enter your WhyLabs API key\n",
-      "Using API Key ID:  ygG04qE3gQ\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import getpass\n",
     "import os\n",
@@ -147,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -288,7 +277,7 @@
        "4         Purchase  39.0  "
       ]
      },
-     "execution_count": 2,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -320,22 +309,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "No timezone set in the datetime_timestamp object. Default to local timezone\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import whylogs as why\n",
-    "from datetime import datetime\n",
+    "from datetime import datetime, timezone\n",
     "\n",
-    "current_date = datetime.now()\n",
+    "current_date = datetime.now(tz=timezone.utc)\n",
     "profile = why.log(df).profile()\n",
     "profile.set_dataset_timestamp(current_date)"
    ]
@@ -370,7 +351,18 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, 'log-0GVvS7QaiQimvyAo')"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from whylogs.api.writer.whylabs import WhyLabsWriter\n",
     "\n",
@@ -383,7 +375,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A `200` response should mean that it went through successfully.\n",
+    "A `200` response should mean that it went through successfully, and your status returned will be a tuple contained if the write was successful and the profile reference on WhyLabs if successful, otherwise an error string.\n",
     "\n",
     "The writer expects a __Profile View__ as parameter."
    ]
@@ -408,7 +400,18 @@
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(True, 'log-rqIB3CwupXqAD3Mg')]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "profile_results = why.log(df)\n",
     "profile_results.writer(\"whylabs\").write()"
@@ -461,9 +464,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Logged profile for 2023-07-26 14:32:34.189991+00:00\n",
+      "Logged profile for 2023-07-25 14:32:37.045585+00:00\n",
+      "Logged profile for 2023-07-24 14:32:38.582456+00:00\n",
+      "Logged profile for 2023-07-23 14:32:40.233105+00:00\n",
+      "Logged profile for 2023-07-22 14:32:41.752926+00:00\n",
+      "Logged profile for 2023-07-21 14:32:43.296560+00:00\n",
+      "Logged profile for 2023-07-20 14:32:44.850047+00:00\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "from datetime import datetime, timedelta\n",
@@ -476,12 +493,12 @@
     "def log_data(df,timestamp):\n",
     "    profile = why.log(df).profile()\n",
     "    profile.set_dataset_timestamp(timestamp)\n",
-    "    writer.write(profile=profile.view())\n",
+    "    writer.write(profile.view())\n",
     "    print(\"Logged profile for {}\".format(timestamp))\n",
     "\n",
     "# This will log each data split for the last 7 days, starting with the current date and finishing 7 days in the past\n",
     "for day, df_split in enumerate(df_splits):\n",
-    "    dataset_timestamp = datetime.now() - timedelta(days=day)\n",
+    "    dataset_timestamp = datetime.now(tz=timezone.utc) - timedelta(days=day)\n",
     "    log_data(df_split,dataset_timestamp)"
    ]
   },
@@ -490,7 +507,114 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This should give you a quick way to look at how your features can be monitored over time!"
+    "This should give you a quick way to look at how your features can be monitored over time!\n",
+    "\n",
+    "### Logging in a production service a rolling logger\n",
+    "In a production service you can profile in line using a rolling logger as your telemetry gathering agent, which will aggregate the statistics over many messages or batches of your data, and the agen can be configured to write profiles with a configured interval to one or more destinations such as Whylabs, local disk, s3 etc.\n",
+    "\n",
+    "Below we will use this same dataframe and split it into 100 pieces to mimic small batches of inputs in a service, and log these with a rolling logger configured to write to WhyLabs every 5 minutes. To make it easier to see what's going on we also provide a callback on serialization, which gives access to the writer, the profile written, and a status."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "profiling batch: 0 out of 10 batches of data\n",
+      "profiling batch: 1 out of 10 batches of data\n",
+      "profiling batch: 2 out of 10 batches of data\n",
+      "profiling batch: 3 out of 10 batches of data\n",
+      "profiling batch: 4 out of 10 batches of data\n",
+      "profiling batch: 5 out of 10 batches of data\n",
+      "profiling batch: 6 out of 10 batches of data\n",
+      "profiling batch: 7 out of 10 batches of data\n",
+      "profiling batch: 8 out of 10 batches of data\n",
+      "profiling batch: 9 out of 10 batches of data\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from whylogs.api.writer.whylabs import WhyLabsWriter\n",
+    "from whylogs.api.writer.writer import Writer\n",
+    "from whylogs.core.view.dataset_profile_view import DatasetProfileView\n",
+    "\n",
+    "\n",
+    "# step 0 - setup a serialization callback handler to debug/trace, \n",
+    "# replace the print with your own application logging\n",
+    "def upload_callback(writer: Writer, profile: DatasetProfileView, filename: str):\n",
+    "    print(f\"Uploaded with {writer}, profile with timestamp: {profile.dataset_timestamp} and filename {filename}\")\n",
+    "\n",
+    "# step 1 setup the telemetry agent as a rolling logger and use the WhyLabs writer\n",
+    "telemetry_agent = why.logger(mode='rolling', interval=5, when=\"M\", callback=upload_callback)\n",
+    "whylabs_writer = WhyLabsWriter()\n",
+    "telemetry_agent.append_writer(writer=whylabs_writer)\n",
+    "# you can also append writers by name with default configuration using env variables,\n",
+    "# below we append the default local disk profile writer for debug purposes,\n",
+    "# but it is easier to write only to WhyLabs in a production setup.\n",
+    "telemetry_agent.append_writer(name='local')\n",
+    "\n",
+    "# step 2 some fake data in batches, typically this would be service traffic or batches of your data in a map/reduce setup.\n",
+    "total_batches = 10\n",
+    "df_splits = np.array_split(df, total_batches)\n",
+    "\n",
+    "# step 3 - log the fake data in batches, this loop will log each batch of the split, but won't create more than one profile.\n",
+    "for batch, df_split in enumerate(df_splits):\n",
+    "    print(f\"profiling batch: {batch} out of {total_batches} batches of data\")\n",
+    "    telemetry_agent.log(df_split)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this point there should be several batches of data profiled, but there is stil a single compact dataset profile describing all this data. If we waited for the interval to expire (5 minutes after instantiating the telemetry agent), we should see an upload get triggered, and our `upload_callback` triggered, but the rolling logger also has a `close()` method so you can flush any profile data during an application shutdown ahead of the interval's deadline. This will flush the profile."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+     "Uploaded with <whylogs.api.writer.whylabs.WhyLabsWriter object at 0x7f5506ed4160>, profile with timestamp: 2023-07-26 14:45:00+00:00 and filename profile.2023-07-26_07-45.bin\n",
+     "Uploaded with <whylogs.api.writer.local.LocalWriter object at 0x7f5507a38820>, profile with timestamp: 2023-07-26 14:45:00+00:00 and filename profile.2023-07-26_07-45.bin\n"
+     ]
+    }
+   ],
+   "source": [
+    "telemetry_agent.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You now have a local copy of the profile, you can check it out, and it is also uploaded to your WhyLabs account where it will be merged with other profiles in the same monitoring time window (e.g. daily or hourly) based on the profiles timestamp."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "profile.2023-07-26_07-45.bin\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls *.bin"
    ]
   }
  ],


### PR DESCRIPTION
## Description
The writing to WhyLabs example is missing the intended production logging pattern, adding a rolling logger example at the very end.

## Changes

- Same example notebook, just putting in a little extra content at the end to show case using the rolling logger writing to WhyLabs as the appending of loggers is not necessarily easy to find in combining other examples.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
