### PR TITLE
Update Getting Started notebook to use init

### DIFF
--- a/python/examples/integrations/writers/Getting_Started_with_WhyLabsV1.ipynb
+++ b/python/examples/integrations/writers/Getting_Started_with_WhyLabsV1.ipynb
@@ -117,7 +117,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 2,
       "id": "b78028ea-c7cb-494f-a303-071f1c345dfc",
       "metadata": {
         "colab": {
@@ -154,7 +154,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": 3,
       "id": "67b81ab4-a456-4d2d-9547-ad0d772e0aaa",
       "metadata": {
         "colab": {
@@ -471,7 +471,7 @@
               "[8 rows x 126 columns]"
             ]
           },
-          "execution_count": 9,
+          "execution_count": 3,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -510,16 +510,25 @@
       },
       "outputs": [],
       "source": [
-        "import getpass\n",
-        "import os\n",
+        "import whylogs as why\n",
         "\n",
-        "# set your org-id here\n",
-        "print(\"Enter your WhyLabs Org ID\")\n",
-        "os.environ[\"WHYLABS_DEFAULT_ORG_ID\"] = input()\n",
-        "# set your API key here\n",
-        "print(\"Enter your WhyLabs API key\")\n",
-        "os.environ[\"WHYLABS_API_KEY\"] = getpass.getpass()\n",
-        "print(\"Using API Key ID: \", os.environ[\"WHYLABS_API_KEY\"][0:10])"
+        "# Create a model in the dashboard and use that model id as the default dataset id in the prompt here. It will be\n",
+        "# saved in your whylogs conifg for future use. You can optionally supply reinit=True to reset your conifg. \n",
+        "why.init()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "49d0e0af",
+      "metadata": {},
+      "source": [
+        "You can run this init from the command line as well with.\n",
+        "\n",
+        "```bash\n",
+        "python -m whylogs.api.whylabs.session.why_init\n",
+        "```\n",
+        "\n",
+        "You can use this to reset your config if you want to change your api key or default dataset it."
       ]
     },
     {
@@ -547,7 +556,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 5,
       "id": "3a006a2b-8403-477f-a1f5-a37ea33b160c",
       "metadata": {
         "colab": {
@@ -561,14 +570,41 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Enter your model ID from WhyLabs:\n",
-            "Logged data for 2022-09-15 22:33:57.496049+00:00 writing to WhyLabs\n",
-            "Logged data for 2022-09-14 22:33:59.389619+00:00 writing to WhyLabs\n",
-            "Logged data for 2022-09-13 22:34:00.706354+00:00 writing to WhyLabs\n",
-            "Logged data for 2022-09-12 22:34:02.056278+00:00 writing to WhyLabs\n",
-            "Logged data for 2022-09-11 22:34:03.369750+00:00 writing to WhyLabs\n",
-            "Logged data for 2022-09-10 22:34:04.674566+00:00 writing to WhyLabs\n",
-            "Logged data for 2022-09-09 22:34:05.995988+00:00 writing to WhyLabs\n"
+            "\n",
+            "✅ Aggregated 407 rows into profile \n",
+            "\n",
+            "Visualize and explore this profile with one-click\n",
+            "🔍 https://hub.whylabsapp.com/resources/model-62/profiles?profile=1694131200000\n",
+            "\n",
+            "✅ Aggregated 390 rows into profile \n",
+            "\n",
+            "Visualize and explore this profile with one-click\n",
+            "🔍 https://hub.whylabsapp.com/resources/model-62/profiles?profile=1694044800000\n",
+            "\n",
+            "✅ Aggregated 382 rows into profile \n",
+            "\n",
+            "Visualize and explore this profile with one-click\n",
+            "🔍 https://hub.whylabsapp.com/resources/model-62/profiles?profile=1693958400000\n",
+            "\n",
+            "✅ Aggregated 371 rows into profile \n",
+            "\n",
+            "Visualize and explore this profile with one-click\n",
+            "🔍 https://hub.whylabsapp.com/resources/model-62/profiles?profile=1693872000000\n",
+            "\n",
+            "✅ Aggregated 301 rows into profile \n",
+            "\n",
+            "Visualize and explore this profile with one-click\n",
+            "🔍 https://hub.whylabsapp.com/resources/model-62/profiles?profile=1693785600000\n",
+            "\n",
+            "✅ Aggregated 392 rows into profile \n",
+            "\n",
+            "Visualize and explore this profile with one-click\n",
+            "🔍 https://hub.whylabsapp.com/resources/model-62/profiles?profile=1693699200000\n",
+            "\n",
+            "✅ Aggregated 283 rows into profile \n",
+            "\n",
+            "Visualize and explore this profile with one-click\n",
+            "🔍 https://hub.whylabsapp.com/resources/model-62/profiles?profile=1693612800000\n"
           ]
         }
       ],
@@ -577,21 +613,13 @@
         "import whylogs as why\n",
         "import datetime\n",
         "\n",
-        "print(\"Enter your model ID from WhyLabs:\")\n",
-        "model_id = input()\n",
-        "writer = WhyLabsWriter(dataset_id=model_id)\n",
         "for i, df in enumerate(pdfs):\n",
         "    # walking backwards. Each dataset has to map to a date to show up as a different batch\n",
         "    # in WhyLabs\n",
         "    dt = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=i)\n",
         "\n",
         "    # log each day's data and set the date on the profile\n",
-        "    profile = why.log(df).profile()\n",
-        "    profile.set_dataset_timestamp(dt)\n",
-        "\n",
-        "    print(f\"Logged data for {dt} writing to WhyLabs\")\n",
-        "    # write the profile to WhyLabs. Note you could also use the local or s3 writer here.\n",
-        "    writer.write(file=profile)\n"
+        "    profile = why.log(df, dataset_timestamp=dt).profile()"
       ]
     },
     {
@@ -608,7 +636,12 @@
       },
       "outputs": [],
       "source": [
+        "from whylogs.api.whylabs.session.session_manager import get_current_session\n",
         "from IPython.core.display import HTML\n",
+        "\n",
+        "session = get_current_session()\n",
+        "model_id = session.config.get_default_dataset_id()\n",
+        "\n",
         "HTML(f'To view your statistics, go to the <a href=\"https://hub.whylabsapp.com/models/{model_id}/summary\" target=\"_blank\">model dashboard</a>')"
       ]
     },
