### PR TITLE
Allow setting timestamp on ViewResultSet

### DIFF
--- a/python/tests/api/logger/test_result_set.py
+++ b/python/tests/api/logger/test_result_set.py
@@ -1,11 +1,13 @@
+from datetime import datetime, timedelta, timezone
 from logging import getLogger
 
 import pandas as pd
 
 import whylogs as why
-from whylogs.api.logger.result_set import SegmentedResultSet
+from whylogs.api.logger.result_set import SegmentedResultSet, ViewResultSet
 from whylogs.core.schema import DatasetSchema
 from whylogs.core.segmentation_partition import segment_on_column
+from whylogs.core.view.dataset_profile_view import DatasetProfileView
 
 TEST_LOGGER = getLogger(__name__)
 
@@ -27,3 +29,10 @@ def test_result_set_metadata_on_writables():
         assert profile.metadata["whylabs.traceId"] == trace_id
         assert custom_metadata_key in profile.metadata
         assert profile.metadata[custom_metadata_key] == custom_metadata_value
+
+
+def test_view_result_set_timestamp():
+    results = ViewResultSet(DatasetProfileView(columns=dict(), dataset_timestamp=None, creation_timestamp=None))
+    timestamp = datetime.now(tz=timezone.utc) - timedelta(days=1)
+    results.set_dataset_timestamp(timestamp)
+    assert results.view().dataset_timestamp == timestamp

--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -281,7 +281,7 @@ class ViewResultSet(ResultSet):
         if view is None:
             raise ValueError("Cannot set timestamp on a view result set without a view!")
         else:
-            view.set_dataset_timestamp(dataset_timestamp)
+            view.dataset_timestamp = dataset_timestamp
 
 
 class ProfileResultSet(ResultSet):

--- a/python/whylogs/experimental/api/logger/__init__.py
+++ b/python/whylogs/experimental/api/logger/__init__.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional, Union
 
 from whylogs.api.logger import log
-from whylogs.api.logger.result_set import ProfileResultSet
+from whylogs.api.logger.result_set import ViewResultSet
 from whylogs.core import DatasetSchema
 from whylogs.core.stubs import np, pd
 
@@ -17,7 +17,7 @@ def log_batch_ranking_metrics(
     score_column: Optional[str] = None,
     schema: Union[DatasetSchema, None] = None,
     log_full_data: bool = False,
-) -> ProfileResultSet:
+) -> ViewResultSet:
     formatted_data = data.copy(deep=True)  # TODO: does this have to be deep?
 
     relevant_cols = [prediction_column]


### PR DESCRIPTION
## Description

Allow setting timestamp on `ViewResultSet`

## Changes

- `DatasetProfileView`'s timestamp is a property, there's no setter method
- Fix type annotation mistake in `log_batch_ranking_metrics()`
- 
## Related

Fixes https://app.clickup.com/t/86ayyfybj

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
