### PR TITLE
Support both new and older API Key formats when writing DebugEvents

### DIFF
--- a/python/whylogs/api/logger/events/event.py
+++ b/python/whylogs/api/logger/events/event.py
@@ -37,7 +37,7 @@ class DebugClient:
             )
             cache = WhylabsClientCache.instance()
             self._api_client, _ = cache.get_client(self._cache_config)
-            self._org_id = config.require_api_key().split(":")[-1]
+            self._org_id = config.require_org_id()
             self._dataset_id = config.require_default_dataset_id()
         else:
             self._api_client = api_client


### PR DESCRIPTION
## Description

The DebugClient required the org-id to be part of the API Key which is how new API Keys are generated, but older formats should still be supported where the org-id would be set with an environment var.

## Changes

- Use existing require_org_id over splitting the value from the API Key.

Closes #1420 

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