@@ -672,7 +705,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.8.10"
+      "version": "3.9.16"
     },
     "vscode": {
       "interpreter": {

--- a/python/examples/integrations/writers/Writing_Feature_Weights_to_WhyLabs.ipynb
+++ b/python/examples/integrations/writers/Writing_Feature_Weights_to_WhyLabs.ipynb
@@ -63,9 +63,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: whylogs in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (1.3.1)\n",
+      "Requirement already satisfied: platformdirs<4.0.0,>=3.5.0 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylogs) (3.10.0)\n",
+      "Requirement already satisfied: protobuf>=3.19.4 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylogs) (4.24.2)\n",
+      "Requirement already satisfied: requests<3.0,>=2.27 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylogs) (2.31.0)\n",
+      "Requirement already satisfied: types-requests<3.0.0.0,>=2.30.0.0 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylogs) (2.31.0.2)\n",
+      "Requirement already satisfied: typing-extensions>=3.10 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylogs) (4.7.1)\n",
+      "Requirement already satisfied: whylabs-client<0.6.0,>=0.5.5 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylogs) (0.5.5)\n",
+      "Requirement already satisfied: whylogs-sketching>=3.4.1.dev3 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylogs) (3.4.1.dev3)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from requests<3.0,>=2.27->whylogs) (3.2.0)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from requests<3.0,>=2.27->whylogs) (3.4)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from requests<3.0,>=2.27->whylogs) (1.26.16)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from requests<3.0,>=2.27->whylogs) (2023.7.22)\n",
+      "Requirement already satisfied: types-urllib3 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from types-requests<3.0.0.0,>=2.30.0.0->whylogs) (1.26.25.14)\n",
+      "Requirement already satisfied: python-dateutil in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylabs-client<0.6.0,>=0.5.5->whylogs) (2.8.2)\n",
+      "Requirement already satisfied: six>=1.5 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from python-dateutil->whylabs-client<0.6.0,>=0.5.5->whylogs) (1.16.0)\n",
+      "\u001b[33mDEPRECATION: feast 0.22.4 has a non-standard dependency specifier googleapis-common-protos<2,>=1.52.*. pip 23.3 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of feast or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063\u001b[0m\u001b[33m\n",
+      "\u001b[0m\u001b[33mDEPRECATION: feast 0.22.4 has a non-standard dependency specifier PyYAML<7,>=5.4.*. pip 23.3 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of feast or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063\u001b[0m\u001b[33m\n",
+      "\u001b[0m\u001b[33mDEPRECATION: feast 0.22.4 has a non-standard dependency specifier dask<2022.02.0,>=2021.*. pip 23.3 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of feast or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063\u001b[0m\u001b[33m\n",
+      "\u001b[0mNote: you may need to restart the kernel to use updated packages.\n",
+      "Collecting scikit-learn==1.0.2\n",
+      "  Downloading scikit_learn-1.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (26.4 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m26.4/26.4 MB\u001b[0m \u001b[31m3.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: numpy>=1.14.6 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from scikit-learn==1.0.2) (1.25.2)\n",
+      "Requirement already satisfied: scipy>=1.1.0 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from scikit-learn==1.0.2) (1.9.3)\n",
+      "Requirement already satisfied: joblib>=0.11 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from scikit-learn==1.0.2) (1.3.2)\n",
+      "Requirement already satisfied: threadpoolctl>=2.0.0 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from scikit-learn==1.0.2) (3.2.0)\n",
+      "\u001b[33mDEPRECATION: feast 0.22.4 has a non-standard dependency specifier googleapis-common-protos<2,>=1.52.*. pip 23.3 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of feast or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063\u001b[0m\u001b[33m\n",
+      "\u001b[0m\u001b[33mDEPRECATION: feast 0.22.4 has a non-standard dependency specifier PyYAML<7,>=5.4.*. pip 23.3 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of feast or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063\u001b[0m\u001b[33m\n",
+      "\u001b[0m\u001b[33mDEPRECATION: feast 0.22.4 has a non-standard dependency specifier dask<2022.02.0,>=2021.*. pip 23.3 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of feast or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063\u001b[0m\u001b[33m\n",
+      "\u001b[0mInstalling collected packages: scikit-learn\n",
+      "  Attempting uninstall: scikit-learn\n",
+      "    Found existing installation: scikit-learn 1.3.0\n",
+      "    Uninstalling scikit-learn-1.3.0:\n",
+      "      Successfully uninstalled scikit-learn-1.3.0\n",
+      "Successfully installed scikit-learn-1.0.2\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "# Note: you may need to restart the kernel to use updated packages.\n",
     "%pip install whylogs\n",
@@ -86,25 +129,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'Feature_0': -3.330399790430435e-15,\n",
-       " 'Feature_1': 12.44482785538977,\n",
-       " 'Feature_2': -4.393883142916863e-14,\n",
-       " 'Feature_3': -2.7047779443616894e-14,\n",
+       "{'Feature_0': 3.4778530780712388e-15,\n",
+       " 'Feature_1': 12.444827855389764,\n",
+       " 'Feature_2': -3.108624468950438e-14,\n",
+       " 'Feature_3': -1.9095836023552692e-14,\n",
        " 'Feature_4': 93.32225450776932,\n",
-       " 'Feature_5': 86.50810998606804,\n",
-       " 'Feature_6': 26.746066698034504,\n",
-       " 'Feature_7': 3.285346398262185,\n",
-       " 'Feature_8': -2.7795267559640957e-14,\n",
-       " 'Feature_9': 3.430594380756143e-14}"
+       " 'Feature_5': 86.50810998606799,\n",
+       " 'Feature_6': 26.74606669803453,\n",
+       " 'Feature_7': 3.285346398262155,\n",
+       " 'Feature_8': -2.531308496145357e-14,\n",
+       " 'Feature_9': 1.9539925233402755e-14}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -157,26 +200,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initializing session with config /home/anthony/.config/whylogs/config.ini\n",
+      "\n",
+      "✅ Using session type: WHYLABS\n",
+      " ⤷ org id: org-JpsdM6\n",
+      " ⤷ api key: l70gARzBVZ\n",
+      " ⤷ default dataset: model-66\n",
+      "\n",
+      "In production, you should pass the api key as an environment variable WHYLABS_API_KEY, the org id as WHYLABS_DEFAULT_ORG_ID, and the default dataset id as WHYLABS_DEFAULT_DATASET_ID.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<whylogs.api.whylabs.session.session.ApiKeySession at 0x7fd8b24392b0>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "import getpass\n",
-    "import os\n",
+    "import whylogs as why\n",
     "\n",
-    "# set your org-id here - should be something like \"org-xxxx\"\n",
-    "print(\"Enter your WhyLabs Org ID\") \n",
-    "os.environ[\"WHYLABS_DEFAULT_ORG_ID\"] = input()\n",
-    "\n",
-    "# set your datased_id (or model_id) here - should be something like \"model-xxxx\"\n",
-    "print(\"Enter your WhyLabs Dataset ID\")\n",
-    "os.environ[\"WHYLABS_DEFAULT_DATASET_ID\"] = input()\n",
-    "\n",
-    "# set your API key here\n",
-    "print(\"Enter your WhyLabs API key\")\n",
-    "os.environ[\"WHYLABS_API_KEY\"] = getpass.getpass()\n",
-    "\n",
-    "print(\"Using API Key ID: \", os.environ[\"WHYLABS_API_KEY\"][0:10])"
+    "why.init()"
    ]
   },
   {
@@ -199,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -226,7 +281,7 @@
        "(True, '200')"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -248,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -257,7 +312,7 @@
        "(True, '200')"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -278,15 +333,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'Feature_4': 93.32225450776932, 'Feature_5': 86.50810998606804, 'Feature_6': 26.746066698034504, 'Feature_1': 12.44482785538977, 'Feature_7': 3.285346398262185, 'Feature_2': -4.393883142916863e-14, 'Feature_9': 3.430594380756143e-14, 'Feature_8': -2.7795267559640957e-14, 'Feature_3': -2.7047779443616894e-14, 'Feature_0': -3.330399790430435e-15}\n",
