### PR TITLE
Don't throw on profile url link generation errors post upload

### DIFF
--- a/python/whylogs/api/whylabs/session/session.py
+++ b/python/whylogs/api/whylabs/session/session.py
@@ -326,9 +326,7 @@ class ApiKeySession(Session):
                 dataset_id, org_id, request
             )
         except Exception as e:
-            logger.warning(
-                f"Convenience profile links could not be generated for the sucessfully uploading profiles: {e}"
-            )
+            logger.info(f"Convenience profile links could not be generated for the sucessfully uploading profiles: {e}")
 
         profile_url = response.observatory_url if response else ""
         individual_urls = response.individual_observatory_urls if response else None

--- a/python/whylogs/api/whylabs/session/session.py
+++ b/python/whylogs/api/whylabs/session/session.py
@@ -320,12 +320,20 @@ class ApiKeySession(Session):
 
         org_id = self.config.require_org_id()
         dataset_id = self.config.require_default_dataset_id()
-        response: GetProfileObservatoryLinkResponse = self._whylabs_log_api.value.get_profile_observatory_link(
-            dataset_id, org_id, request
-        )
 
+        try:
+            response: GetProfileObservatoryLinkResponse = self._whylabs_log_api.value.get_profile_observatory_link(
+                dataset_id, org_id, request
+            )
+        except Exception as e:
+            logger.warning(
+                f"Convenience profile links could not be generated for the sucessfully uploading profiles: {e}"
+            )
+
+        profile_url = response.observatory_url if response else ""
+        individual_urls = response.individual_observatory_urls if response else None
         return UploadResult(
-            viewing_url=response.observatory_url,
+            viewing_url=profile_url,
             result=result,
-            individual_viewing_urls=response.individual_observatory_urls,
+            individual_viewing_urls=individual_urls,
         )


### PR DESCRIPTION
## Description

wrap the call to get the profile url in try/except and log as warning so we're not raising in the case where profile upload is successful.

## Changes

try/except arount post upload profile url call
default strings for results

## Related

Address #1449

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
