### PR TITLE
Getting Started w/ WhyLabs - change html to make link open in new tab

### DIFF
--- a/python/examples/integrations/writers/Getting_Started_with_WhyLabsV1.ipynb
+++ b/python/examples/integrations/writers/Getting_Started_with_WhyLabsV1.ipynb
@@ -609,7 +609,7 @@
       "outputs": [],
       "source": [
         "from IPython.core.display import HTML\n",
-        "HTML(f'To view your statistics, go to the <a href=\"https://hub.whylabsapp.com/models/{model_id}/summary\">model dashboard</a>')"
+        "HTML(f'To view your statistics, go to the <a href=\"https://hub.whylabsapp.com/models/{model_id}/summary\" target=\"_blank\">model dashboard</a>')"
       ]
     },
     {


### PR DESCRIPTION
## Description

Broken link, only worked if right clicking and selecting "open in new tab".

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
