### PR TITLE
handle double registration for condition validators

### DIFF
--- a/python/tests/experimental/core/test_udf_schema.py
+++ b/python/tests/experimental/core/test_udf_schema.py
@@ -98,6 +98,7 @@ def test_validator_double_register_udf_pandas() -> None:
     schema = udf_schema()
     # registering the same validator twice should keep only the latest registration
     assert schema.validators["col1"][0].conditions["less_than_four"].__name__ == "lt_4_2"
+    assert len(schema.validators["col1"]) == 1
 
 
 def test_validator_udf_row_with_id() -> None:

--- a/python/tests/experimental/core/test_udf_schema.py
+++ b/python/tests/experimental/core/test_udf_schema.py
@@ -88,6 +88,18 @@ def test_validator_udf_pandas() -> None:
     assert 7 in action_list
 
 
+def test_validator_double_register_udf_pandas() -> None:
+    global action_list
+
+    @condition_validator(["col1", "add5"], condition_name="less_than_four", actions=[do_something_important])
+    def lt_4_2(x):
+        return x < 4
+
+    schema = udf_schema()
+    # registering the same validator twice should keep only the latest registration
+    assert schema.validators["col1"][0].conditions["less_than_four"].__name__ == "lt_4_2"
+
+
 def test_validator_udf_row_with_id() -> None:
     global action_list
     config = MetricConfig(identity_column="cid")

--- a/python/whylogs/experimental/core/validators/validator.py
+++ b/python/whylogs/experimental/core/validators/validator.py
@@ -6,9 +6,19 @@ from whylogs.core.validators import Validator
 _validator_udfs: Dict[str, List[Dict[str, List[Validator]]]] = defaultdict(list)
 
 
-def append_validator(schema_name: str, col_name: str, validator: Validator):
+def append_validator(schema_name, col_name: str, validator: Validator):
     global _validator_udfs
-    _validator_udfs[schema_name].append({col_name: [validator]})
+    validator_name = validator.name
+    exists = False
+    # if validator with same name and column exists, replace it
+    for col_validator in _validator_udfs.get(schema_name, []):
+        if col_name in col_validator:
+            for i, v in enumerate(col_validator[col_name]):
+                if v.name == validator_name:
+                    exists = True
+                    col_validator[col_name][i] = validator
+    if not exists:
+        _validator_udfs[schema_name].append({col_name: [validator]})
 
 
 def generate_validators(


### PR DESCRIPTION
## Description

Currently, double registration for condition validators is allowed. 

This PR will check upon registration if a condition validator with the same name, for the same column, under the same schema name, already exists. If it exists, it will replace the older version to the current one.

Closes #1429 

This repository needs <!-- Add 1-2 sentences explaining the purpose of this PR. -->

The commits in this pull request will <!-- Summarize PR. -->

## Changes

- Imperative commit or change title (commit ID) <!-- Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls). -->
  - Add some bullet points to explain the change
- Next commit or change (commit ID)

## Related

Relates to organization/repo#number

<!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->

Closes organization/repo#number

<!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
