### PR TITLE
Fix CI badge link in README.md

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -26,7 +26,7 @@
     <img src="https://pepy.tech/badge/whylogs" alt="PyPi Downloads">
 </a>
 <a href="bit.ly/whylogs" target="_blank">
-    <img src="https://github.com/whylabs/whylogs-python/workflows/whylogs%20CI/badge.svg" alt="CI">
+    <img src="https://github.com/whylabs/whylogs/actions/workflows/whylogs-ci.yml/badge.svg" alt="CI">
 </a>
 <a href="https://codeclimate.com/github/whylabs/whylogs-python/maintainability" target="_blank">
     <img src="https://api.codeclimate.com/v1/badges/442f6ca3dca1e583a488/maintainability" alt="Maintainability">


### PR DESCRIPTION
## Description

fixes #1368 

The link to our CI badge appears broken, this update works:
https://github.com/whylabs/whylogs/actions/workflows/whylogs-ci.yml/badge.svg

Made some updates based on the documentation here: https://docs.github.com/en/actions/monitoring-and-troubleshooting-

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
