### PR TITLE
Factor out the whylabs client cache so sessions can use it

### DIFF
--- a/python/examples/integrations/Guest Session.ipynb
+++ b/python/examples/integrations/Guest Session.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,6 +28,38 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initializing session with config /home/anthony/.config/whylogs/config.ini\n",
+      "\n",
+      "✅ Using session type: WHYLABS_ANONYMOUS\n",
+      " ⤷ session id: session-6LpLjnAE\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<whylogs.api.whylabs.session.session.GuestSession at 0x7fc674559c70>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import whylogs as why\n",
+    "\n",
+    "why.init()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
    "outputs": [
@@ -35,16 +67,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Initialing session with config /home/anthony/.config/whylogs/config.ini\n",
-      "✅ Using session type: WHYLABS_ANONYMOUS\n",
-      " ⤷ session id: session-XfQUnBhJ\n"
+      "\n",
+      "✅ Aggregated 48842 rows into profile foo\n",
+      "\n",
+      "Visualize and explore this profile with one-click\n",
+      "🔍 https://hub.whylabsapp.com/resources/model-1/profiles?profile=ref-zv5Qm5zwJw0XEzpo&sessionToken=session-6LpLjnAE\n"
      ]
     }
    ],
    "source": [
-    "import whylogs as why\n",
-    "\n",
-    "why.init()"
+    "profile = why.log(df, name=\"foo\")"
    ]
   },
   {
@@ -56,15 +88,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ Aggregated 48842 rows into profile foo\n",
+      "\n",
+      "✅ Aggregated 48842 rows into profile \n",
       "\n",
       "Visualize and explore this profile with one-click\n",
-      "🔍 https://hub.whylabsapp.com/resources/model-1/profiles?profile=ref-547v42LMV5rKJi4R&sessionToken=session-XfQUnBhJ\n"
+      "🔍 https://hub.whylabsapp.com/resources/model-1/profiles?profile=1691712000000&sessionToken=session-6LpLjnAE\n"
      ]
     }
    ],
    "source": [
-    "profile = why.log(df, name=\"foo\")"
+    "# Upload the same data as a batch profile by leaving out the name\n",
+    "profile = why.log(df)"
    ]
   },
   {
@@ -76,16 +110,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ Aggregated 48842 rows into profile \n",
       "\n",
-      "Visualize and explore this profile with one-click\n",
-      "🔍 https://hub.whylabsapp.com/resources/model-1/profiles?profile=1689292800000&sessionToken=session-XfQUnBhJ\n"
+      "✅ Aggregated 48842 lines into profile 'foo', 48842 lines into profile 'bar'\n",
+      "\n",
+      "Visualize and explore the profiles with one-click\n",
+      "🔍 https://hub.whylabsapp.com/resources/model-1/profiles?profile=ref-aj7Q52Zszb0VhjeW&profile=ref-6awZJWQI347XFBgD&sessionToken=session-6LpLjnAE\n",
+      "\n",
+      "Or view each profile individually\n",
+      " ⤷ https://hub.whylabsapp.com/resources/model-1/profiles?profile=ref-aj7Q52Zszb0VhjeW&sessionToken=session-6LpLjnAE\n",
+      " ⤷ https://hub.whylabsapp.com/resources/model-1/profiles?profile=ref-6awZJWQI347XFBgD&sessionToken=session-6LpLjnAE\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<whylogs.api.logger.result_set.ViewResultSet at 0x7fc5dc310d30>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Upload the same data as a batch profile by leaving out the name\n",
-    "profile = why.log(df)"
+    "why.log(multiple={'foo': df, 'bar': df}) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Switch to an autheneticated session"
    ]
   },
   {
@@ -97,20 +152,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ Aggregated 48842 lines into profile 'foo', 48842 lines into profile 'bar'\n",
+      "Initializing session with config /home/anthony/.config/whylogs/config.ini\n",
       "\n",
-      "Visualize and explore the profiles with one-click\n",
-      "🔍 https://hub.whylabsapp.com/resources/model-1/profiles?profile=ref-6xJz70VbH7duHTaW&profile=ref-E2sM0Wd9RkPYPuu9&sessionToken=session-XfQUnBhJ\n",
-      "\n",
-      "Or view each profile individually\n",
-      " ⤷ https://hub.whylabsapp.com/resources/model-1/profiles?profile=ref-6xJz70VbH7duHTaW&sessionToken=session-XfQUnBhJ\n",
-      " ⤷ https://hub.whylabsapp.com/resources/model-1/profiles?profile=ref-E2sM0Wd9RkPYPuu9&sessionToken=session-XfQUnBhJ\n"
+      "✅ Using session type: WHYLABS\n",
+      " ⤷ org id: org-JpsdM6\n",
+      " ⤷ api key: MPq7Hg002z\n",
+      " ⤷ default dataset: model-62\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<whylogs.api.logger.result_set.ViewResultSet at 0x7f99ddb67670>"
+       "<whylogs.api.whylabs.session.session.ApiKeySession at 0x7fc6765e76a0>"
       ]
      },
      "execution_count": 6,
