### PR TITLE
Fix passing in dataset_timestamp to DebugClient

### DIFF
--- a/python/whylogs/api/logger/__init__.py
+++ b/python/whylogs/api/logger/__init__.py
@@ -26,6 +26,7 @@ from whylogs.api.whylabs.session.notebook_logger import (
     notebook_session_log_comparison,
 )
 from whylogs.core import DatasetProfile, DatasetSchema
+from whylogs.core.metadata import WHYLABS_TRACE_ID_KEY
 from whylogs.core.model_performance_metrics.model_performance_metrics import (
     ModelPerformanceMetrics,
 )
@@ -72,6 +73,8 @@ def log(
         notebook_session_log(result_set, obj, pandas=pandas, row=row, name=name)
 
         if debug_event is not None:
+            if trace_id is None and WHYLABS_TRACE_ID_KEY in result_set.metadata:
+                trace_id = result_set.metadata.get(WHYLABS_TRACE_ID_KEY)
             debug_event_status = log_debug_event(
                 debug_event=debug_event,
                 trace_id=trace_id,

--- a/python/whylogs/api/logger/events/event.py
+++ b/python/whylogs/api/logger/events/event.py
@@ -77,7 +77,7 @@ class DebugClient:
         debug_segment = Segment(tags=segment_tags)
         if dataset_timestamp is not None:
             ensure_timezone(dataset_timestamp)
-        dataset_timestamp_in_ms = to_utc_milliseconds(dataset_timestamp) or now_ms
+        dataset_timestamp_in_ms = to_utc_milliseconds(dataset_timestamp) if dataset_timestamp else now_ms
         whylabs_debug_event = DebugEvent(
             content=json.dumps(debug_event),
             trace_id=trace_id,

--- a/python/whylogs/api/logger/events/event.py
+++ b/python/whylogs/api/logger/events/event.py
@@ -77,13 +77,13 @@ class DebugClient:
         debug_segment = Segment(tags=segment_tags)
         if dataset_timestamp is not None:
             ensure_timezone(dataset_timestamp)
-        checked_dataset_timestamp = dataset_timestamp or now_ms
+        dataset_timestamp_in_ms = to_utc_milliseconds(dataset_timestamp) or now_ms
         whylabs_debug_event = DebugEvent(
             content=json.dumps(debug_event),
             trace_id=trace_id,
             tags=tags,
             segment=debug_segment,
-            dataset_timestamp=checked_dataset_timestamp,
+            dataset_timestamp=dataset_timestamp_in_ms,
             creation_timestamp=now_ms,
         )
         # TODO: retry


### PR DESCRIPTION
## Description

Fixes #1408 

## Changes

converts the passed dataset_timestamp to int ms since epoch format before sending to WhyLabs API which expects int or None for this parameter.

Also fixed case where trace_id is not specified but a debug_event is to inherit the profile's traceId.

dev build published here for evaluation:
```pip install whylogs==1.3.11.dev1```

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