-      "{'version': 28, 'updatedTimestamp': 1664373654215, 'author': 'system'}\n"
+      "{'Feature_4': 93.32225450776932, 'Feature_5': 86.50810998606799, 'Feature_6': 26.74606669803453, 'Feature_1': 12.444827855389764, 'Feature_7': 3.285346398262155, 'Feature_2': -3.108624468950438e-14, 'Feature_8': -2.531308496145357e-14, 'Feature_9': 1.9539925233402755e-14, 'Feature_3': -1.9095836023552692e-14, 'Feature_0': 3.4778530780712388e-15}\n",
+      "{'author': 'system', 'updated_timestamp': 1694207704547, 'version': 2}\n"
      ]
     }
    ],
@@ -342,7 +397,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.16"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/python/examples/integrations/writers/Writing_Reference_Profiles_to_WhyLabs.ipynb
+++ b/python/examples/integrations/writers/Writing_Reference_Profiles_to_WhyLabs.ipynb
@@ -61,7 +61,33 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: whylogs in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (1.3.1)\n",
+      "Requirement already satisfied: platformdirs<4.0.0,>=3.5.0 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylogs) (3.10.0)\n",
+      "Requirement already satisfied: protobuf>=3.19.4 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylogs) (4.24.2)\n",
+      "Requirement already satisfied: requests<3.0,>=2.27 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylogs) (2.31.0)\n",
+      "Requirement already satisfied: types-requests<3.0.0.0,>=2.30.0.0 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylogs) (2.31.0.2)\n",
+      "Requirement already satisfied: typing-extensions>=3.10 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylogs) (4.7.1)\n",
+      "Requirement already satisfied: whylabs-client<0.6.0,>=0.5.5 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylogs) (0.5.5)\n",
+      "Requirement already satisfied: whylogs-sketching>=3.4.1.dev3 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylogs) (3.4.1.dev3)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from requests<3.0,>=2.27->whylogs) (3.2.0)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from requests<3.0,>=2.27->whylogs) (3.4)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from requests<3.0,>=2.27->whylogs) (1.26.16)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from requests<3.0,>=2.27->whylogs) (2023.7.22)\n",
+      "Requirement already satisfied: types-urllib3 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from types-requests<3.0.0.0,>=2.30.0.0->whylogs) (1.26.25.14)\n",
+      "Requirement already satisfied: python-dateutil in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from whylabs-client<0.6.0,>=0.5.5->whylogs) (2.8.2)\n",
+      "Requirement already satisfied: six>=1.5 in /home/anthony/workspace/whylogs/python/.venv/lib/python3.9/site-packages (from python-dateutil->whylabs-client<0.6.0,>=0.5.5->whylogs) (1.16.0)\n",
+      "\u001b[33mDEPRECATION: feast 0.22.4 has a non-standard dependency specifier googleapis-common-protos<2,>=1.52.*. pip 23.3 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of feast or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063\u001b[0m\u001b[33m\n",
+      "\u001b[0m\u001b[33mDEPRECATION: feast 0.22.4 has a non-standard dependency specifier PyYAML<7,>=5.4.*. pip 23.3 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of feast or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063\u001b[0m\u001b[33m\n",
+      "\u001b[0m\u001b[33mDEPRECATION: feast 0.22.4 has a non-standard dependency specifier dask<2022.02.0,>=2021.*. pip 23.3 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of feast or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063\u001b[0m\u001b[33m\n",
+      "\u001b[0mNote: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "# Note: you may need to restart the kernel to use updated packages.\n",
     "%pip install whylogs"
