### PR TITLE
Handle None/NaN with multi-column segmentation

### DIFF
--- a/python/whylogs/api/logger/segment_processing.py
+++ b/python/whylogs/api/logger/segment_processing.py
@@ -1,4 +1,6 @@
 import logging
+import math
+from functools import reduce
 from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Tuple
 
 from whylogs.api.logger.result_set import SegmentedResultSet
@@ -9,8 +11,6 @@ from whylogs.core.input_resolver import _pandas_or_dict
 from whylogs.core.segment import Segment
 from whylogs.core.segmentation_partition import SegmentationPartition, SegmentFilter
 from whylogs.core.stubs import pd
-from functools import reduce
-import math
 
 logger = logging.getLogger(__name__)
 
@@ -59,14 +59,14 @@ def _process_simple_partition(
         # simple means we can segment on column values
         grouped_data = pandas.groupby(columns)
         for group in grouped_data.groups.keys():
-            if any([math.isnan(x) for x in group]):
+            if isinstance(group, tuple) and any([math.isnan(x) for x in group]):
                 evaluations = []
-                for val,col in zip(group,columns):
+                for val, col in zip(group, columns):
                     if math.isnan(val):
                         evaluations.append((pandas[col].isna()))
                     else:
                         evaluations.append((pandas[col] == val))
-                mask = reduce(lambda x,y: x&y, evaluations)
+                mask = reduce(lambda x, y: x & y, evaluations)
                 pandas_segment = pandas[mask]
             else:
                 pandas_segment = grouped_data.get_group(group)

--- a/python/whylogs/api/logger/segment_processing.py
+++ b/python/whylogs/api/logger/segment_processing.py
@@ -46,6 +46,13 @@ def _get_segment_from_group_key(group_key, partition_id) -> Tuple[str, ...]:
     return Segment(segment_tuple_key, partition_id)
 
 
+def _is_nan(x):
+    try:
+        return math.isnan(x)
+    except TypeError:
+        return False
+
+
 def _process_simple_partition(
     partition_id: str,
     schema: DatasetSchema,
@@ -59,10 +66,10 @@ def _process_simple_partition(
         # simple means we can segment on column values
         grouped_data = pandas.groupby(columns)
         for group in grouped_data.groups.keys():
-            if isinstance(group, tuple) and any([math.isnan(x) for x in group]):
+            if isinstance(group, tuple) and any([_is_nan(x) for x in group]):
                 evaluations = []
                 for val, col in zip(group, columns):
-                    if math.isnan(val):
+                    if _is_nan(val):
                         evaluations.append((pandas[col].isna()))
                     else:
                         evaluations.append((pandas[col] == val))


### PR DESCRIPTION
## Description

The presence of Nones/NaNs would cause multi-column segmentation to crash.
This PR handles the presence of nans by grouping all classes of nans (None, np.nan, math.nan) into a single segment combination.


closes #1300

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
