### PR TITLE
remove 7-day old profile warning

### DIFF
--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -603,12 +603,6 @@ class WhyLabsWriter(Writer):
                         f"compared to current datetime: {utc_now}. Uploads of profiles older than 5 years "
                         "might not be monitored in WhyLabs and may take up to 24 hours to show up."
                     )
-                else:
-                    logger.warning(
-                        f"A profile being uploaded to WhyLabs has a dataset_timestamp of {dataset_timestamp} "
-                        f"which is older than 7 days compared to {utc_now}. These profiles should be processed "
-                        f"within 24 hours."
-                    )
 
             if stamp <= 0:
                 logger.error(

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -60,7 +60,6 @@ from whylogs.migration.uncompound import (
 
 FIVE_MINUTES_IN_SECONDS = 60 * 5
 DAY_IN_SECONDS = 60 * 60 * 24
-WEEK_IN_SECONDS = DAY_IN_SECONDS * 7
 FIVE_YEARS_IN_SECONDS = DAY_IN_SECONDS * 365 * 5
 logger = logging.getLogger(__name__)
 
@@ -596,13 +595,12 @@ class WhyLabsWriter(Writer):
                     f"About to upload a profile with a dataset_timestamp that is in the future: "
                     f"{time_delta_seconds}s old."
                 )
-            elif time_delta_seconds > WEEK_IN_SECONDS:
-                if time_delta_seconds > FIVE_YEARS_IN_SECONDS:
-                    logger.error(
-                        f"A profile being uploaded to WhyLabs has a dataset_timestamp of({dataset_timestamp}) "
-                        f"compared to current datetime: {utc_now}. Uploads of profiles older than 5 years "
-                        "might not be monitored in WhyLabs and may take up to 24 hours to show up."
-                    )
+            if time_delta_seconds > FIVE_YEARS_IN_SECONDS:
+                logger.error(
+                    f"A profile being uploaded to WhyLabs has a dataset_timestamp of({dataset_timestamp}) "
+                    f"compared to current datetime: {utc_now}. Uploads of profiles older than 5 years "
+                    "might not be monitored in WhyLabs and may take up to 24 hours to show up."
+                )
 
             if stamp <= 0:
                 logger.error(


### PR DESCRIPTION
## Description

Removes whylabs writer warning for 7-day old profiles.

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes whylabs/whylogs/#1375

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
