### PR TITLE
Maintenance/0.7.x Java/Scala: Support for profiling model performance metrics only

### DIFF
--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.whylabs"
-version = "0.2.0-b1"
+version = "0.2.0-b2"
 //version = "0.1.7-b1-${project.properties.getOrDefault("versionType", "SNAPSHOT")}"
 extra["isReleaseVersion"] = !version.toString().endsWith("SNAPSHOT")
 

--- a/java/spark-bundle/build.gradle.kts
+++ b/java/spark-bundle/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 val scalaVersion = project.properties.getOrDefault("scalaVersion", "2.12")
-val sparkVersion = project.properties.getOrDefault("sparkVersion", "3.1.1") as String
+val sparkVersion = project.properties.getOrDefault("sparkVersion", "2.4.7") as String
 val artifactBaseName = "whylogs-spark-bundle_${sparkVersion}-scala_$scalaVersion"
 val versionString = rootProject.version
 

--- a/java/spark/build.gradle.kts
+++ b/java/spark/build.gradle.kts
@@ -20,7 +20,7 @@ spotless {
 }
 
 val scalaVersion = project.properties.getOrDefault("scalaVersion", "2.12")
-val sparkVersion = project.properties.getOrDefault("sparkVersion", "3.1.1") as String
+val sparkVersion = project.properties.getOrDefault("sparkVersion", "2.4.7") as String
 val artifactBaseName = "${rootProject.name}-spark_$sparkVersion-scala_$scalaVersion"
 
 tasks.jar {


### PR DESCRIPTION
## Description

The v0 spark profiling methods did not support profiling performance metrics without also profiling the input and output columns for a model.

## Changes

Now if you used the following in scala
```scala
val res = df.newProfilingSession("model")
      .withRegressionModel("predictions", "targets")
      .excludeNonPerformanceMetricsProfiling()
```

or in python you can do the following:
```python
session = new_profiling_session(spark_df, "YOUR_MODEL_NAME") 
session = session.withClassificationModel("PREDICTIONS_COLUMN", "ACTUALS_COLUMN", "SCORES_COLUMN", perf_only=True)
session.log()
```

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