@@ -119,7 +172,77 @@
     }
    ],
    "source": [
-    "why.log(multiple={'foo': df, 'bar': df}) "
+    "why.init(reinit=True, allow_anonymous=False, whylabs_api_key=\"MPq7Hg002z.Na5VweqsJfu5ArGILjQTlGAyPyOhtOnEVEtqY2b5PXNGJLZLjHscT:org-JpsdM6\", default_dataset_id=\"model-62\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "✅ Aggregated 48842 rows into profile real_dataset\n",
+      "\n",
+      "Visualize and explore this profile with one-click\n",
+      "🔍 https://hub.whylabsapp.com/resources/model-62/profiles?profile=ref-WvU6X5tH0Nrkh4a3\n"
+     ]
+    }
+   ],
+   "source": [
+    "profile = why.log(df, name=\"real_dataset\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Or upload via the whylabs writer\n",
+    "This will use the session for credentials as well, it just won't have all of the fancy output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(True, 'log-KCaCKErR8Gi7TooV')]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "profile.writer('whylabs').write()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(True, 'ref-vdBRFKAO8y9J2C7M')]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# as a reference profile\n",
+    "profile.writer('whylabs').option(reference_profile_name=\"authenticated_ref\").write()"
    ]
   }
  ],

--- a/python/tests/api/logger/experimental/logger/actor/test_actor_loggers.py
+++ b/python/tests/api/logger/experimental/logger/actor/test_actor_loggers.py
@@ -96,9 +96,10 @@ class MPRollingLogger(ProcessRollingLogger):
 
 @pytest.fixture(scope="module", autouse=True)
 def init_tests() -> Generator[None, None, None]:
+    SessionManager.reset()  # Ensure this test is in a good state from previous moduels
     init(default_dataset_id=dataset_id)
     yield
-    SessionManager._SessionManager__instance = None  # type: ignore
+    SessionManager.reset()  # Leave it in a good state for future modules
 
 
 params = [MPRollingLogger, ThreadRollingLogger]

--- a/python/tests/api/whylabs/session/test_whylabs_client_cache.py
+++ b/python/tests/api/whylabs/session/test_whylabs_client_cache.py
@@ -1,0 +1,36 @@
+from whylogs.api.whylabs.session.whylabs_client_cache import ClientCacheConfig
+
+
+def test_empty_cache_key_works() -> None:
+    cache = dict()
+
+    key1 = ClientCacheConfig()
+    cache[key1] = 1
+
+    key2 = ClientCacheConfig()
+    cache[key2] = 2
+
+    assert len(cache) == 1
+    assert cache[key1] == 2
+
+
+def test_cache_key_works() -> None:
+    cache = dict()
+
+    key1 = ClientCacheConfig(
+        api_key="api_key", endpoint_hostname="endpoint_hostname", whylabs_api_endpoint="whylabs_api_endpoint"
+    )
+    cache[key1] = 1
+
+    key2 = ClientCacheConfig(
+        api_key="api_key", endpoint_hostname="endpoint_hostname", whylabs_api_endpoint="whylabs_api_endpoint"
+    )
+    cache[key2] = 2
+
+    key3 = ClientCacheConfig(api_key="api_key")
+    cache[key3] = 3
+
+    assert len(cache) == 2
+    assert cache[key1] == 2
+    assert cache[key2] == 2
+    assert cache[key3] == 3

--- a/python/whylogs/api/whylabs/session/lazy.py
+++ b/python/whylogs/api/whylabs/session/lazy.py
@@ -1,0 +1,15 @@
+from typing import Callable, Generic, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+class Lazy(Generic[T]):
+    def __init__(self, fn: Callable[[], T]) -> None:
+        self.fn = fn
+        self.__value: Optional[T] = None
+
+    @property
+    def value(self) -> T:
+        if self.__value is None:
+            self.__value = self.fn()
+        return self.__value

