### PR TITLE
fix serializing confusion matrix from older whylogs

### DIFF
--- a/python/tests/core/test_model_performance_metrics.py
+++ b/python/tests/core/test_model_performance_metrics.py
@@ -277,7 +277,20 @@ def test_profile_top_level_api_segmented_performance():
 
 
 def test_deserialize_confusion_matrix_with_kll_floats() -> None:
+    # this sketch generates ValueError when deserialized as kll_doubles_sketch.
     sample = "CgEwCgExEhxkZWxpdmVyeV9wcmVkaWN0aW9uIChvdXRwdXQpGhhkZWxpdmVyeV9zdGF0dXMgKG91dHB1dCkiHGRlbGl2ZXJ5X2NvbmZpZGVuY2UgKG91dHB1dClSFgoAIggCAQ8BAAEIADIIAQMDAAAezJNSFgoAIggCAQ8BAAEIADIIAQMDAAAezJNS0QEKFAgKEUcu/yH99rU/GeF6FK5H4eo/Eh0IChGuR+F6FK7nPxkAAAAAAADwPyHNzMzMzMwgQCJIBQEPAAABCAAKAAAAAAAAAAABAQD2AAAApHA9PwAAgD/Xo3A/uB5FP6RwPT/NzEw/PQpXP0jhej+kcD0/cT1KPwAAgD/NzEw/MlACAwMAABrMkwgAAAAAAAAA08wssPU9DQg/rZkmPpX4CJp1jlD5me4aoWIjAG6MNiCLJTyeLc5zUuyIHr4Td6ZphdLO5crXo3zWNEUNX4OGflIWCgAiCAIBDwEAAQgAMggBAwMAAB7Mkw=="  # noqa: E501
+    bytes = base64.b64decode(sample)
+    msg = ScoreMatrixMessage()
+    msg.ParseFromString(bytes)
+    confusion_matrix = ConfusionMatrix.from_protobuf(msg)
+    assert confusion_matrix is not None
+    merged = confusion_matrix.merge(confusion_matrix)
+    merged.to_protobuf()
+    # test passes if no crash
+
+def test_deserialize_confusion_matrix_with_kll_floats_IndexError() -> None:
+    # this sketch generates IndexError when deserialized as kll_doubles_sketch.
+    sample = "CgEwCgExEhxkZWxpdmVyeV9wcmVkaWN0aW9uIChvdXRwdXQpGhhkZWxpdmVyeV9zdGF0dXMgKG91dHB1dCkiHGRlbGl2ZXJ5X2NvbmZpZGVuY2UgKG91dHB1dClSFgoAIggCAQ8BAAEIADIIAQMDAAAezJNSFgoAIggCAQ8BAAEIADIIAQMDAAAezJNSTAoLCAEZhetRuB6F6z8SHQgBEYXrUbgehes/GYXrUbgehes/IYXrUbgehes/IgwCAg8EAAEIAPYoXD8yEAEDAwAAGsyTtq3UmCeZQWBSFgoAIggCAQ8BAAEIADIIAQMDAAAezJM="  # noqa: E501
     bytes = base64.b64decode(sample)
     msg = ScoreMatrixMessage()
     msg.ParseFromString(bytes)

--- a/python/tests/core/test_model_performance_metrics.py
+++ b/python/tests/core/test_model_performance_metrics.py
@@ -288,6 +288,7 @@ def test_deserialize_confusion_matrix_with_kll_floats() -> None:
     merged.to_protobuf()
     # test passes if no crash
 
+
 def test_deserialize_confusion_matrix_with_kll_floats_IndexError() -> None:
     # this sketch generates IndexError when deserialized as kll_doubles_sketch.
     sample = "CgEwCgExEhxkZWxpdmVyeV9wcmVkaWN0aW9uIChvdXRwdXQpGhhkZWxpdmVyeV9zdGF0dXMgKG91dHB1dCkiHGRlbGl2ZXJ5X2NvbmZpZGVuY2UgKG91dHB1dClSFgoAIggCAQ8BAAEIADIIAQMDAAAezJNSFgoAIggCAQ8BAAEIADIIAQMDAAAezJNSTAoLCAEZhetRuB6F6z8SHQgBEYXrUbgehes/GYXrUbgehes/IYXrUbgehes/IgwCAg8EAAEIAPYoXD8yEAEDAwAAGsyTtq3UmCeZQWBSFgoAIggCAQ8BAAEIADIIAQMDAAAezJM="  # noqa: E501

--- a/python/whylogs/core/model_performance_metrics/confusion_matrix.py
+++ b/python/whylogs/core/model_performance_metrics/confusion_matrix.py
@@ -163,7 +163,7 @@ class ConfusionMatrix:
     def _numbers_to_dist(numbers: NumbersMessageV0) -> DistributionMetric:
         try:
             doubles_sk = ds.kll_doubles_sketch.deserialize(numbers.histogram)
-        except ValueError:
+        except Exception:
             # Fall back to KLL float for backward compatibility and convert it to doubles sketch
             sk = ds.kll_floats_sketch.deserialize(numbers.histogram)
             doubles_sk = ds.kll_floats_sketch.float_to_doubles(sk)


### PR DESCRIPTION
## Description

Support backwards compatibility.
Decoding a KllFloatsSketch when expecting a KllDoublesSketch can result in a few different types of exceptions.
This change broadens the class of exceptions that can be caught before trying to decode the sketch as KllFloatsSketch. 
Adds unit test to make sure `IndexError` is caught.


