### PR TITLE
Preserve metadata when uncompounding DatasetProfileView

### DIFF
--- a/python/tests/migration/test_uncompound.py
+++ b/python/tests/migration/test_uncompound.py
@@ -86,6 +86,21 @@ def test_uncompounded_image_profile() -> None:
     assert set(uncomp1.get_columns()) == set(uncompM.get_columns())
 
 
+def test_uncompounded_profile_metadata() -> None:
+    results = why.log({"a": 1.2})
+    view = results.view()
+    test_key = "test_key"
+    test_value = "metadata value"
+    test_metadata = {test_key: test_value}
+    assert view is not None
+    view._metadata = test_metadata
+    uncompounded = _uncompound_dataset_profile(view)
+    assert uncompounded is not None
+    assert uncompounded._metadata is not None
+    assert test_key in uncompounded._metadata
+    assert view._metadata[test_key] == test_value
+
+
 def test_uncompounded_condition_count() -> None:
     conditions = {
         "alpha": Condition(X.matches("[a-zA-Z]+")),

--- a/python/whylogs/migration/uncompound.py
+++ b/python/whylogs/migration/uncompound.py
@@ -157,6 +157,7 @@ def _uncompound_dataset_profile(prof: DatasetProfileView, flags: Optional[Featur
         dataset_timestamp=prof._dataset_timestamp,
         creation_timestamp=prof._creation_timestamp,
         metrics=prof._metrics,
+        metadata=prof._metadata,
     )
     new_columns: Dict[str, ColumnProfileView] = dict()
     for col_name, col_prof in new_prof._columns.items():


### PR DESCRIPTION
## Description

pass the internal _metadata to the copy created when uncompounding DatasetProfileView so that we can access debug metadata in WhyLabs.

## Changes

- pass the _metadata to the new profile when uncompounding 
- Add  unit test to cover the behavior.

## Related

Fixes #1349

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