@@ -95,37 +121,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Enter your WhyLabs Org ID\n",
-      "Enter your WhyLabs Dataset ID\n",
-      "Enter your WhyLabs API key\n",
-      "Using API Key ID:  ygG04qE3gQ\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import getpass\n",
-    "import os\n",
+    "import whylogs as why\n",
     "\n",
-    "# set your org-id here - should be something like \"org-xxxx\"\n",
-    "print(\"Enter your WhyLabs Org ID\") \n",
-    "os.environ[\"WHYLABS_DEFAULT_ORG_ID\"] = input()\n",
-    "\n",
-    "# set your datased_id (or model_id) here - should be something like \"model-xxxx\"\n",
-    "print(\"Enter your WhyLabs Dataset ID\")\n",
-    "os.environ[\"WHYLABS_DEFAULT_DATASET_ID\"] = input()\n",
-    "\n",
-    "# set your API key here\n",
-    "print(\"Enter your WhyLabs API key\")\n",
-    "os.environ[\"WHYLABS_API_KEY\"] = getpass.getpass()\n",
-    "\n",
-    "print(\"Using API Key ID: \", os.environ[\"WHYLABS_API_KEY\"][0:10])"
+    "why.init()"
    ]
   },
   {
@@ -140,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -281,7 +283,7 @@
        "4         Purchase  39.0  "
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -307,15 +309,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import whylogs as why\n",
     "from datetime import datetime, timezone\n",
     "current_date = datetime.now(timezone.utc)\n",
-    "profile = why.log(df).profile()\n",
-    "profile.set_dataset_timestamp(current_date)"
+    "profile = why.log(df, dataset_timestamp=current_date, name=\"tour\")"
    ]
   },
   {
@@ -323,7 +324,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We're also setting the profile's dataset timestamp as the current datetime. If this is not set, the Writer would simply assign the current datetime automatically to the profile."
+    "We're setting the profile's dataset timestamp as the current datetime. If this is not set, the Writer would simply assign the current datetime automatically to the profile."
    ]
   },
   {
@@ -331,77 +332,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## ✍️ The WhyLabs Writer"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now, you can simply create a WhyLabsWriter object and use it to send your profiles.\n",
-    "The process is very similar to sending a regular profile. The only difference is you should the `option` method in order to pass `reference_profile_name` to indicate and name this profile as a static Reference Profile:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from whylogs.api.writer.whylabs import WhyLabsWriter\n",
-    "\n",
-    "writer = WhyLabsWriter().option(reference_profile_name=\"my_reference_profile\")\n",
-    "writer.write(file=profile.view())"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "> Another way of setting `reference_profile_name` is to define the environment variable `WHYLABS_REFERENCE_PROFILE_NAME`\n",
-    "\n",
-    "A `200` response should mean that it went through successfully.\n",
-    "\n",
-    "The writer expects a __Profile View__ as parameter."
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Option #2: Profile Result writer"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A second way to write to WhyLabs is by directly using the `writer` method of a __Profile Result__ set.\n",
-    "\n",
-    "Again, this is very much alike sending regular profiles to WhyLabs. The only difference is using the `option` method just as before:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "profile_results = why.log(df)\n",
-    "profile_results.writer(\"whylabs\").option(reference_profile_name=\"\").write()"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In this case, we passed an empty string as the reference profile name. This will still make the profile to be considered a Static Profile, but its name will be set to the datetime it was created, something like:\n",
-    "`ref-2022-08-16T17:53:49.041`"
+    "In this case, We named the refrence profile `tour`, which means we can find it in the profile page under that name. We could also name it `\"\"` (empty string) which tells WhyLabs to generate a name for it based on the timestamp, like `ref-2022-08-16T17:53:49.041`"
    ]
   },
   {
@@ -447,7 +378,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.16"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/python/examples/integrations/writers/Writing_to_WhyLabs.ipynb
+++ b/python/examples/integrations/writers/Writing_to_WhyLabs.ipynb
@@ -96,26 +96,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import getpass\n",
-    "import os\n",
+    "import whylogs as why\n",
     "\n",
-    "# set your org-id here - should be something like \"org-xxxx\"\n",
-    "print(\"Enter your WhyLabs Org ID\") \n",
-    "os.environ[\"WHYLABS_DEFAULT_ORG_ID\"] = input()\n",
+    "why.init()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
-    "# set your datased_id (or model_id) here - should be something like \"model-xxxx\"\n",
-    "print(\"Enter your WhyLabs Dataset ID\")\n",
-    "os.environ[\"WHYLABS_DEFAULT_DATASET_ID\"] = input()\n",
-    "\n",
-    "\n",
-    "# set your API key here\n",
-    "print(\"Enter your WhyLabs API key\")\n",
-    "os.environ[\"WHYLABS_API_KEY\"] = getpass.getpass()\n",
-    "print(\"Using API Key ID: \", os.environ[\"WHYLABS_API_KEY\"][0:10])\n"
+    "Normally, uploads are done automatically after logging when you use why.init, but this notebook demonstrates\n",
+    "manual WhyLabs uploads using the WhyLabs writer API, which you might need if you're doing something custom with\n",
+    "the profiles before they get uploaded. Doing this will disable automatic uploads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "why.init(force_local=True, reinit=True)"
    ]
   },
   {
@@ -136,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -277,7 +283,7 @@
        "4         Purchase  39.0  "
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -309,16 +315,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import whylogs as why\n",
     "from datetime import datetime, timezone\n",
     "\n",
-    "current_date = datetime.now(tz=timezone.utc)\n",
-    "profile = why.log(df).profile()\n",
-    "profile.set_dataset_timestamp(current_date)"
+    "profile = why.log(df, dataset_timestamp=datetime.now(tz=timezone.utc)).profile()"
    ]
   },
   {
@@ -349,16 +352,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(True, 'log-0GVvS7QaiQimvyAo')"
+       "(True, 'log-f8V2ZqQLLXXlBIwi')"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -366,6 +369,7 @@
    "source": [
     "from whylogs.api.writer.whylabs import WhyLabsWriter\n",
     "\n",
+    "# The writer uses the same credentials that you set up in why.init\n",
     "writer = WhyLabsWriter()\n",
     "writer.write(file=profile.view())"
    ]
@@ -398,16 +402,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(True, 'log-rqIB3CwupXqAD3Mg')]"
+       "[(True, 'log-F8p8MMkxQ7U6PxjG')]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -464,20 +468,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Logged profile for 2023-07-26 14:32:34.189991+00:00\n",
-      "Logged profile for 2023-07-25 14:32:37.045585+00:00\n",
-      "Logged profile for 2023-07-24 14:32:38.582456+00:00\n",
-      "Logged profile for 2023-07-23 14:32:40.233105+00:00\n",
-      "Logged profile for 2023-07-22 14:32:41.752926+00:00\n",
-      "Logged profile for 2023-07-21 14:32:43.296560+00:00\n",
-      "Logged profile for 2023-07-20 14:32:44.850047+00:00\n"
+      "Logged profile for 2023-09-08 20:45:08.661221+00:00\n",
+      "Logged profile for 2023-09-07 20:45:09.714203+00:00\n",
+      "Logged profile for 2023-09-06 20:45:10.755056+00:00\n",
+      "Logged profile for 2023-09-05 20:45:11.696173+00:00\n",
+      "Logged profile for 2023-09-04 20:45:12.807533+00:00\n",
+      "Logged profile for 2023-09-03 20:45:13.793383+00:00\n",
+      "Logged profile for 2023-09-02 20:45:14.460016+00:00\n"
      ]
     }
    ],
