### PR TITLE
Fix typo in whylabs session config error message

### DIFF
--- a/python/whylogs/api/whylabs/session/config.py
+++ b/python/whylogs/api/whylabs/session/config.py
@@ -248,7 +248,7 @@ class SessionConfig:
         if value is None:
             session_type = self.get_session_type()
             raise ValueError(
-                f"Can't determine {name}. Current session type if {session_type.value}. "
+                f"Can't determine {name}. Current session type is {session_type.value}. "
                 f"See {_INIT_DOCS} for instructions on using why.init()."
             )
 

--- a/python/whylogs/api/writer/writer.py
+++ b/python/whylogs/api/writer/writer.py
@@ -29,8 +29,9 @@ class Writer(ABC):
     def check_interval(self, interval_seconds: int) -> None:
         """Validate an interval configuration for a given writer.
 
-        Some writer only accepts certain interval configuration. By default, this should return True for a valid
-        non-negative interval."""
+        Some writer only accepts certain interval configuration. Raise BadConfigError for
+        an unacceptable interval."""
+        pass
 
     @abstractmethod
     def write(


### PR DESCRIPTION
s/if/is/

Also corrects `writer::check_interval()` doctoring