### PR TITLE
custom performance metrics - removing reference to previously deleted validation function

### DIFF
--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -430,7 +430,6 @@ class WhyLabsWriter(Writer):
             column=column,
             default_metric=default_metric,
         )
-        self._validate_org_and_dataset()  # TODO this just doesn't exist?
         try:
             res = api_instance.put_entity_schema_metric(self._org_id, self._dataset_id, metric_schema)
             return True, str(res)


### PR DESCRIPTION
## Description

Bug fix: removing reference to `_validate_org_and_dataset` in `tag_custom_performance_metric`, which was removed in https://github.com/whylabs/whylogs/pull/1311.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