@@ -490,16 +494,12 @@
     "\n",
     "df_splits = np.array_split(df, 7)\n",
     "\n",
-    "def log_data(df,timestamp):\n",
-    "    profile = why.log(df).profile()\n",
-    "    profile.set_dataset_timestamp(timestamp)\n",
-    "    writer.write(profile.view())\n",
-    "    print(\"Logged profile for {}\".format(timestamp))\n",
-    "\n",
     "# This will log each data split for the last 7 days, starting with the current date and finishing 7 days in the past\n",
     "for day, df_split in enumerate(df_splits):\n",
-    "    dataset_timestamp = datetime.now(tz=timezone.utc) - timedelta(days=day)\n",
-    "    log_data(df_split,dataset_timestamp)"
+    "    timestamp = datetime.now(tz=timezone.utc) - timedelta(days=day)\n",
+    "    profile = why.log(df, dataset_timestamp=timestamp).profile()\n",
+    "    writer.write(profile.view())\n",
+    "    print(\"Logged profile for {}\".format(timestamp))"
    ]
   },
   {
@@ -517,22 +517,67 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "profiling batch: 0 out of 10 batches of data\n",
+      "profiling batch: 0 out of 10 batches of data\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "trace_id was specified as None but there is already a trace_id defined in metadata[whylabs.traceId]: 717a6394-cef6-46f7-8f0f-38d8cbdfee0b\n",
+      "trace_id was specified as None but there is already a trace_id defined in metadata[whylabs.traceId]: 717a6394-cef6-46f7-8f0f-38d8cbdfee0b\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "profiling batch: 1 out of 10 batches of data\n",
       "profiling batch: 2 out of 10 batches of data\n",
-      "profiling batch: 3 out of 10 batches of data\n",
+      "profiling batch: 3 out of 10 batches of data\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "trace_id was specified as None but there is already a trace_id defined in metadata[whylabs.traceId]: 717a6394-cef6-46f7-8f0f-38d8cbdfee0b\n",
+      "trace_id was specified as None but there is already a trace_id defined in metadata[whylabs.traceId]: 717a6394-cef6-46f7-8f0f-38d8cbdfee0b\n",
+      "trace_id was specified as None but there is already a trace_id defined in metadata[whylabs.traceId]: 717a6394-cef6-46f7-8f0f-38d8cbdfee0b\n",
+      "trace_id was specified as None but there is already a trace_id defined in metadata[whylabs.traceId]: 717a6394-cef6-46f7-8f0f-38d8cbdfee0b\n",
+      "trace_id was specified as None but there is already a trace_id defined in metadata[whylabs.traceId]: 717a6394-cef6-46f7-8f0f-38d8cbdfee0b\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "profiling batch: 4 out of 10 batches of data\n",
       "profiling batch: 5 out of 10 batches of data\n",
       "profiling batch: 6 out of 10 batches of data\n",
       "profiling batch: 7 out of 10 batches of data\n",
-      "profiling batch: 8 out of 10 batches of data\n",
+      "profiling batch: 8 out of 10 batches of data\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "trace_id was specified as None but there is already a trace_id defined in metadata[whylabs.traceId]: 717a6394-cef6-46f7-8f0f-38d8cbdfee0b\n",
+      "trace_id was specified as None but there is already a trace_id defined in metadata[whylabs.traceId]: 717a6394-cef6-46f7-8f0f-38d8cbdfee0b\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "profiling batch: 9 out of 10 batches of data\n"
      ]
     }
