### PR TITLE
Add graceful behavior when processes are killed

### DIFF
--- a/python/tests/api/logger/experimental/logger/actor/test_actor_loggers.py
+++ b/python/tests/api/logger/experimental/logger/actor/test_actor_loggers.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import multiprocessing as mp
 import os
+import time
 from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union, cast
 
 import pytest
@@ -331,6 +332,53 @@ def test_closing_works(actor: Tuple[DataLogger, FakeWriter]) -> None:
     # These shouldn't change
     assert writer.write_calls == 3
     assert len(writer.last_writables) == 3
+
+
+def test_process_throws_after_killed(actor: Tuple[DataLogger, FakeWriter]) -> None:
+    """
+    Test that the logger throws after the process is killed on the caller side. This
+    version of the test asserts against the sync=True behavior. First the process is force
+    killed and then immediately after the logger is used, which means the is_alive check
+    won't have time to start returning false. This tests the case where something kills the process
+    while something else is trying to use it.
+    """
+    logger, writer = actor
+    if isinstance(logger, ProcessActor):
+        logger = cast(ProcessActor, logger)  # type: ignore
+        ms = 1689881671000
+
+        # kill it
+        os.kill(logger.pid, 9)  # type: ignore
+
+        # Further sync calls close should throw
+        with pytest.raises(Exception):
+            logger.log(data={"a": 1}, sync=True, timestamp_ms=ms)
+
+        with pytest.raises(Exception, match="Process isn't active. It might have been killed."):
+            logger.close()
+
+
+def test_process_throws_after_killed_delay(actor: Tuple[DataLogger, FakeWriter]) -> None:
+    """
+    Very similar to test_process_throws_after_killed but there is a delay after the process is killed
+    before logging so the log() call will throw before doing any actual work with a clear error message.
+    """
+    logger, writer = actor
+    if isinstance(logger, ProcessActor):
+        logger = cast(ProcessActor, logger)  # type: ignore
+        ms = 1689881671000
+
+        # kill it
+        os.kill(logger.pid, 9)  # type: ignore
+        time.sleep(2)  # should be enough
+
+        # Further sync calls close should throw
+        with pytest.raises(Exception, match="Logger is no longer alive. It may have been killed."):
+            # Throws even when it isn't sync
+            logger.log(data={"a": 1}, timestamp_ms=ms)
+
+        with pytest.raises(Exception, match="Process isn't active. It might have been killed."):
+            logger.close()
 
 
 def test_actor_multiple_days(actor: Tuple[DataLogger, FakeWriter]) -> None:

--- a/python/tests/api/logger/experimental/logger/test_future_util.py
+++ b/python/tests/api/logger/experimental/logger/test_future_util.py
@@ -1,9 +1,12 @@
 from concurrent.futures import Future
 
-import pytest
+import pytest  # type: ignore
 
 try:
-    from whylogs.api.logger.experimental.logger.actor.future_util import wait_result
+    from whylogs.api.logger.experimental.logger.actor.future_util import (
+        wait_result,
+        wait_result_while,
+    )
 except Exception as e:
     if str(e) == "'type' object is not subscriptable":
         pytest.skip("Skipping module because of a pytest bug on older python versions.", allow_module_level=True)
@@ -32,3 +35,22 @@ def test_cancel() -> None:
 
     with pytest.raises(Exception):
         wait_result(f)
+
+
+def test_timeout() -> None:
+    f: Future[int] = Future()
+    with pytest.raises(TimeoutError):
+        wait_result(f, 0.1)
+
+
+def test_while_timeout() -> None:
+    i = 0
+
+    def predicate() -> bool:
+        nonlocal i
+        i += 1
+        return i < 3
+
+    f: Future[int] = Future()
+    with pytest.raises(TimeoutError):
+        wait_result_while(f, predicate)

--- a/python/whylogs/api/logger/experimental/logger/actor/faster_fifo_queue_wrapper.py
+++ b/python/whylogs/api/logger/experimental/logger/actor/faster_fifo_queue_wrapper.py
@@ -2,6 +2,7 @@ from typing import Generic, List, Optional, TypeVar
 
 from whylogs.api.logger.experimental.logger.actor.actor import (
     _DEFAULT_TIMEOUT,
+    QueueConfig,
     QueueWrapper,
 )
 
@@ -14,7 +15,6 @@ except ImportError:
 
     raise ImportError(_proc_error_message)
 
-_DEFAULT_QUEUE_SiZE = 1000 * 1000 * 1000
 
 FasterQueueMessageType = TypeVar("FasterQueueMessageType")
 
