### PR TITLE
schema metadata support

### DIFF
--- a/python/tests/api/logger/test_rolling.py
+++ b/python/tests/api/logger/test_rolling.py
@@ -269,11 +269,19 @@ def test_rolling_row_messages_with_segments(tmp_path: Any) -> None:
 def test_rolling_do_rollover():
     import pandas as pd
 
+    custom_key = "my_version"
+    custom_value = "2.1.0"
+
+    colliding_key = "whylogs.version"
+    bad_version = "bad_version"
+    schema = DatasetSchema(metadata={custom_key: custom_value, colliding_key: bad_version})
+
     df = pd.DataFrame(data={"col1": [1, 2], "col2": [3.0, 4.0], "col3": ["a", "b"]})
-    rolling_logger = why.logger(mode="rolling", interval=5, when="M", base_name="profile_")
+    rolling_logger = why.logger(mode="rolling", interval=5, when="M", base_name="profile_", schema=schema)
     rolling_logger.append_writer("local")
     rolling_logger.log(df)
     now = datetime.now(timezone.utc)
+    initial_profile = rolling_logger._current_profile
     initial_profile_id = id(rolling_logger._current_profile)
     profile_timestamp = rolling_logger._current_profile.dataset_timestamp
     rolling_logger._do_rollover()
@@ -281,6 +289,9 @@ def test_rolling_do_rollover():
     rolling_logger.close()
     assert initial_profile_id != post_rollover_profile_id
     assert now.timestamp() == pytest.approx(profile_timestamp.timestamp())
-    # these lines below fail as a comparison
-    # now_plus_1h = now + datetime.timedelta(hours=1)
-    # assert now.timestamp() == pytest.approx(now_plus_1h.timestamp())
+    assert initial_profile.metadata
+    assert custom_key in initial_profile.metadata
+    assert initial_profile.metadata[custom_key] == custom_value
+
+    assert colliding_key in initial_profile.metadata
+    assert initial_profile.metadata[colliding_key] != bad_version

--- a/python/tests/core/test_schema.py
+++ b/python/tests/core/test_schema.py
@@ -20,6 +20,15 @@ def test_schema_default_value_overrides() -> None:
     assert schema.cache_size == 12
 
 
+def test_schema_metadata() -> None:
+    custom_key = "custom_key"
+    custom_value = "1.2.3"
+    schema = DatasetSchema(metadata={custom_key: custom_value})
+
+    assert custom_key in schema.metadata
+    assert schema.metadata[custom_key] == custom_value
+
+
 def test_schema_subclass_copy() -> None:
     schema = DatasetSchema(
         types={"col1": str, "col2": np.int32, "col3": pd.CategoricalDtype(categories=("foo", "bar"), ordered=True)},

--- a/python/whylogs/core/metadata.py
+++ b/python/whylogs/core/metadata.py
@@ -59,3 +59,21 @@ def _populate_common_profile_metadata(
         metadata[WHYLOGS_VERSION_KEY] = whylogs_version
 
     return metadata
+
+
+def _safe_merge_metadata(
+    default_metadata: Optional[Dict[str, str]], incoming_metadata: Optional[Dict[str, str]]
+) -> Dict[str, str]:
+    if default_metadata is None:
+        default_metadata = dict()
+    if not incoming_metadata:
+        return default_metadata
+
+    for key in incoming_metadata:
+        if not default_metadata.get(key):
+            default_metadata[key] = incoming_metadata[key]
+        elif incoming_metadata[key] != default_metadata[key] and incoming_metadata[key]:
+            diagnostic_logger.warning(
+                f"metadata collision on key {key}. Current value is {default_metadata[key]} so ignoring attempt to set to {incoming_metadata[key]}"
+            )
+    return default_metadata

--- a/python/whylogs/core/schema.py
+++ b/python/whylogs/core/schema.py
@@ -77,6 +77,7 @@ class DatasetSchema:
         schema_based_automerge: bool = False,
         segments: Optional[Dict[str, SegmentationPartition]] = None,
         validators: Optional[Dict[str, List[Validator]]] = None,
+        metadata: Optional[Dict[str, str]] = None,
     ) -> None:
         self._columns = dict()
         self.types = types or dict()
@@ -87,6 +88,7 @@ class DatasetSchema:
         self.schema_based_automerge = schema_based_automerge
         self.segments = segments or dict()
         self.validators = validators or dict()
+        self.metadata = metadata or dict()
 
         if self.cache_size < 0:
             logger.warning("Negative cache size value. Disabling caching")
@@ -122,6 +124,7 @@ class DatasetSchema:
         copy = self.__class__(**args)
         copy._columns = deepcopy(self._columns)
         copy.segments = self.segments.copy()
+        copy.metadata = self.metadata.copy()
         return copy
 
     def resolve(
@@ -246,6 +249,7 @@ class DeclarativeSchema(DatasetSchema):
         schema_based_automerge: bool = False,
         segments: Optional[Dict[str, SegmentationPartition]] = None,
         validators: Optional[Dict[str, List[Validator]]] = None,
+        metadata: Optional[Dict[str, str]] = None,
     ) -> None:
         if resolvers is None:
             resolvers = res.DEFAULT_RESOLVER
@@ -260,6 +264,7 @@ class DeclarativeSchema(DatasetSchema):
             schema_based_automerge=schema_based_automerge,
             segments=segments,
             validators=validators,
+            metadata=metadata,
         )
 
     def copy(self) -> "DeclarativeSchema":
@@ -272,6 +277,7 @@ class DeclarativeSchema(DatasetSchema):
             self.schema_based_automerge,
             self.segments.copy(),
             deepcopy_validators(self.validators),
+            metadata=self.metadata.copy(),
         )
         copy.resolvers = deepcopy(self.resolvers)
         copy._columns = deepcopy(self._columns)


### PR DESCRIPTION
## Description

This is to support adding metadata to the schema, which can help identify custom metrics or configuration and allows metadata to be added to profiles generated from rolling loggers.

## Changes

- Adds optional metadata to the DatasetSchema and related classes
- pass through values from schema to profiles in metadata
- add a safe merge so that metadata is not accidentally overwritten

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