--- a/python/whylogs/api/whylabs/session/notebook_logger.py
+++ b/python/whylogs/api/whylabs/session/notebook_logger.py
@@ -71,7 +71,9 @@ def notebook_session_log(
     if session is None:
         return
     elif session.get_type() == SessionType.LOCAL:
-        il.message("Skipping uploading profiles to WhyLabs because this session is configured to be local only.")
+        il.warning_once(
+            "Skipping automatic upload because the session type is LOCAL. Uploads have to be done manually."
+        )
         return
 
     # Get the length of whatever was just logged

--- a/python/whylogs/api/whylabs/session/session_manager.py
+++ b/python/whylogs/api/whylabs/session/session_manager.py
@@ -1,18 +1,15 @@
 import logging
-from typing import Optional, Union
-
-from whylabs_client.api_client import ApiClient, Configuration  # type: ignore
+from typing import Optional
 
 from whylogs.api.whylabs.session.config import InitConfig, SessionConfig
-from whylogs.api.whylabs.session.notebook_check import is_interractive
 from whylogs.api.whylabs.session.session import (
     ApiKeySession,
     GuestSession,
     LocalSession,
     Session,
 )
+from whylogs.api.whylabs.session.session_types import InteractiveLogger as il
 from whylogs.api.whylabs.session.session_types import SessionType
-from whylogs.core.utils.utils import deprecated_alias
 
 logger = logging.getLogger(__name__)
 
@@ -24,20 +21,14 @@ class SessionManager:
         self,
         config: SessionConfig,
     ):
-        self._config = config
-        client_config = Configuration()
-        client_config.host = self._config.get_whylabs_endpoint()
-        self._whylabs_client = ApiClient(client_config)
-
         self.session: Session
         session_type = config.get_session_type()
         if session_type == SessionType.LOCAL:
-            self.session = LocalSession(self._config)
+            self.session = LocalSession(config)
         elif session_type == SessionType.WHYLABS_ANONYMOUS:
-            self.session = GuestSession(self._config, self._whylabs_client)
+            self.session = GuestSession(config)
         elif session_type == SessionType.WHYLABS:
-            client_config.api_key = {"ApiKeyAuth": self._config.require_api_key()}
-            self.session = ApiKeySession(self._config, self._whylabs_client)
+            self.session = ApiKeySession(config)
         else:
             raise ValueError(f"Unknown session type: {session_type}")
 
@@ -63,16 +54,15 @@ class SessionManager:
         return SessionManager.get_instance() is not None
 
 
-@deprecated_alias(session_type="allow_anonymous")
-def init(
-    session_type: Optional[Union[SessionType, str]] = None,
+def init(  # type: ignore
     reinit: bool = False,
     allow_anonymous: bool = True,
     allow_local: bool = False,
     whylabs_api_key: Optional[str] = None,
     default_dataset_id: Optional[str] = None,
     config_path: Optional[str] = None,
-) -> None:
+    **kwargs,
+) -> Session:
     """
     Set up authentication for this whylogs logging session. There are three modes that you can authentiate in.
 
@@ -108,15 +98,12 @@ def init(
             you're only using a single dataset id.
 
     """
-    if session_type in ["whylabs_anonymous", SessionType.WHYLABS_ANONYMOUS]:
-        allow_anonymous = True
-
     if reinit:
         SessionManager.reset()
 
