### PR TITLE
Fix type hints on pyspark timestamps

### DIFF
--- a/python/whylogs/api/pyspark/experimental/profiler.py
+++ b/python/whylogs/api/pyspark/experimental/profiler.py
@@ -121,8 +121,8 @@ def _get_column_batch_size() -> Optional[int]:
 
 def collect_dataset_profile_view(
     input_df: SparkDataFrame,
-    dataset_timestamp: Optional[int] = None,
-    creation_timestamp: Optional[int] = None,
+    dataset_timestamp: Optional[datetime] = None,
+    creation_timestamp: Optional[datetime] = None,
     schema: Optional[DatasetSchema] = None,
 ) -> DatasetProfileView:
     now = datetime.now(timezone.utc)

--- a/python/whylogs/api/pyspark/experimental/segmented_profiler.py
+++ b/python/whylogs/api/pyspark/experimental/segmented_profiler.py
@@ -130,8 +130,8 @@ def _lookup_segment_partition_by_id(schema: DatasetSchema, partition_id: str) ->
 def collect_segmented_results(
     input_df: SparkDataFrame,
     schema: DatasetSchema,
-    dataset_timestamp: Optional[int] = None,
-    creation_timestamp: Optional[int] = None,
+    dataset_timestamp: Optional[datetime] = None,
+    creation_timestamp: Optional[datetime] = None,
 ) -> ResultSet:
     now = datetime.now(timezone.utc)
 


### PR DESCRIPTION
## Description

Small change to fix #1381

## Changes

There are incorrect type hints in the experimental pyspark api for optional datetimes for timestamps, switch them to correct type hints.

These parameters don't work with int specified so this is updating the hints to reflect behavior but does not change the run time behavior.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