@@ -24,8 +24,8 @@ class FasterQueueWrapper(QueueWrapper, Generic[FasterQueueMessageType]):
     Implementation of QueueWrapper sufficient for use in the threaded actor.
     """
 
-    def __init__(self) -> None:
-        self._queue = FasterQueue(_DEFAULT_QUEUE_SiZE)
+    def __init__(self, config: QueueConfig) -> None:
+        self._queue = FasterQueue(config.max_buffer_bytes)
 
     def send(self, message: FasterQueueMessageType, timeout: float = _DEFAULT_TIMEOUT) -> None:
         self._queue.put(message, timeout=timeout)

--- a/python/whylogs/api/logger/experimental/logger/actor/future_util.py
+++ b/python/whylogs/api/logger/experimental/logger/actor/future_util.py
@@ -1,11 +1,18 @@
 from concurrent.futures import Future, wait
-from typing import Optional, TypeVar
+from typing import Callable, Optional, TypeVar
 
 T = TypeVar("T")
 
 
 def wait_result(future: "Future[T]", timeout: Optional[float] = None) -> T:
+    """
+    Wait on a future with an optional timeout.
+    """
     done, not_done = wait([future], timeout=timeout)
+
+    for timeouts in not_done:
+        timeouts.set_exception(TimeoutError("Timeout waiting for result"))
+
     all = done.union(not_done)
     for it in all:
         e = it.exception()
@@ -19,3 +26,20 @@ def wait_result(future: "Future[T]", timeout: Optional[float] = None) -> T:
             return r
 
     raise Exception("Couldn't find a result")
+
+
+def wait_result_while(future: "Future[T]", predicate: Callable[[], bool]) -> T:
+    """
+    Wait on a future while the condition is true.
+    """
+    result: Optional[T] = None
+    while predicate():
+        try:
+            result = wait_result(future, 1.0)
+        except TimeoutError:
+            pass
+
+    if result is None:
+        raise TimeoutError("Wait signal stopped before result was available.")
+
+    return result

--- a/python/whylogs/api/logger/experimental/logger/actor/process_rolling_logger.py
+++ b/python/whylogs/api/logger/experimental/logger/actor/process_rolling_logger.py
@@ -5,12 +5,14 @@ import threading as th
 import time
 from abc import abstractmethod
 from concurrent.futures import Future
+from dataclasses import dataclass, field
 from functools import reduce
 from itertools import groupby
 from typing import (
     Any,
     Callable,
     Dict,
+    Generic,
     List,
     Optional,
     Tuple,
@@ -21,6 +23,7 @@ from typing import (
 )
 
 from whylogs.api.whylabs.session.config import _INIT_DOCS
+from whylogs.api.whylabs.session.session_manager import _default_init
 
 try:
     import orjson
@@ -72,12 +75,11 @@ from whylogs.api.logger.experimental.logger.actor.time_util import (
     TimeGranularity,
     current_time_ms,
 )
-from whylogs.api.whylabs.session.session_manager import get_current_session
 from whylogs.api.writer import Writer, Writers
 from whylogs.core.schema import DatasetSchema
 from whylogs.core.stubs import pd
 
-MessageType = Union[
+BuiltinMessageTypes = Union[
     FlushMessage,
     RawLogMessage,
     RawLogEmbeddingsMessage,
@@ -110,7 +112,49 @@ class WhyLabsWriterFactory(WriterFactory):
         ]
 
 
-class ProcessRollingLogger(ProcessActor[MessageType], DataLogger[Dict[str, ProcessLoggerStatus]]):
+@dataclass
+class LoggerOptions:
+    aggregate_by: TimeGranularity = TimeGranularity.Hour
+    write_schedule: Optional[Schedule] = field(
+        default_factory=lambda: Schedule(cadence=TimeGranularity.Minute, interval=5)
+    )
+    schema: Optional[DatasetSchema] = None
+    sync_enabled: bool = False
+    current_time_fn: Optional[Callable[[], int]] = None
+    queue_config: QueueConfig = QueueConfig()
+    thread_queue_config: QueueConfig = QueueConfig()
+    writer_factory: WriterFactory = field(default_factory=WhyLabsWriterFactory)
+    queue_type: QueueType = QueueType.FASTER_FIFO
+
+
+class LoggerFactory:
+    @abstractmethod
+    def create_logger(self, dataset_id: str, options: LoggerOptions) -> ThreadRollingLogger:
+        raise NotImplementedError()
+
+
+class ThreadLoggerFactory(LoggerFactory):
+    def create_logger(self, dataset_id: str, options: LoggerOptions) -> ThreadRollingLogger:
+        logger = ThreadRollingLogger(
+            aggregate_by=options.aggregate_by,
+            writers=options.writer_factory.create_writers(dataset_id),
+            schema=options.schema,
+            write_schedule=options.write_schedule,
+            current_time_fn=options.current_time_fn,
+            queue_config=options.thread_queue_config,
+        )
+
+        return logger
+
+
+AdditionalMessages = TypeVar("AdditionalMessages")
+
+
+class BaseProcessRollingLogger(
+    ProcessActor[Union[AdditionalMessages, BuiltinMessageTypes]],
+    DataLogger[Dict[str, ProcessLoggerStatus]],
+    Generic[AdditionalMessages],
+):
     """
     Log data asynchronously using a separate process.
 