@@ -577,15 +622,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:whylogs.api.writer.whylabs:About to upload a profile with a dataset_timestamp that is in the future: -283.243124961853s old.\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-     "Uploaded with <whylogs.api.writer.whylabs.WhyLabsWriter object at 0x7f5506ed4160>, profile with timestamp: 2023-07-26 14:45:00+00:00 and filename profile.2023-07-26_07-45.bin\n",
-     "Uploaded with <whylogs.api.writer.local.LocalWriter object at 0x7f5507a38820>, profile with timestamp: 2023-07-26 14:45:00+00:00 and filename profile.2023-07-26_07-45.bin\n"
+      "Uploaded with <whylogs.api.writer.whylabs.WhyLabsWriter object at 0x7f001c0a2d60>, profile with timestamp: 2023-09-08 20:50:00+00:00 and filename profile.2023-09-08_13-50.bin\n",
+      "Uploaded with <whylogs.api.writer.local.LocalWriter object at 0x7f001c0d2280>, profile with timestamp: 2023-09-08 20:50:00+00:00 and filename profile.2023-09-08_13-50.bin\n"
      ]
     }
    ],
@@ -602,14 +654,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "profile.2023-07-26_07-45.bin\n"
+      "profile.2023-09-08_13-45.bin  profile.2023-09-08_13-50.bin\n"
      ]
     }
    ],
