### PR TITLE
Fix bug that prevents prefixes from being omitted in udfs

### DIFF
--- a/python/tests/experimental/core/test_udf_schema.py
+++ b/python/tests/experimental/core/test_udf_schema.py
@@ -71,6 +71,14 @@ def f2(x: Union[Dict[str, List], pd.DataFrame]) -> Union[Dict[str, List], pd.Dat
         return pd.DataFrame({"foo": x["xx1"], "bar": x["xx2"]})
 
 
+@register_multioutput_udf(["xx1", "xx2"], no_prefix=True)
+def no_prefix_udf(x: Union[Dict[str, List], pd.DataFrame]) -> Union[Dict[str, List], pd.DataFrame]:
+    if isinstance(x, dict):
+        return {"foo": [x["xx1"][0]], "bar": [x["xx2"][0]]}
+    else:
+        return pd.DataFrame({"foo": x["xx1"], "bar": x["xx2"]})
+
+
 def test_multioutput_udf_row() -> None:
     schema = udf_schema()
     row = {"xx1": 42, "xx2": 3.14}
@@ -79,6 +87,8 @@ def test_multioutput_udf_row() -> None:
     assert results.get_column("f1.bar") is not None
     assert results.get_column("blah.foo") is not None
     assert results.get_column("blah.bar") is not None
+    assert results.get_column("foo") is not None
+    assert results.get_column("bar") is not None
 
 
 def test_multioutput_udf_dataframe() -> None:
@@ -89,6 +99,8 @@ def test_multioutput_udf_dataframe() -> None:
     assert results.get_column("f1.bar") is not None
     assert results.get_column("blah.foo") is not None
     assert results.get_column("blah.bar") is not None
+    assert results.get_column("foo") is not None
+    assert results.get_column("bar") is not None
 
 
 @register_dataset_udf(["col1"], schema_name="unit-tests")


### PR DESCRIPTION
The types for a udf schema allow the prefix to be None, but our code doesn't work in that scenario. In addition, the annotation interface for udfs don't even let you have a None prefix. This change fixes both of those issues.
