### PR TITLE
Fix writing segmented performance metrics to WhyLabs

### DIFF
--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -525,7 +525,10 @@ class WhyLabsWriter(Writer):
         upload_statuses = list()
         for view, url in zip(files, upload_urls):
             with tempfile.NamedTemporaryFile() as tmp_file:
-                view.write(file=tmp_file)
+                if kwargs.get("use_v0") is None or kwargs.get("use_v0"):
+                    view.write(file=tmp_file, use_v0=True)
+                else:
+                    view.write(file=tmp_file)
                 tmp_file.flush()
                 tmp_file.seek(0)
 
@@ -583,7 +586,13 @@ class WhyLabsWriter(Writer):
             self._dataset_id = kwargs.get("dataset_id")
 
         with tempfile.NamedTemporaryFile() as tmp_file:
-            view.write(file=tmp_file)
+            # currently whylabs is not ingesting the v1 format of segmented profiles as segmented
+            # so we default to sending them as v0 profiles if the override `use_v0` is not defined,
+            # if `use_v0` is defined then pass that through to control the serialization format.
+            if has_segments and (kwargs.get("use_v0") is None or kwargs.get("use_v0")):
+                view.write(file=tmp_file, use_v0=True)
+            else:
+                view.write(file=tmp_file)
             tmp_file.flush()
             tmp_file.seek(0)
             utc_now = datetime.datetime.now(datetime.timezone.utc)

--- a/python/whylogs/core/view/segmented_dataset_profile_view.py
+++ b/python/whylogs/core/view/segmented_dataset_profile_view.py
@@ -215,8 +215,11 @@ class SegmentedDatasetProfileView(Writable):
         return True, path
 
     def write(self, path: Optional[str] = None, **kwargs: Any) -> Tuple[bool, str]:
-        if kwargs.get("use_v0"):
-            logger.warning("writing segmented profile as v0 format, some info may be converted")
+        if kwargs.get("use_v0") or self.profile_view.model_performance_metrics:
+            if self.profile_view.model_performance_metrics:
+                logger.info("Converting segmented profile with performance metrics to v0 format before writing.")
+            else:
+                logger.info("writing segmented profile as v0 format.")
             return self._write_as_v0_message(path, **kwargs)
         else:
             return self._write_v1(path, **kwargs)


### PR DESCRIPTION
## Description

Fixes #1385 by forcing v0 format for profiles that contain performance metrics. We missed this check when writing segmented results as v1, but we still need v0 for performance metrics message.

## Changes

- Switch back to v0 for performance metrics, added some checks and logging
- Test updates to check that v0 preserves new metadata such as trace_id

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
