### PR TITLE
Add better warning message on failed profile uploads

### DIFF
--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import os
+import pprint
 import tempfile
 from typing import IO, Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
@@ -789,7 +790,9 @@ class WhyLabsWriter(Writer):
                 f"{self.whylabs_api_endpoint} with API token ID: {self._key_refresher.key_id}"
             )
         else:
-            logger.warning(f"response from file upload was not 200, instead got: {response}")
+            logger.warning(
+                f"response from file upload was not 200, instead got: {pprint.pformat(vars(response), indent=4)}"
+            )
 
         return is_successful, response.reason
 

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -788,6 +788,9 @@ class WhyLabsWriter(Writer):
                 f"Done uploading {self._org_id}/{self._dataset_id}/{dataset_timestamp} to "
                 f"{self.whylabs_api_endpoint} with API token ID: {self._key_refresher.key_id}"
             )
+        else:
+            logger.warning(f"response from file upload was not 200, instead got: {response}")
+
         return is_successful, response.reason
 
     def _do_upload(


### PR DESCRIPTION
## Description

If upload fails with a non-200 status code return but doesn't encounter an error, we don't log enough information to diagnose this scenario.

## Changes

- Adds a warning message to any profile uploads to WhyLabs that get back a status code other than 200.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