@@ -135,6 +179,9 @@ class ProcessRollingLogger(ProcessActor[MessageType], DataLogger[Dict[str, Proce
     You should be able to get around it by setting the environment variable OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
     in the environment that the process logger runs in, but you can't set it in Python (no using os.environ).
 
+    Most of the arguments that are passed to the underlying loggers are considered the default options for those
+    loggers. If you supply a logger_factory then you can override the options for each dataset id's logger.
+
     Args:
         aggregate_by: The time granularity to aggregate data by. This determines how the time bucketing is done. For
             the Hour type, the logger will end up pooling data into profiles by the hour.
@@ -152,8 +199,8 @@ class ProcessRollingLogger(ProcessActor[MessageType], DataLogger[Dict[str, Proce
 
     def __init__(
         self,
-        aggregate_by: TimeGranularity = TimeGranularity.Hour,
-        write_schedule: Optional[Schedule] = Schedule(cadence=TimeGranularity.Minute, interval=10),
+        aggregate_by: TimeGranularity = TimeGranularity.Day,
+        write_schedule: Optional[Schedule] = Schedule(cadence=TimeGranularity.Minute, interval=5),
         schema: Optional[DatasetSchema] = None,
         sync_enabled: bool = False,
         current_time_fn: Optional[Callable[[], int]] = None,
@@ -161,38 +208,39 @@ class ProcessRollingLogger(ProcessActor[MessageType], DataLogger[Dict[str, Proce
         thread_queue_config: QueueConfig = QueueConfig(),
         writer_factory: WriterFactory = WhyLabsWriterFactory(),
         queue_type: QueueType = QueueType.FASTER_FIFO,
+        logger_factory: LoggerFactory = ThreadLoggerFactory(),
     ) -> None:
         super().__init__(queue_config=queue_config, queue_type=queue_type)
+        self._logger_options = LoggerOptions(
+            aggregate_by=aggregate_by,
+            write_schedule=write_schedule,
+            schema=schema,
+            sync_enabled=sync_enabled,
+            current_time_fn=current_time_fn,
+            queue_config=queue_config,
+            thread_queue_config=thread_queue_config,
+            writer_factory=writer_factory,
+        )
+        self._logger_factory = logger_factory
+
         self._sync_enabled = sync_enabled
         self._thread_queue_config = thread_queue_config
         self._writer_factory = writer_factory
         self.current_time_ms = current_time_fn or current_time_ms
         self.loggers: Dict[str, ThreadRollingLogger] = {}
-        self.write_schedule = write_schedule
         self.schema = schema
-        self.aggregate_by = aggregate_by
         self._pipe_signaler: Optional[PipeSignaler] = PipeSignaler() if sync_enabled else None
-        self._session = get_current_session()
+        self._session = _default_init()
 
     def _create_logger(self, dataset_id: str) -> ThreadRollingLogger:
-        logger = ThreadRollingLogger(
-            aggregate_by=self.aggregate_by,
-            writers=self._writer_factory.create_writers(dataset_id),
-            schema=self.schema,
-            write_schedule=self.write_schedule,
-            current_time_fn=self.current_time_ms,
-            queue_config=self._thread_queue_config,
-        )
-
-        self._logger.info(f"Created logger for {dataset_id}")
-        return logger
+        return self._logger_factory.create_logger(dataset_id, self._logger_options)
 
     def _get_logger(self, dataset_id: str) -> ThreadRollingLogger:
         if dataset_id not in self.loggers:
             self.loggers[dataset_id] = self._create_logger(dataset_id)
         return self.loggers[dataset_id]
 
-    def process_batch(self, batch: List[MessageType], batch_type: Type) -> None:
+    def process_batch(self, batch: List[Union[AdditionalMessages, BuiltinMessageTypes]], batch_type: Type) -> None:
         if batch_type == FlushMessage:
             self.process_flush_message(cast(List[FlushMessage], batch))
         elif batch_type == LogMessage:
@@ -329,7 +377,7 @@ class ProcessRollingLogger(ProcessActor[MessageType], DataLogger[Dict[str, Proce
     ) -> None:
         for dataset_id, group in groupby(dicts, lambda it: it["datasetId"]):
             for dataset_timestamp, ts_grouped in groupby(
-                group, lambda it: determine_dataset_timestamp(self.aggregate_by, it)
+                group, lambda it: determine_dataset_timestamp(self._logger_options.aggregate_by, it)
             ):
                 for n, sub_group in groupby(ts_grouped, lambda it: encode_strings(get_columns(it))):
                     self._logger.info(
@@ -377,7 +425,7 @@ class ProcessRollingLogger(ProcessActor[MessageType], DataLogger[Dict[str, Proce
             raise Exception("Logger hasn't been started yet. Call start() first.")
 
         if not self.is_alive():
-            raise Exception("Logger is no longer alive. It may have been killed.")
+            raise Exception("Logger process is no longer alive. It may have been killed.")
 
         if dataset_id is None:
             dataset_id = self._session.config.get_default_dataset_id()
@@ -497,6 +545,7 @@ class PipeSignaler(th.Thread):
                     if future is not None:
                         self._logger.debug(f"Setting result for message id {message_id} {exception}")
                         if exception is None:
+                            print(f"Setting result for message id {message_id} {data}")
                             future.set_result(data)
                         else:
                             future.set_exception(exception)
@@ -504,8 +553,10 @@ class PipeSignaler(th.Thread):
             except EOFError:
                 self._logger.exception("Broken pipe")
                 break
-            except Exception:
-                self._logger.exception("Error in ipc pipe")
+            except OSError as e:
+                self._logger.exception(f"OS Error in ipc pipe. Was the logger closed? {e}")
+            except Exception as e:
+                self._logger.exception(f"Error in ipc pipe {e}")
 
         self._done.set()
 
@@ -530,3 +581,7 @@ class PipeSignaler(th.Thread):
         self._end_polling.set()
         self._done.wait()
         self.join()
+
+
+class ProcessRollingLogger(BaseProcessRollingLogger[None]):
+    pass

--- a/python/whylogs/api/logger/experimental/logger/actor/signal_util.py
+++ b/python/whylogs/api/logger/experimental/logger/actor/signal_util.py
@@ -3,11 +3,17 @@ from contextlib import contextmanager
 from typing import Any
 
 
+def _ignore(signal: int, frame: Any) -> None:
+    pass
+
+
 @contextmanager
-def suspended_signals(*signals: Any) -> Any:
+def suspended_signals(*signals: signal.Signals) -> Any:
     """
     Suspends signal handling execution
     """
+    for sig in signals:
+        signal.signal(sig, _ignore)
     signal.pthread_sigmask(signal.SIG_BLOCK, set(signals))
     try:
         yield None

--- a/python/whylogs/api/whylabs/session/session_manager.py
+++ b/python/whylogs/api/whylabs/session/session_manager.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from whylogs.api.whylabs.session.config import InitConfig, SessionConfig
+from whylogs.api.whylabs.session.config import _INIT_DOCS, InitConfig, SessionConfig
 from whylogs.api.whylabs.session.session import (
     ApiKeySession,
     GuestSession,
@@ -128,9 +128,6 @@ def init(  # type: ignore
     except Exception as e:
         logger.warning("Could not initialize session", e)
         raise e
-
-
-_INIT_DOCS = "https://docs.whylabs.ai/docs/whylabs-whylogs-init"
 
 
 def get_current_session() -> Optional[Session]:

--- a/python/whylogs/api/writer/writer.py
+++ b/python/whylogs/api/writer/writer.py
@@ -27,11 +27,12 @@ class Writable(ABC):
 class Writer(ABC):
     # noinspection PyMethodMayBeStatic
     def check_interval(self, interval_seconds: int) -> None:
-        """Validate an interval configuration for a given writer.
+        """
+        Validate an interval configuration for a given writer.
 
         Some writers only accepts certain interval configuration. Raise BadConfigError for
-        an unacceptable interval."""
-        pass
+        an unacceptable interval.
+        """
 
     @abstractmethod
     def write(


### PR DESCRIPTION
When working with gunicorn I discovered that you'll end up shooting yourself in the foot if you start the process logger at the wrong time because gunicorn will end up killing the logger, which results in apparently nothing happening after you make log calls. This will update the logger to be explicit about how dead it is and why, throwing on log() and close() calls.
