### PR TITLE
Support v1 format for segmented profiles if they don't have perf metrics

### DIFF
--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -592,7 +592,9 @@ class WhyLabsWriter(Writer):
             file = file.profile()
 
         view = file.view() if isinstance(file, DatasetProfile) else file
+
         has_segments = isinstance(view, SegmentedDatasetProfileView)
+        has_performance_metrics = view.model_performance_metrics
         self._tag_custom_perf_metrics(view)
         if not has_segments and not isinstance(view, DatasetProfileView):
             raise ValueError(
@@ -618,7 +620,7 @@ class WhyLabsWriter(Writer):
             # currently whylabs is not ingesting the v1 format of segmented profiles as segmented
             # so we default to sending them as v0 profiles if the override `use_v0` is not defined,
             # if `use_v0` is defined then pass that through to control the serialization format.
-            if has_segments and (kwargs.get("use_v0") is None or kwargs.get("use_v0")):
+            if has_performance_metrics or kwargs.get("use_v0"):
                 view.write(file=tmp_file, use_v0=True)
             else:
                 view.write(file=tmp_file)

--- a/python/whylogs/core/view/segmented_dataset_profile_view.py
+++ b/python/whylogs/core/view/segmented_dataset_profile_view.py
@@ -69,6 +69,10 @@ class SegmentedDatasetProfileView(Writable):
         return self.profile_view.creation_timestamp
 
     @property
+    def model_performance_metrics(self) -> Any:
+        return self.profile_view.model_performance_metrics
+
+    @property
     def metadata(self) -> Dict[str, str]:
         return self.profile_view.metadata
 


### PR DESCRIPTION
## Description

WhyLabs trace_id query is only supported on v1 format profiles, so we need to make sure we can send segmented dataset profiles as v1 where the platform supports this.

## Changes

- Add model_performance_metrics property to segmented dataset profiles views
- Only use v0 format when required due to model_performance_metrics in segmented profiles.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
