### PR TITLE
Respect the allow_anonymous flag even if you've previously been anonymous

### DIFF
--- a/python/tests/api/whylabs/session/test_config.py
+++ b/python/tests/api/whylabs/session/test_config.py
@@ -1,0 +1,47 @@
+from typing import cast
+
+import pytest
+
+from whylogs.api.whylabs.session.config import InitException
+from whylogs.api.whylabs.session.session import Session
+from whylogs.api.whylabs.session.session_manager import get_current_session, init
+from whylogs.api.whylabs.session.session_types import SessionType
+
+_config_path = "/tmp/whylogs.ini"
+
+# FYI, these tests do require network to work. They call whylabs to generate session ids.
+
+
+def test_whylabs_works() -> None:
+    init(config_path=_config_path, allow_anonymous=True, allow_local=True, whylabs_api_key="key", reinit=True)
+    session = cast(Session, get_current_session())
+    assert session.get_type() == SessionType.WHYLABS
+
+
+def test_allow_true_anonymous_works() -> None:
+    init(config_path=_config_path, allow_anonymous=True, allow_local=False, reinit=True)
+    session = cast(Session, get_current_session())
+    assert session.get_type() == SessionType.WHYLABS_ANONYMOUS
+
+
+def test_allow_false_anonymous_works() -> None:
+    # Will throw because it has no info to infer a session type with, and everything is not allowed
+    with pytest.raises(InitException):
+        init(config_path=_config_path, allow_anonymous=False, allow_local=False, reinit=True)
+
+
+def test_allow_true_local_works() -> None:
+    init(config_path=_config_path, allow_anonymous=False, allow_local=True, reinit=True)
+
+    session = cast(Session, get_current_session())
+    assert session.get_type() == SessionType.LOCAL
+
+
+def test_allow_false_anonymous_keeps_working() -> None:
+    # First init as anonymous
+    init(config_path=_config_path, allow_anonymous=True, allow_local=False, reinit=True)
+    # Then disable init and expect it to work
+    init(config_path=_config_path, allow_anonymous=False, allow_local=True, reinit=True)
+
+    session = cast(Session, get_current_session())
+    assert session.get_type() == SessionType.LOCAL

--- a/python/whylogs/api/whylabs/session/notebook_check.py
+++ b/python/whylogs/api/whylabs/session/notebook_check.py
@@ -1,12 +1,3 @@
-def is_notebook() -> bool:
-    result = False
-    try:
-        result = is_ipython_notebook()
-    except Exception:
-        pass
-    return result
-
-
 def is_ipython_notebook() -> bool:
     """
     Detects whether the current environment is an IPython notebook or not.
@@ -14,3 +5,16 @@ def is_ipython_notebook() -> bool:
     import sys
 
     return "ipykernel" in sys.modules
+
+
+def is_ipython_terminal() -> bool:
+    # Works for colab too
+    try:
+        __IPYTHON__  # type: ignore
+        return True
+    except NameError:
+        return False
+
+
+def is_interractive() -> bool:
+    return is_ipython_terminal() or is_ipython_notebook()

--- a/python/whylogs/api/whylabs/session/session_manager.py
+++ b/python/whylogs/api/whylabs/session/session_manager.py
@@ -67,6 +67,7 @@ def init(
     allow_local: bool = False,
     whylabs_api_key: Optional[str] = None,
     default_dataset_id: Optional[str] = None,
+    config_path: Optional[str] = None,
 ) -> None:
     """
     Set up authentication for this whylogs logging session. There are three modes that you can authentiate in.
@@ -105,12 +106,17 @@ def init(
     if reinit:
         SessionManager.reset()
 
+    # python name mangling...
+    if SessionManager._SessionManager__instance is not None:  # type: ignore
+        return
+
     session_config = SessionConfig(
         InitConfig(
             allow_anonymous=allow_anonymous,
             allow_local=allow_local,
             whylabs_api_key=whylabs_api_key,
             default_dataset_id=default_dataset_id,
+            config_path=config_path,
         )
     )
 

--- a/python/whylogs/api/whylabs/session/session_types.py
+++ b/python/whylogs/api/whylabs/session/session_types.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Union
 
-from whylogs.api.whylabs.session.notebook_check import is_notebook
+from whylogs.api.whylabs.session.notebook_check import is_interractive
 
 
 # This is used to indicate that a result is either a success or a failure
@@ -24,7 +24,7 @@ class InteractiveLogger:
 
     @staticmethod
     def init_notebook_logging() -> None:
-        if is_notebook():
+        if is_interractive():
             InteractiveLogger._is_notebook = True
 
     @staticmethod


### PR DESCRIPTION


Previously, you would do an anonymous upload despite allow_anonymous being False if you already had an anonymous session id stored in your local config file. Now the flag is required in addition.
