### PR TITLE
make HTTP_PROXY env var accessible in WhyLabsWriter

### DIFF
--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -320,11 +320,9 @@ class WhyLabsWriter(Writer):
         cache_key += str(hash(self._key_refresher))
         if self._proxy:
             config.proxy = self._proxy
-            cache_key += str(hash(self._proxy))
             default_header = _get_auth_headers(self._proxy)
             if default_header:
                 config.proxy_headers = default_header
-                cache_key += str(hash(str(default_header)))
         config.discard_unknown_keys = True
         # Disable client side validation and trust the server
         config.client_side_validation = False

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -243,6 +243,7 @@ class WhyLabsWriter(Writer):
         _private_api_endpoint = os.environ.get("WHYLABS_PRIVATE_API_ENDPOINT")
         _private_s3_endpoint = os.environ.get("WHYLABS_PRIVATE_S3_ENDPOINT")
         _http_proxy = os.environ.get("HTTP_PROXY")
+        _https_proxy = os.environ.get("HTTPS_PROXY")
         if _private_api_endpoint:
             logger.debug(f"Using private API endpoint: {_private_api_endpoint}")
             self._endpoint_hostname = urlparse(self.whylabs_api_endpoint).netloc
@@ -262,9 +263,9 @@ class WhyLabsWriter(Writer):
         pool = _UPLOAD_POOLER_CACHE.get(pooler_cache_key)
         if pool is None:
             logger.debug(f"Pooler is not available. Creating a new one for key: {pooler_cache_key}")
-            if _http_proxy:
+            if _https_proxy or _http_proxy:
                 pool = ProxyManager(
-                    _http_proxy,
+                    _https_proxy or _http_proxy,
                     num_pools=4,
                     maxsize=10,
                     assert_hostname=self._s3_endpoint_subject,

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -118,15 +118,15 @@ def _validate_api_key(api_key: Optional[str]) -> str:
         raise ValueError("Invalid format. Expecting a dot at an index 10")
     return api_key[:10]
 
+
 def _get_auth_headers(proxy_url: str) -> Dict[str, str]:
     parsed_url = urlparse(proxy_url)
     if parsed_url.username and parsed_url.password:
-        default_headers = util.make_headers(
-            proxy_basic_auth=f"{str(parsed_url.username)}:{str(parsed_url.password)}"
-        )
+        default_headers = util.make_headers(proxy_basic_auth=f"{str(parsed_url.username)}:{str(parsed_url.password)}")
     else:
         default_headers = None
     return default_headers
+
 
 class KeyRefresher(abc.ABC):
     @property


### PR DESCRIPTION
## Description

This PR adds a ProxyManager for the s3 pool manager if http/https proxy env vars are available, and also forwards proxy URL and authorization headers to whylabs client.


- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
