### PR TITLE
Switch to writing segmented profiles as v1 format.

### DIFF
--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -526,10 +526,7 @@ class WhyLabsWriter(Writer):
         upload_statuses = list()
         for view, url in zip(files, upload_urls):
             with tempfile.NamedTemporaryFile() as tmp_file:
-                if kwargs.get("use_v0") is None or kwargs.get("use_v0"):
-                    view.write(file=tmp_file, use_v0=True)
-                else:
-                    view.write(file=tmp_file)
+                view.write(file=tmp_file)
                 tmp_file.flush()
                 tmp_file.seek(0)
 
@@ -587,13 +584,7 @@ class WhyLabsWriter(Writer):
             self._dataset_id = kwargs.get("dataset_id")
 
         with tempfile.NamedTemporaryFile() as tmp_file:
-            # currently whylabs is not ingesting the v1 format of segmented profiles as segmented
-            # so we default to sending them as v0 profiles if the override `use_v0` is not defined,
-            # if `use_v0` is defined then pass that through to control the serialization format.
-            if has_segments and (kwargs.get("use_v0") is None or kwargs.get("use_v0")):
-                view.write(file=tmp_file, use_v0=True)
-            else:
-                view.write(file=tmp_file)
+            view.write(file=tmp_file)
             tmp_file.flush()
             tmp_file.seek(0)
             utc_now = datetime.datetime.now(datetime.timezone.utc)

--- a/python/whylogs/core/view/segmented_dataset_profile_view.py
+++ b/python/whylogs/core/view/segmented_dataset_profile_view.py
@@ -216,6 +216,7 @@ class SegmentedDatasetProfileView(Writable):
 
     def write(self, path: Optional[str] = None, **kwargs: Any) -> Tuple[bool, str]:
         if kwargs.get("use_v0"):
+            logger.warning("writing segmented profile as v0 format, some info may be converted")
             return self._write_as_v0_message(path, **kwargs)
         else:
             return self._write_v1(path, **kwargs)

--- a/python/whylogs/migration/converters.py
+++ b/python/whylogs/migration/converters.py
@@ -348,6 +348,11 @@ def v1_to_dataset_profile_message_v0(
         raise NotImplementedError(
             f"Conversion of custom v1 segmented profiles to v0 not supported! please use column value segmentation, found tags: {segment_tags}"
         )
+    if profile_view.metadata:
+        if segment_metadata is not None:
+            segment_metadata.update(profile_view.metadata)
+        else:
+            segment_metadata = profile_view.metadata
 
     properties_v0 = DatasetPropertiesV0(
         schema_major_version=1,  # https://github.com/whylabs/whylogs/blob/maintenance/0.7.x/src/whylogs/core/datasetprofile.py#L37-L38


### PR DESCRIPTION
## Description

Platform side WhyLabs can handle processing segmented profiles in v1 format, so we should stop converting automatically on upload in the whylabs writer.

Fixes #1360

## Changes

* Switch default behavior to writing segmented profiles as v1 format in whylabs writer.
* minor simpification
* log warning if passing use_v0 parameter.
Also published a dev build of these changes here:
```
!pip install whylogs[all]==1.3.4.dev0
```

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