@@ -634,7 +686,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.16"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/python/whylogs/api/logger/__init__.py
+++ b/python/whylogs/api/logger/__init__.py
@@ -83,8 +83,6 @@ def _log_with_metrics(
         results = log(pandas=data, schema=schema, dataset_timestamp=dataset_timestamp)
     else:
         results = ProfileResultSet(DatasetProfile(schema=schema))
-        if dataset_timestamp is not None:
-            results.set_dataset_timestamp(dataset_timestamp)
 
     results.add_model_performance_metrics(metrics)
     return results
@@ -108,6 +106,7 @@ def _segmented_performance_metrics(
     data: pd.DataFrame,
     performance_column_mapping: Dict[str, Optional[str]],
     performance_metric: str,
+    dataset_timestamp: Optional[datetime] = None,
 ) -> SegmentedResultSet:
     segmented_profiles = dict()
     segment_partitions = list()
@@ -137,7 +136,11 @@ def _segmented_performance_metrics(
         segmented_profiles[partition.id] = partition_segments
         segment_partitions.append(partition)
 
-    return SegmentedResultSet(segments=segmented_profiles, partitions=segment_partitions)
+    result_set = SegmentedResultSet(segments=segmented_profiles, partitions=segment_partitions)
+    if dataset_timestamp is not None:
+        result_set.set_dataset_timestamp(dataset_timestamp)
+
+    return result_set
 
 
 def log_classification_metrics(
@@ -147,6 +150,7 @@ def log_classification_metrics(
     score_column: Optional[str] = None,
     schema: Optional[DatasetSchema] = None,
     log_full_data: bool = False,
+    dataset_timestamp: Optional[datetime] = None,
 ) -> ResultSet:
     """
     Function to track metrics based on validation data.
@@ -172,13 +176,20 @@ def log_classification_metrics(
             data=data,
             performance_column_mapping=perf_column_mapping,
             performance_metric="compute_confusion_matrix",
+            dataset_timestamp=dataset_timestamp,
         )
 
     model_performance_metrics = _performance_metric(
         pandas=data, perf_columns=perf_column_mapping, metric_name="compute_confusion_matrix"
     )
 
-    return _log_with_metrics(data=data, metrics=model_performance_metrics, schema=schema, include_data=log_full_data)
+    return _log_with_metrics(
+        data=data,
+        metrics=model_performance_metrics,
+        schema=schema,
+        include_data=log_full_data,
+        dataset_timestamp=dataset_timestamp,
+    )
 
 
 def log_regression_metrics(
@@ -212,6 +223,7 @@ def log_regression_metrics(
             data=data,
             performance_column_mapping=perf_column_mapping,
             performance_metric="compute_regression_metrics",
+            dataset_timestamp=dataset_timestamp,
         )
 
     model_performance_metrics = _performance_metric(

--- a/python/whylogs/api/whylabs/session/config.py
+++ b/python/whylogs/api/whylabs/session/config.py
@@ -315,6 +315,13 @@ class SessionConfig:
         if default_dataset_id:
             il.option(f"default dataset: {default_dataset_id}")
 
+        il.message()
+        il.message(
+            f"In production, you should pass the api key as an environment variable {EnvVariableName.WHYLABS_API_KEY.value}, "
+            f"the org id as {EnvVariableName.WHYLABS_ORG_ID.value}, and the default dataset id as "
+            f"{EnvVariableName.WHYLABS_DEFAULT_DATASET_ID.value}."
+        )
+
     def _notify_type_anon(self) -> None:
         anonymous_session_id = self.get_session_id()
         il.success(f"Using session type: {SessionType.WHYLABS_ANONYMOUS.name}", ignore_suppress=True)

--- a/python/whylogs/api/whylabs/session/notebook_logger.py
+++ b/python/whylogs/api/whylabs/session/notebook_logger.py
@@ -71,9 +71,6 @@ def notebook_session_log(
     if session is None:
         return
     elif session.get_type() == SessionType.LOCAL:
-        il.warning_once(
-            "Skipping automatic upload because the session type is LOCAL. Uploads have to be done manually."
-        )
         return
 
     # Get the length of whatever was just logged

--- a/python/whylogs/api/whylabs/session/prompts.py
+++ b/python/whylogs/api/whylabs/session/prompts.py
@@ -1,3 +1,4 @@
+import getpass
 import sys
 from typing import List, Optional
 
@@ -57,7 +58,7 @@ def prompt_api_key() -> ApiKey:
         try:
             sys.stdout.flush()
             il.message(ignore_suppress=True)
-            api_key = input(
+            api_key = getpass.getpass(
                 "Enter your WhyLabs api key. You can find it at https://hub.whylabsapp.com/settings/access-tokens: "
             )
             return parse_api_key(api_key)


### PR DESCRIPTION
Just a small sample of how the docs/ux will look after the update to include init(). We can use this to make tweaks or back compat fixes before switching more things over.

Gaps:
- There isn't an easy way to make segmented classification/regression metrics work because those don't use why.log under the hood, so I'll have to make a custom integration for them at some point. Just left those examples the same (no init).
