### PR TITLE
Support images in calculate_drift_score

### DIFF
--- a/python/tests/viz/drift/test_column_drift_algorithm.py
+++ b/python/tests/viz/drift/test_column_drift_algorithm.py
@@ -1,7 +1,10 @@
+import numpy as np
 import pandas as pd
 import pytest
+from PIL import Image
 
 import whylogs as why
+from whylogs.extras.image_metric import log_image
 from whylogs.viz.drift.column_drift_algorithms import (
     KS,
     ChiSquare,
@@ -14,10 +17,6 @@ from whylogs.viz.drift.configs import (
     HellingerConfig,
     KSTestConfig,
 )
-
-import numpy as np
-from PIL import Image
-from whylogs.extras.image_metric import log_image
 
 
 @pytest.fixture

--- a/python/whylogs/viz/drift/column_drift_algorithms.py
+++ b/python/whylogs/viz/drift/column_drift_algorithms.py
@@ -9,6 +9,7 @@ from scipy.spatial.distance import euclidean
 
 from whylogs.core.view.column_profile_view import ColumnProfileView  # type: ignore
 from whylogs.core.view.dataset_profile_view import DatasetProfileView  # type: ignore
+from whylogs.migration.uncompound import _uncompound_dataset_profile
 from whylogs.viz.drift.configs import (
     ChiSquareConfig,
     DriftThresholds,
@@ -21,7 +22,6 @@ from whylogs.viz.utils.frequent_items_calculations import (
     get_frequent_stats,
     zero_padding_frequent_items,
 )
-from whylogs.migration.uncompound import _uncompound_dataset_profile
 
 
 @dataclass

--- a/python/whylogs/viz/drift/column_drift_algorithms.py
+++ b/python/whylogs/viz/drift/column_drift_algorithms.py
@@ -21,6 +21,7 @@ from whylogs.viz.utils.frequent_items_calculations import (
     get_frequent_stats,
     zero_padding_frequent_items,
 )
+from whylogs.migration.uncompound import _uncompound_dataset_profile
 
 
 @dataclass
@@ -483,8 +484,10 @@ def calculate_drift_scores(
         )
     """
     drift_scores: Dict[str, Optional[Dict[str, Any]]] = {}
-    target_view_columns = target_view.get_columns()
-    reference_view_columns = reference_view.get_columns()
+    target_view_uncompounded = _uncompound_dataset_profile(target_view)
+    reference_view_uncompounded = _uncompound_dataset_profile(reference_view)
+    target_view_columns = target_view_uncompounded.get_columns()
+    reference_view_columns = reference_view_uncompounded.get_columns()
     if drift_map:
         for column_name in drift_map.keys():
             if column_name not in target_view_columns.keys():


### PR DESCRIPTION
## Description

As surfaced in https://github.com/whylabs/whylogs/issues/1422, `calculate_drift_scores` is currently broken for images, requiring the user to manually call `_uncompound_dataset_profile` beforehand.

This PR:

- calls `_uncompound_dataset_profile` internally in `calculate_drift_scores` to make it work seamlessly with images
- add tests for `calculate_drift_score` with images scenario

closes https://github.com/whylabs/whylogs/issues/1422



- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
