### PR TITLE
Fix noisy warning in rolling logger with traceId already set

### DIFF
--- a/python/whylogs/core/metadata.py
+++ b/python/whylogs/core/metadata.py
@@ -39,7 +39,7 @@ def _populate_common_profile_metadata(
         if not trace_id:
             trace_id = str(uuid4())
         metadata[WHYLABS_TRACE_ID_KEY] = trace_id
-    elif metadata[WHYLABS_TRACE_ID_KEY] != trace_id:
+    elif metadata[WHYLABS_TRACE_ID_KEY] != trace_id and trace_id is not None:
         diagnostic_logger.warning(
             f"trace_id was specified as {trace_id} but there is already a trace_id defined "
             f"in metadata[{WHYLABS_TRACE_ID_KEY}]: {metadata[WHYLABS_TRACE_ID_KEY]}"


### PR DESCRIPTION
## Description

Reduces noise in warnings emitted during use of rolling logger related to traceId.

## Changes

- checks if there was an actual traceId specified before warning if the traceId does not match one already set for the profile.

## Related

Fixes #1402 

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
