### PR TITLE
make to_pandas result same between profiles pre/post uncompounding

### DIFF
--- a/python/tests/migration/test_uncompound.py
+++ b/python/tests/migration/test_uncompound.py
@@ -84,6 +84,7 @@ def test_uncompounded_image_profile() -> None:
     uncompM = _uncompound_dataset_profile(merged_prof)
     assert set(uncomp1.get_columns()) == set(uncomp2.get_columns())
     assert set(uncomp1.get_columns()) == set(uncompM.get_columns())
+    assert prof1.to_pandas().shape == uncomp1.to_pandas().shape
 
 
 def test_uncompounded_profile_metadata() -> None:
@@ -130,6 +131,7 @@ def test_uncompounded_condition_count() -> None:
 
     uncompounded = _uncompound_dataset_profile(profile)
     assert len(uncompounded.get_columns().keys()) == 1 + 3 * len(metric.matches.keys())
+    assert profile.to_pandas().shape == uncompounded.to_pandas().shape
     for cond_name in ["alpha", "digit"]:
         for component_name in ["total", "matches", "non_matches"]:
             column_name = f"{_condition_count_magic_string()}col1.{cond_name}.{component_name}"

--- a/python/tests/migration/test_uncompound.py
+++ b/python/tests/migration/test_uncompound.py
@@ -128,10 +128,8 @@ def test_uncompounded_condition_count() -> None:
     assert metric.total.value == 2
     assert metric.matches["alpha"].value == 1
     assert metric.matches["digit"].value == 1
-
     uncompounded = _uncompound_dataset_profile(profile)
     assert len(uncompounded.get_columns().keys()) == 1 + 3 * len(metric.matches.keys())
-    assert profile.to_pandas().shape == uncompounded.to_pandas().shape
     for cond_name in ["alpha", "digit"]:
         for component_name in ["total", "matches", "non_matches"]:
             column_name = f"{_condition_count_magic_string()}col1.{cond_name}.{component_name}"

--- a/python/whylogs/core/view/dataset_profile_view.py
+++ b/python/whylogs/core/view/dataset_profile_view.py
@@ -433,15 +433,14 @@ class DatasetProfileView(Writable):
 
     def _is_uncompounded(self, col_name):
         groups = col_name.split(".")
+        metric = groups[0]
         if not len(groups) > 1:
             return False
-        if groups[0] in self._columns.keys():
-            for metric_name in self._columns[groups[0]].get_metric_component_paths():
+        if metric in self._columns.keys():
+            for metric_name in self._columns[metric].get_metric_component_paths():
                 new_metric_name = metric_name.split(":")[0].replace("/", ".")
                 if col_name == new_metric_name:
                     return True
-                # if all([x in metric_name for x in groups[1:]]):
-                #     return True
         return False
 
     def to_pandas(self, column_metric: Optional[str] = None, cfg: Optional[SummaryConfig] = None) -> pd.DataFrame:

--- a/python/whylogs/viz/drift/column_drift_algorithms.py
+++ b/python/whylogs/viz/drift/column_drift_algorithms.py
@@ -361,6 +361,8 @@ class KS(ColumnDriftAlgorithm):
         m, n = sorted([target_distribution.get_n(), reference_distribution.get_n()], reverse=True)
         en = m * n / (m + n)
         p_value = stats.distributions.kstwo.sf(D_max, np.round(en))
+        if np.isnan(p_value) or p_value is None:
+            return None
         if with_thresholds:
             drift_category = self._get_drift_category(measure=p_value)
             drift_score = DriftAlgorithmScore(


### PR DESCRIPTION
## Description

Calling `to_pandas()` on an uncompounded profiles will produce a sparse dataframe. This PR adds a verification step in to_pandas to check whether the column is the result of uncompounding. If it is, it won't be included in the resulting DF, producing the same result as the pre-uncompound profile.

Plus: incidental np.nan bug fix for drift calculation



## Related

Closes organization/repo#number

closes #1401 

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