-    # python name mangling...
-    if SessionManager._SessionManager__instance is not None:  # type: ignore
-        return
+    manager: SessionManager = SessionManager._SessionManager__instance  # type: ignore
+    if manager is not None:
+        return manager.session
 
     session_config = SessionConfig(
         InitConfig(
@@ -125,33 +112,51 @@ def init(
             whylabs_api_key=whylabs_api_key,
             default_dataset_id=default_dataset_id,
             config_path=config_path,
+            force_local=kwargs.get("force_local", False),
         )
     )
 
     try:
-        SessionManager.init(session_config)
+        manager = SessionManager.init(session_config)
         session_config.notify_session_type()
+        return manager.session
     except PermissionError as e:
+        # TODO PR this implies that we need disk access to work correctly, but isn't that already the case
+        # because we write profilfes to disk as tmp files?
         logger.warning("Could not create or read configuration file for session. Profiles won't be uploaded.", e)
+        raise e
     except Exception as e:
         logger.warning("Could not initialize session", e)
+        raise e
 
-
-_missing_session_warned = False
 
 _INIT_DOCS = "https://docs.whylabs.ai/docs/whylabs-whylogs-init"
 
 
 def get_current_session() -> Optional[Session]:
-    global _missing_session_warned
     manager = SessionManager.get_instance()
     if manager is not None:
         return manager.session
 
-    if not _missing_session_warned and is_interractive():
-        logger.warning(
-            f"No session found. Call whylogs.init() to initialize a session and authenticate. See {_INIT_DOCS} for more information."
-        )
-        _missing_session_warned = True
+    il.warning_once(
+        f"No session found. Call whylogs.init() to initialize a session and authenticate. See {_INIT_DOCS} for more information.",
+        logger.warning,
+    )
 
     return None
+
+
+def _default_init() -> Session:
+    """
+    For internal use. This initializes a default session for the user if they don't call why.init() themselves.
+    This will behave as though they called why.init() with no arguments and print out a warning with a link to the docs.
+    """
+    manager = SessionManager.get_instance()
+    if manager is None:
+        il.warning_once("Initializing default session because no session was found.", logger.warning)
+
+        # To be safe, don't allow default session to be anonymous or local if this is happening as a side effect
+        # that users don't know about.
+        return init(allow_anonymous=False, allow_local=True, force_local=True)
+    else:
+        return manager.session

--- a/python/whylogs/api/whylabs/session/whylabs_client_cache.py
+++ b/python/whylogs/api/whylabs/session/whylabs_client_cache.py
@@ -1,0 +1,177 @@
+import abc
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from urllib3 import ProxyManager
+from whylabs_client import ApiClient, Configuration  # type: ignore
+
+from whylogs.core.utils.utils import get_auth_headers
+
+
+class KeyRefresher(abc.ABC):
+    @property
+    @abc.abstractmethod
+    def key_id(self) -> str:
+        pass
+
+    @abc.abstractmethod
+    def __call__(self, config: Configuration) -> None:
+        pass
+
+    def _validate_api_key(self, api_key: Optional[str]) -> str:
+        if api_key is None:
+            raise ValueError("Missing API key. Set it via WHYLABS_API_KEY environment variable or as an api_key option")
+        if len(api_key) < 12:
+            raise ValueError("API key too short")
+        if len(api_key) > 80:
+            raise ValueError("API key too long")
+        if api_key[10] != ".":
+            raise ValueError("Invalid format. Expecting a dot at an index 10")
+        return api_key[:10]
+
+
+class StaticKeyRefresher(KeyRefresher):
+    def __init__(self, api_key: str) -> None:
+        self._key_id = self._validate_api_key(api_key)
+        self._api_key = api_key
+
+    @property
+    def key_id(self) -> str:
+        return self._key_id
+
+    def __call__(self, config: Configuration) -> None:
+        config.api_key = {"ApiKeyAuth": self._api_key}
+
+    def __hash__(self) -> int:
+        return hash(self._api_key)
+
+
+class EnvironmentKeyRefresher(KeyRefresher):
+    """
+    This key refresher uses environment variable key. The key is automatically picked up if the
+    user changes the environment variable.
+    """
+
+    @property
+    def key_id(self) -> str:
+        return self._key_id
+
+    def __call__(self, config: Configuration) -> None:
+        from whylogs.api.whylabs.session.session_manager import _default_init
+
+        session = _default_init()
+        session_config = session.config
+        api_key = session_config.get_env_api_key()
+        self._key_id = self._validate_api_key(api_key)
+        assert api_key is not None
+        config.api_key = {"ApiKeyAuth": api_key}
+
+
+@dataclass(frozen=True)
+class ClientCacheConfig:
+    api_key: Optional[str] = None
+    ssl_ca_cert: Optional[str] = None
+    whylabs_api_endpoint: Optional[str] = None
+    endpoint_hostname: Optional[str] = None  # TODO What is this thing?
+
+
+class WhylabsClientCache:
+    __instance: Optional["WhylabsClientCache"] = None
+
+    # Must be initialized from the session code as a side effect of why.init()
+    @staticmethod
+    def __init_instance() -> None:
+        if WhylabsClientCache.__instance is None:
+            WhylabsClientCache.__instance = WhylabsClientCache()
+
+    @staticmethod
+    def reset() -> None:
+        WhylabsClientCache.__instance = None
+
+    @staticmethod
+    def instance() -> "WhylabsClientCache":
+        if WhylabsClientCache.__instance is None:
+            # Internally, we'll call _default_init() to initialize the instance wherever we need
+            # a guarantee that one exists.
+            raise ValueError("WhylabsClientCache is not initialized. Call why.init() to initialize it.")
+        return WhylabsClientCache.__instance
+
+    def __init__(self) -> None:
+        self._api_client_cache: Dict[ClientCacheConfig, Tuple[ApiClient, KeyRefresher]] = dict()
+        self._logger = logging.getLogger(__name__)
+
+    def get_client(self, config: ClientCacheConfig) -> Tuple[ApiClient, KeyRefresher]:
+        entry = self._api_client_cache.get(config)
+
+        if entry is None:
+            entry = self._create_client(config)
+            self._api_client_cache[config] = entry
+
+        return entry
+
+    def _create_client(self, cache_config: ClientCacheConfig) -> Tuple[ApiClient, KeyRefresher]:
+        """
+        Refresh the API client by comparing various configs. We try to
+        re-use the client as much as we can since using a new client
+        every time can be expensive.
+        """
+        from whylogs.api.whylabs.session.session_manager import _default_init
+
+        session = _default_init()
+        session_config = session.config
+        self._proxy = session_config.get_https_proxy() or session_config.get_http_proxy()
+
+        config = Configuration()
+        config.api_key = {"ApiKeyAuth": ""}
+        refresher: KeyRefresher = (
+            StaticKeyRefresher(cache_config.api_key)
+            if cache_config.api_key
+            else EnvironmentKeyRefresher()  # TODO when would this be used? I'm requiring api keys right now in the whylabs writer
+        )
+        config.refresh_api_key_hook = refresher
+        config.discard_unknown_keys = True
+        config.client_side_validation = False  # Disable client side validation and trust the server
+
+        if self._proxy:
+            config.proxy = self._proxy
+            default_header = get_auth_headers(self._proxy)
+            if default_header:
+                config.proxy_headers = default_header
+
+        if cache_config.ssl_ca_cert:
+            config.ssl_ca_cert = cache_config.ssl_ca_cert
+
+        config.host = cache_config.whylabs_api_endpoint or session_config.get_whylabs_endpoint()
+
+        client = ApiClient(config)
+        from whylogs import __version__ as _version
+
+        client.user_agent = f"whylogs/python/{_version}"
+
+        if cache_config.endpoint_hostname:
+            self._logger.info(
+                f"Override endpoint hostname for TLS verification is set to: {cache_config.endpoint_hostname}"
+            )
+            self._update_hostname_config(client, cache_config.endpoint_hostname)
+
+        return client, refresher
+
+    def _update_hostname_config(self, client: ApiClient, endpoint_hostname_override: str) -> None:
+        """
+        This method overrides the pool manager's new connection method to add the hostname
+        """
+        if isinstance(client.rest_client.pool_manager, ProxyManager):
+            raise ValueError("Endpoint hostname override is not supported when using with proxy")
+
+        self._logger.debug(f"Override endpoint hostname to: {endpoint_hostname_override}")
+        old_conn_factory = client.rest_client.pool_manager.connection_from_host
+
+        def new_conn_factory(host: str, port: int, scheme: str, pool_kwargs: Optional[Dict[str, str]] = None) -> Any:
+            if pool_kwargs is None:
+                pool_kwargs = {}
+            pool_kwargs["assert_hostname"] = endpoint_hostname_override
+            pool_kwargs["server_hostname"] = endpoint_hostname_override
+            return old_conn_factory(host, port, scheme, pool_kwargs)
+
+        client.rest_client.pool_manager.connection_from_host = new_conn_factory

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -1,5 +1,3 @@
-import abc
-import copy
 import datetime
 import logging
 import os
@@ -8,8 +6,7 @@ from typing import IO, Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import requests  # type: ignore
-import whylabs_client  # type: ignore
-from urllib3 import PoolManager, ProxyManager, util
+from urllib3 import PoolManager, ProxyManager
 from whylabs_client import ApiClient, Configuration  # type: ignore
 from whylabs_client.api.dataset_profile_api import DatasetProfileApi  # type: ignore
 from whylabs_client.api.feature_weights_api import FeatureWeightsApi  # type: ignore
@@ -30,11 +27,16 @@ from whylabs_client.model.segment import Segment  # type: ignore
 from whylabs_client.model.segment_tag import SegmentTag  # type: ignore
 from whylabs_client.rest import ForbiddenException  # type: ignore
 
-from whylogs import __version__ as _version
 from whylogs.api.logger import log
 from whylogs.api.logger.result_set import SegmentedResultSet
-from whylogs.api.whylabs.session.config import _INIT_DOCS, SessionConfig
-from whylogs.api.whylabs.session.session_manager import get_current_session
+from whylogs.api.whylabs.session.config import _INIT_DOCS
+from whylogs.api.whylabs.session.session_manager import _default_init
+from whylogs.api.whylabs.session.whylabs_client_cache import (
+    ClientCacheConfig,
+    EnvironmentKeyRefresher,
+    KeyRefresher,
+    WhylabsClientCache,
+)
 from whylogs.api.writer import Writer
 from whylogs.api.writer.writer import Writable
 from whylogs.core import DatasetProfileView
@@ -42,6 +44,7 @@ from whylogs.core.dataset_profile import DatasetProfile
 from whylogs.core.errors import BadConfigError
 from whylogs.core.feature_weights import FeatureWeights
 from whylogs.core.utils import deprecated_alias
+from whylogs.core.utils.utils import get_auth_headers
 from whylogs.core.view.segmented_dataset_profile_view import SegmentedDatasetProfileView
 from whylogs.experimental.performance_estimation.estimation_results import (
     EstimationResult,
@@ -107,79 +110,6 @@ def _check_whylabs_condition_count_uncompound() -> bool:
     return True
 
 
-# TODO update this validator for new format
-def _validate_api_key(api_key: Optional[str]) -> str:
-    if api_key is None:
-        raise ValueError("Missing API key. Set it via WHYLABS_API_KEY environment variable or as an api_key option")
-    if len(api_key) < 12:
-        raise ValueError("API key too short")
-    if len(api_key) > 80:
-        raise ValueError("API key too long")
-    if api_key[10] != ".":
-        raise ValueError("Invalid format. Expecting a dot at an index 10")
-    return api_key[:10]
-
-
-def _get_auth_headers(proxy_url: str) -> Dict[str, str]:
-    parsed_url = urlparse(proxy_url)
-    if parsed_url.username and parsed_url.password:
-        default_headers = util.make_headers(proxy_basic_auth=f"{str(parsed_url.username)}:{str(parsed_url.password)}")
-    else:
-        default_headers = None
-    return default_headers
-
-
-class KeyRefresher(abc.ABC):
-    @property
-    @abc.abstractmethod
-    def key_id(self) -> str:
-        pass
-
-    @abc.abstractmethod
-    def __call__(self, config: Configuration) -> None:
-        pass
-
-
-class StaticKeyRefresher(KeyRefresher):
-    def __init__(self, api_key: str) -> None:
-        self._key_id = _validate_api_key(api_key)
-        self._api_key = api_key
-
-    @property
-    def key_id(self) -> str:
-        return self._key_id
-
-    def __call__(self, config: Configuration) -> None:
-        config.api_key = {"ApiKeyAuth": self._api_key}
-
-    def __hash__(self):
-        return hash(self._api_key)
-
-
-class EnvironmentKeyRefresher(KeyRefresher):
-    """
-    This key refresher uses environment variable key. The key is automatically picked up if the
-    user changes the environment variable.
-    """
-
-    @property
-    def key_id(self) -> str:
-        return self._key_id
-
-    def __call__(self, config: Configuration) -> None:
-        session = get_current_session()
-        # TODO this can be removed once we enforce why.init usage. Backwards compatible for now.
-        session_config = session.config if session is not None else SessionConfig()
-
-        api_key = session_config.get_api_key()
-        self._key_id = _validate_api_key(api_key)
-        assert api_key is not None
-        config.api_key = {"ApiKeyAuth": api_key}
-
-
-_ENV_KEY_REFRESHER = EnvironmentKeyRefresher()
-
-
 class WhyLabsWriter(Writer):
     f"""
     A WhyLogs writer to upload DatasetProfileView's onto the WhyLabs platform.
@@ -240,41 +170,32 @@ class WhyLabsWriter(Writer):
         ssl_ca_cert: Optional[str] = None,
         _timeout_seconds: Optional[float] = None,
     ):
-        session = get_current_session()
-        config = session.config if session is not None else SessionConfig()
+        session = _default_init()  # Force an init if the user didn't do it, it's idempotent
+        config = session.config
 
         self._org_id = org_id or config.require_org_id()
         self._dataset_id = dataset_id or config.require_default_dataset_id()
-        _api_key = api_key or config.require_api_key()
 
-        self.whylabs_api_endpoint = config.get_whylabs_endpoint()
         self._feature_weights = None
         self._reference_profile_name = config.get_whylabs_refernce_profile_name()
-        self._ssl_ca_cert = ssl_ca_cert
         self._api_config: Optional[Configuration] = None
 
         _http_proxy = os.environ.get("HTTP_PROXY")
         _https_proxy = os.environ.get("HTTPS_PROXY")
         self._proxy = _https_proxy or _http_proxy
 
-        if _api_key:
-            self._key_refresher = StaticKeyRefresher(_api_key)
-        else:
-            self._key_refresher = _ENV_KEY_REFRESHER
-
-        if api_client:
-            self._api_client = api_client
-        else:
-            self._api_client = None
-            self._refresh_client()
-
         # Enable private access to WhyLabs endpoints
         _private_api_endpoint = config.get_whylabs_private_api_endpoint()
+        _whylabs_endpoint = config.get_whylabs_endpoint()
+        # TODO everything is incoherant when a client is supplied because all of these other variables are ignored,
+        # the custom client should probably just be a parameter of write() and never be stored, or all of this other state
+        # needs to be abstracted into some other container
+        self.whylabs_api_endpoint = _private_api_endpoint or _whylabs_endpoint
+
         _private_s3_endpoint = config.get_whylabs_private_s3_endpoint()
         if _private_api_endpoint:
             logger.debug(f"Using private API endpoint: {_private_api_endpoint}")
             self._endpoint_hostname = urlparse(self.whylabs_api_endpoint).netloc
-            self.whylabs_api_endpoint = _private_api_endpoint
 
         pooler_cache_key: str = ""
         if _private_s3_endpoint:
@@ -287,13 +208,29 @@ class WhyLabsWriter(Writer):
         if _timeout_seconds is not None:
             self._timeout_seconds = _timeout_seconds
 
+        self._cache_config = ClientCacheConfig(
+            ssl_ca_cert=ssl_ca_cert,
+            whylabs_api_endpoint=self.whylabs_api_endpoint,
+            endpoint_hostname=self._endpoint_hostname,
+            api_key=api_key or config.require_api_key(),
+        )
+
+        if api_client:
+            # Just ignore the other args if a client was passed in. They're saved in the cache config if we need them.
+            self._api_client = api_client
+            # TODO this key refresher is only used to print the key id from the env, it isn't actually in the api client because
+            # someone else constructed the client and its config.
+            self._key_refresher = EnvironmentKeyRefresher()
+        else:
+            self._refresh_client(self._cache_config)
+
         # Using a pooler for uploading data
         pool = _UPLOAD_POOLER_CACHE.get(pooler_cache_key)
         if pool is None:
             logger.debug(f"Pooler is not available. Creating a new one for key: {pooler_cache_key}")
             if self._proxy:
                 proxy_url = self._proxy
-                default_headers = _get_auth_headers(proxy_url)
+                default_headers = get_auth_headers(proxy_url)
                 pool = ProxyManager(
                     proxy_url,
                     num_pools=4,
@@ -318,57 +255,8 @@ class WhyLabsWriter(Writer):
     def key_id(self) -> str:
         return self._key_refresher.key_id
 
-    def _refresh_client(self) -> None:
-        """
-        Refresh the API client by comparing various configs. We try to
-        re-use the client as much as we can since using a new client
-        every time can be expensive.
-
-        """
-        cache_key = ""
-
-        if self._api_client:
-            config = copy.deepcopy(self._api_client.configuration)
-        else:
-            config = Configuration()
-        # Set an empty api key. The key refresher will refresh it
-        config.api_key = {"ApiKeyAuth": ""}
-        config.refresh_api_key_hook = self._key_refresher
-        cache_key += str(hash(self._key_refresher))
-        if self._proxy:
-            config.proxy = self._proxy
-            default_header = _get_auth_headers(self._proxy)
-            if default_header:
-                config.proxy_headers = default_header
-        config.discard_unknown_keys = True
-        # Disable client side validation and trust the server
-        config.client_side_validation = False
-
-        cache_key += str(hash(config))
-        if self._ssl_ca_cert:
-            config.ssl_ca_cert = self._ssl_ca_cert
-            cache_key += str(hash(self._ssl_ca_cert))
-        config.host = self.whylabs_api_endpoint
-        cache_key += str(hash(self.whylabs_api_endpoint))
-        if self._endpoint_hostname:
-            cache_key += str(hash(self._endpoint_hostname))
-
-        existing_client = _API_CLIENT_CACHE.get(cache_key)
-        if existing_client:
-            logger.debug(f"Found existing client under cache key: {cache_key}")
-            self._api_client = existing_client
-            return
-
-        client = whylabs_client.ApiClient(config)
-        client.user_agent = f"whylogs/python/{_version}"
-
-        self._api_client = client
-        _API_CLIENT_CACHE[cache_key] = client
-        logger.debug(f"Created and updated new client for cache key: {cache_key}")
-
-        if self._endpoint_hostname:
-            logger.info(f"Override endpoint hostname for TLS verification is set to: {self._endpoint_hostname}")
-            self._update_hostname_config(self._endpoint_hostname)
+    def _refresh_client(self, cache_config: ClientCacheConfig) -> None:
+        self._api_client, self._key_refresher = WhylabsClientCache.instance().get_client(cache_config)
 
     def _update_hostname_config(self, endpoint_hostname_override: str) -> None:
         """
@@ -426,8 +314,15 @@ class WhyLabsWriter(Writer):
         if org_id is not None:
             self._org_id = org_id
         if api_key is not None:
-            self._key_refresher = StaticKeyRefresher(api_key)
-            self._refresh_client()
+            self._refresh_client(
+                ClientCacheConfig(
+                    ssl_ca_cert=self._cache_config.ssl_ca_cert,
+                    whylabs_api_endpoint=self._cache_config.whylabs_api_endpoint,
+                    endpoint_hostname=self._cache_config.endpoint_hostname,
+                    api_key=api_key,
+                )
+            )
+
         if reference_profile_name is not None:
             self._reference_profile_name = reference_profile_name
         if configuration is not None:
@@ -435,8 +330,14 @@ class WhyLabsWriter(Writer):
         if api_client is not None:
             self._api_client = api_client
         if ssl_ca_cert is not None:
-            self._ssl_ca_cert = ssl_ca_cert
-            self._refresh_client()
+            self._refresh_client(
+                ClientCacheConfig(
+                    ssl_ca_cert=ssl_ca_cert,
+                    whylabs_api_endpoint=self._cache_config.whylabs_api_endpoint,
+                    endpoint_hostname=self._cache_config.endpoint_hostname,
+                    api_key=self._cache_config.api_key,
+                )
+            )
         if timeout_seconds is not None:
             self._timeout_seconds = timeout_seconds
         return self
@@ -530,7 +431,7 @@ class WhyLabsWriter(Writer):
             column=column,
             default_metric=default_metric,
         )
-        self._validate_org_and_dataset()
+        self._validate_org_and_dataset()  # TODO this just doesn't exist?
         try:
             res = api_instance.put_entity_schema_metric(self._org_id, self._dataset_id, metric_schema)
             return True, str(res)

--- a/python/whylogs/core/utils/utils.py
+++ b/python/whylogs/core/utils/utils.py
@@ -2,6 +2,9 @@ import datetime
 import functools
 import warnings
 from typing import Any, Callable, Dict
+from urllib.parse import urlparse
+
+from urllib3 import util
 
 
 def deprecated(message):
@@ -29,7 +32,7 @@ def deprecated_alias(**aliases: str) -> Callable:
     return deprecated_decorator
 
 
-def rename_kwargs(func_name: str, kwargs: Dict[str, Any], aliases: Dict[str, str]):
+def rename_kwargs(func_name: str, kwargs: Dict[str, Any], aliases: Dict[str, str]) -> None:
     for alias, new in aliases.items():
         if alias in kwargs:
             if new in kwargs:
@@ -48,3 +51,12 @@ def rename_kwargs(func_name: str, kwargs: Dict[str, Any], aliases: Dict[str, str
 def ensure_timezone(dt: datetime.datetime) -> None:
     if dt.tzinfo is None:
         raise ValueError("whylogs requires timezone-aware datetime. Please use datetime.datetime(..., tzinfo=..) API")
+
+
+def get_auth_headers(proxy_url: str) -> Dict[str, str]:
+    parsed_url = urlparse(proxy_url)
+    if parsed_url.username and parsed_url.password:
+        default_headers = util.make_headers(proxy_basic_auth=f"{str(parsed_url.username)}:{str(parsed_url.password)}")
+    else:
+        default_headers = None
+    return default_headers


### PR DESCRIPTION
The whylabs writer had a ton of complex caching code embedded in it that depended heavily on self mutations and implicit updates. I tried to simplify the cache logic and make everything as explicit as I could so that the client cache would be reused from other places in the application. This moves the http proxy env var logic into the session config as well, where all of the config in whylogs now lives.

There were a lot of circular dependencies and initialization race conditions that made me introduce some lazy initialization. This also makes the new Session concept mandatory for using whylabs, which should have minimal impact because we can call it implicitly for people who don't call it themselves whenever the whylabs writer is used.

This doesn't allow the anonymous sessions to use the private s3 functionality, which seems ok for the moment. The anonymous sessions don't use the whylabs writer under the hood so that didn't come for free.

In general, we should always get the latest session with _default_init() instead of saving a reference to a session because the session can be reinitialized.


## Architectural change summary

### WhyLabs Writer
- Sessions are now required by the whylabs writer, but the whylabs writer implicitly initializes the session if the user didn't. The implicit init doesn't allow for anonymous usage though, just to avoid any surprises.
- If the writer is passed api key/org id/dataset id explicitly then it won't depend on the session.
- If the session is an anonymous session then the writer will throw if its created because it won't have any way of getting the credentials for uploading to WhyLabs. User can still directly supply api key to the writer if they want to use it directly for whatever reason. This behavior is similar to how it was before when the writer couldn't find anything in the env, but it goes through the session now.

### Client Cache
- Cache logic is no longer directly embedded in the whylabs writer as a series of mutations/side effects, it stands alone and anything can get cached instances of clients.
- Cache key is explicitly modeled instead of being a series of string concats with hashes.
- Cache key is immutable (frozen via dataclass)
- The session has to be the one to initialize the client cache, so the session is required now. This is because the session depends on the client cache to do uploads, while the cache depends on the session to get various env variable states. TLDR, either the user calls `why.init()` themselves or we call `_default_init()` as a fallback if we need to make sure the session exists.

### Sessions
- Various parts of the sessions are now lazy. Specifically the GuestSession fetching session ids. It used to happen in the __init__ but because of circular dependencies it now happens whenever its needed (profile upload time). This means that we can't tell the user their session id right after a session is made but it improves the overall experience because it happens on demand whenever the session is "bad" for any reason (like being claimed). Users used to have to reset the notebook kernel to generate a new session id and now it just works automatically (with a warning message when it happens).
- Nothing should ever hang onto the session reference because the user can reinitialize the session at any point. Everything should get a hold of the current session by doing one of these things:
    - `get_current_session()` will give you an optional Session object.
    - `_default_init()` will implicitly initialize a session if the user doesn't, or get the current one. This can be used if a session must exist for whatever reason. The implicitly initialized session is a local session, which means nothing will happen automatically.