### PR TITLE
Add whylogs version to metadata for debugging

### DIFF
--- a/python/whylogs/context/version.py
+++ b/python/whylogs/context/version.py
@@ -1,0 +1,17 @@
+def package_version(package: str = __package__) -> str:
+    """Calculate version number based on pyproject.toml"""
+    try:
+        from importlib import metadata  # type: ignore
+    except ImportError:
+        # Python < 3.8
+        import importlib_metadata as metadata  # type: ignore
+
+    try:
+        version = metadata.version(package)
+    except metadata.PackageNotFoundError:  # type: ignore
+        version = f"{package} is not installed."
+
+    return version
+
+
+whylogs_version = package_version("whylogs")

--- a/python/whylogs/core/metadata.py
+++ b/python/whylogs/core/metadata.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
+from whylogs.context.version import whylogs_version
 from whylogs.core.utils.timestamp_calculations import to_utc_milliseconds
 
 diagnostic_logger = logging.getLogger(__name__)
@@ -13,6 +14,7 @@ CREATION_TIMESTAMP_KEY = "whylogs.creationTimestamp"
 DATASET_TIMESTAMP_KEY = "whylogs.datasetTimestamp"
 USER_TAGS_KEY = "whylogs.user.tags"
 NAME_KEY = "whylogs.name"
+WHYLOGS_VERSION_KEY = "whylogs.version"
 
 
 def _populate_common_profile_metadata(
@@ -52,5 +54,8 @@ def _populate_common_profile_metadata(
         metadata[NAME_KEY] = name
     if tags and USER_TAGS_KEY not in metadata:
         metadata[USER_TAGS_KEY] = json.dumps(sorted(set(tags)))
+
+    if WHYLOGS_VERSION_KEY not in metadata:
+        metadata[WHYLOGS_VERSION_KEY] = whylogs_version
 
     return metadata


### PR DESCRIPTION
## Description

Adds a context utility module to provide common values for debugging or to populate metadata.

## Changes

- Adds whylogs.context
- Add whylogs.version to profile metadata

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
