### PR TITLE
Add prefer sync env variable and option for WhyLabsWriter

### DIFF
--- a/python/whylogs/context/environ.py
+++ b/python/whylogs/context/environ.py
@@ -1,0 +1,12 @@
+import os
+
+_FALSY_STRINGS = ["0", "false", "", "no", "off", "disabled", "n"]
+
+
+def read_bool_env_var(env_var_name, default_value=False):
+    env_var_value = os.environ.get(env_var_name)
+
+    if env_var_value is None:
+        return default_value
+
+    return env_var_value.lower() not in _FALSY_STRINGS


### PR DESCRIPTION
## Description

Adds env variable and option to the WhyLabsWriter to allow writing reference profiles with a sync call to upload the profile to avoid issues with AWS Lambda environment execution.

## Changes

- Adds a WHYLOGS_PREFER_SYNC_KEY env key
- adds _prefer_sync property to the WhyLabsWriter
- Allows env variable to override default value of prefering async where supported by the server side API.
- Add utility helper method read_bool_env_var to parse environ values into bool

Example new environ vars to make AWS Lambda work:
```python
os.environ["WHYLOGS_PREFER_SYNC"] = "1"
os.environ["WHYLOGS_CONFIG_PATH"] = "/tmp/whylogs_config.ini"
```

OR
```python
import whylogs as why

results = why.log({"a": 1})
status = results.writer("whylabs").option(reference_profile_name="ref-a", prefer_sync=True).write()
print(status)
```

## Related

Fixes #1396 

dev build can be evaluated with this PR here:
```
pip install whylogs==1.3.9.dev0
```

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
