### PR TITLE
Don't log session init warning if running outside of notebook or ipython

### DIFF
--- a/python/whylogs/api/whylabs/session/session_manager.py
+++ b/python/whylogs/api/whylabs/session/session_manager.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 from whylabs_client.api_client import ApiClient, Configuration  # type: ignore
 
 from whylogs.api.whylabs.session.config import InitConfig, SessionConfig
+from whylogs.api.whylabs.session.notebook_check import is_interractive
 from whylogs.api.whylabs.session.session import (
     ApiKeySession,
     GuestSession,
@@ -147,7 +148,7 @@ def get_current_session() -> Optional[Session]:
     if manager is not None:
         return manager.session
 
-    if not _missing_session_warned:
+    if not _missing_session_warned and is_interractive():
         logger.warning(
             f"No session found. Call whylogs.init() to initialize a session and authenticate. See {_INIT_DOCS} for more information."
         )


### PR DESCRIPTION
## Description
Mitigates #1342  by avoiding the noisy log statement outside of interactive environments. 

## Changes

- check for interactive environment before logging a session init warning since these would not apply to headless scenarios yet.

## Related

See #1342. The warning is still confusing people in notebook environments but this should remove the warning from production integrations.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
