### PR TITLE
ndcg refactor

### DIFF
--- a/python/tests/experimental/api/test_logger.py
+++ b/python/tests/experimental/api/test_logger.py
@@ -44,7 +44,7 @@ def test_log_batch_ranking_metrics_single_simple():
     assert pandas_summary.loc["average_precision", "counts/n"] == 4
     assert pandas_summary.loc["norm_dis_cumul_gain", "counts/n"] == 1
     # ndcg = [1, 0, 0.63, 0.5]
-    assert isclose(pandas_summary.loc[f"norm_dis_cumul_gain", "distribution/mean"], 0.53273, abs_tol=0.00001)
+    assert isclose(pandas_summary.loc["norm_dis_cumul_gain", "distribution/mean"], 0.53273, abs_tol=0.00001)
 
 
 def test_log_batch_ranking_metrics_binary_simple():
@@ -52,9 +52,7 @@ def test_log_batch_ranking_metrics_binary_simple():
         {"raw_predictions": [[True, False, True], [False, False, False], [True, True, False], [False, True, False]]}
     )
 
-    result = log_batch_ranking_metrics(
-        data=binary_df, prediction_column="raw_predictions", k=2
-    )
+    result = log_batch_ranking_metrics(data=binary_df, prediction_column="raw_predictions", k=2)
     pandas_summary = result.view().to_pandas()
 
     k = 2
@@ -132,9 +130,7 @@ def test_log_batch_ranking_metrics_multiple_simple():
 def test_log_batch_ranking_metrics_default_target():
     multiple_df = pd.DataFrame({"raw_predictions": [[3, 2, 3, 0, 1, 2, 3, 2]]})
 
-    result = log_batch_ranking_metrics(
-        data=multiple_df, prediction_column="raw_predictions", k=3
-    )
+    result = log_batch_ranking_metrics(data=multiple_df, prediction_column="raw_predictions", k=3)
     pandas_summary = result.view().to_pandas()
 
     k = 3

--- a/python/tests/experimental/api/test_logger.py
+++ b/python/tests/experimental/api/test_logger.py
@@ -22,29 +22,29 @@ def test_log_batch_ranking_metrics_single_simple():
     pandas_summary = result.view().to_pandas()
 
     column_names = [
-        "mean_average_precision",
-        "accuracy",
+        "mean_average_precision_k_3",
+        "accuracy_k_3",
         "mean_reciprocal_rank",
-        "precision",
-        "recall",
+        "precision_k_3",
+        "recall_k_3",
         "top_rank",
-        "average_precision",
-        "norm_dis_cumul_gain",
+        "average_precision_k_3",
+        "norm_dis_cumul_gain_k_3",
     ]
     for col in column_names:
         assert col in pandas_summary.index
-    assert pandas_summary.loc["mean_average_precision", "counts/n"] == 1
-    assert pandas_summary.loc["accuracy", "counts/n"] == 1
+    assert pandas_summary.loc["mean_average_precision_k_3", "counts/n"] == 1
+    assert pandas_summary.loc["accuracy_k_3", "counts/n"] == 1
     assert pandas_summary.loc["mean_reciprocal_rank", "counts/n"] == 1
-    assert pandas_summary.loc["precision", "counts/n"] == 4
-    assert pandas_summary.loc["recall", "counts/n"] == 4
+    assert pandas_summary.loc["precision_k_3", "counts/n"] == 4
+    assert pandas_summary.loc["recall_k_3", "counts/n"] == 4
     assert pandas_summary.loc["top_rank", "counts/n"] == 4
-    assert pandas_summary.loc["average_precision", "counts/n"] == 4
-    assert pandas_summary.loc["norm_dis_cumul_gain", "counts/n"] == 1
-    assert pandas_summary.loc["average_precision", "counts/n"] == 4
-    assert pandas_summary.loc["norm_dis_cumul_gain", "counts/n"] == 1
+    assert pandas_summary.loc["average_precision_k_3", "counts/n"] == 4
+    assert pandas_summary.loc["norm_dis_cumul_gain_k_3", "counts/n"] == 1
+    assert pandas_summary.loc["average_precision_k_3", "counts/n"] == 4
+    assert pandas_summary.loc["norm_dis_cumul_gain_k_3", "counts/n"] == 1
     # ndcg = [1, 0, 0.63, 0.5]
-    assert isclose(pandas_summary.loc["norm_dis_cumul_gain", "distribution/mean"], 0.53273, abs_tol=0.00001)
+    assert isclose(pandas_summary.loc["norm_dis_cumul_gain_k_3", "distribution/mean"], 0.53273, abs_tol=0.00001)
 
 
 def test_log_batch_ranking_metrics_binary_simple():
@@ -160,7 +160,7 @@ def test_log_batch_ranking_metrics_default_target():
 
 def test_log_batch_ranking_metrics_ranking_ndcg_wikipedia():
     # From https://en.wikipedia.org/wiki/Discounted_cumulative_gain#Example
-    ranking_df = pd.DataFrame({"targets": [[3, 2, 3, 0, 1, 2, 3, 2]], "predictions": [[0, 1, 2, 3, 4, 5]]})
+    ranking_df = pd.DataFrame({"targets": [[1, 0, 2, 3, 3, 2, 2, 3]], "predictions": [[5, 4, 2, 1, 7, 8, 6, 3]]})
 
     result = log_batch_ranking_metrics(data=ranking_df, prediction_column="predictions", target_column="targets", k=6)
     pandas_summary = result.view().to_pandas()
@@ -175,7 +175,7 @@ def test_log_batch_ranking_metrics_ranking_ndcg_sklearn():
     result = log_batch_ranking_metrics(data=ranking_df, score_column="scores", target_column="true_relevance")
     pandas_summary = result.view().to_pandas()
 
-    assert isclose(pandas_summary.loc["norm_dis_cumul_gain", "distribution/median"], 0.69569, abs_tol=0.00001)
+    assert isclose(pandas_summary.loc["norm_dis_cumul_gain_k_5", "distribution/median"], 0.69569, abs_tol=0.00001)
 
 
 def test_log_batch_ranking_metrics_ranking_ndcg_withk_sklearn():

--- a/python/tests/experimental/api/test_logger.py
+++ b/python/tests/experimental/api/test_logger.py
@@ -160,7 +160,7 @@ def test_log_batch_ranking_metrics_default_target():
 
 def test_log_batch_ranking_metrics_ranking_ndcg_wikipedia():
     # From https://en.wikipedia.org/wiki/Discounted_cumulative_gain#Example
-    ranking_df = pd.DataFrame({"targets": [[3, 2, 3, 0, 1, 2, 3, 2]], "predictions": [[3, 2, 3, 0, 1, 2]]})
+    ranking_df = pd.DataFrame({"targets": [[3, 2, 3, 0, 1, 2, 3, 2]], "predictions": [[0, 1, 2, 3, 4, 5]]})
 
     result = log_batch_ranking_metrics(data=ranking_df, prediction_column="predictions", target_column="targets", k=6)
     pandas_summary = result.view().to_pandas()

--- a/python/whylogs/experimental/api/logger/__init__.py
+++ b/python/whylogs/experimental/api/logger/__init__.py
@@ -33,7 +33,6 @@ def log_batch_ranking_metrics(
         if score_column is not None and target_column is not None:
             prediction_column = "__predictions"
 
-            # sort data[prediction_column] by score_column
             def _sort_by_score(row):
                 return [x for _, x in sorted(zip(row[score_column], row[target_column]), reverse=True)]
 
@@ -47,8 +46,6 @@ def log_batch_ranking_metrics(
     if target_column is None:
         formatted_data = _convert_to_int_if_bool(formatted_data, prediction_column)
         target_column = "__targets"
-        # formatted_data[target_column] = formatted_data[prediction_column].apply(lambda x: list(range(len(x)))[::-1])
-        # formatted_data[target_column] = [[] for _ in range(len(formatted_data[prediction_column]))]
         formatted_data[target_column] = formatted_data[prediction_column]
 
     relevant_cols.append(target_column)

--- a/python/whylogs/experimental/api/logger/__init__.py
+++ b/python/whylogs/experimental/api/logger/__init__.py
@@ -33,11 +33,10 @@ def log_batch_ranking_metrics(
         if score_column is not None and target_column is not None:
             prediction_column = "__predictions"
 
-            def _sort_by_score(row):
-                return [x for _, x in sorted(zip(row[score_column], row[target_column]), reverse=True)]
-
             # Ties are not being handled here
-            formatted_data[prediction_column] = formatted_data.apply(_sort_by_score, axis=1)
+            formatted_data[prediction_column] = formatted_data.apply(
+                lambda row: [x for _, x in sorted(zip(row[score_column], row[target_column]), reverse=True)], axis=1
+            )
         else:
             raise ValueError("Either prediction_column or score+target columns must be specified")
 

--- a/python/whylogs/experimental/api/logger/__init__.py
+++ b/python/whylogs/experimental/api/logger/__init__.py
@@ -1,15 +1,11 @@
 import logging
 import math
 from typing import Optional, Union
-
 from whylogs.api.logger import log
 from whylogs.api.logger.result_set import ViewResultSet
 from whylogs.core import DatasetSchema
 from whylogs.core.stubs import np, pd
-
 diagnostic_logger = logging.getLogger(__name__)
-
-
 def log_batch_ranking_metrics(
     data: pd.core.frame.DataFrame,
     prediction_column: str,
@@ -21,7 +17,6 @@ def log_batch_ranking_metrics(
     log_full_data: bool = False,
 ) -> ViewResultSet:
     formatted_data = data.copy(deep=True)  # TODO: does this have to be deep?
-
     relevant_cols = [prediction_column]
     if target_column is None:
         target_column = "__targets"
@@ -29,37 +24,29 @@ def log_batch_ranking_metrics(
     relevant_cols.append(target_column)
     if score_column is not None:
         relevant_cols.append(score_column)
-
     for col in relevant_cols:
         if not formatted_data[col].apply(lambda x: type(x) == list).all():
             # wrapping in lists because at least one isn't a list
             # TODO: more error checking
             formatted_data[col] = formatted_data[col].apply(lambda x: [x])
-
     _max_k = formatted_data[prediction_column].apply(len).max()
-
     formatted_data["count_at_k"] = formatted_data[relevant_cols].apply(
         lambda row: sum([1 if pred_val in row[target_column] else 0 for pred_val in row[prediction_column][:k]]), axis=1
     )
-
     formatted_data["count_all"] = formatted_data[relevant_cols].apply(
         lambda row: sum([1 if pred_val in row[target_column] else 0 for pred_val in row[prediction_column]]), axis=1
     )
-
     def get_top_rank(row):
         matches = [i + 1 for i, pred_val in enumerate(row[prediction_column]) if pred_val in row[target_column]]
         if not matches:
             return 0
         else:
             return matches[0]
-
     formatted_data["top_rank"] = formatted_data[relevant_cols].apply(get_top_rank, axis=1)
-
     output_data = (formatted_data["count_at_k"] / (k if k else 1)).to_frame()
     output_data.columns = ["precision" + ("_k_" + str(k) if k else "")]
     output_data["recall" + ("_k_" + str(k) if k else "")] = formatted_data["count_at_k"] / formatted_data["count_all"]
     output_data["top_rank"] = formatted_data["top_rank"]
-
     ki_dict: pd.DataFrame = None
     for ki in range(1, (k if k else _max_k) + 1):
         ki_result = (
@@ -76,41 +63,29 @@ def log_batch_ranking_metrics(
             ki_dict.columns = ["p@" + str(ki)]
         else:
             ki_dict["p@" + str(ki)] = ki_result
-
     output_data["average_precision" + ("_k_" + str(k) if k else "")] = ki_dict.mean(axis=1)
-
-    def _convert_non_numeric(row_dict):
-        return (
-            [
-                row_dict[target_column].index(pred_val) if pred_val in row_dict[target_column] else -1
-                for pred_val in row_dict[prediction_column]
-            ],
-            list(range(len(row_dict[prediction_column])))[::-1],
-        )
-
+    def _calc_non_numeric_relevance(row_dict):
+        return ([1 if pred_val in row_dict[target_column] else 0 for pred_val in row_dict[prediction_column]],
+                [1 for target_val in row_dict[target_column] if target_val not in row_dict[prediction_column]])
     if convert_non_numeric:
-        formatted_data[[prediction_column, target_column]] = formatted_data.apply(
-            _convert_non_numeric, result_type="expand", axis=1
+        formatted_data[["predicted_relevance","ideal_relevance"]] = formatted_data.apply(
+            _calc_non_numeric_relevance, result_type="expand", axis=1
         )
-
     def _calculate_row_ndcg(row_dict, k):
-        predicted_order = np.array(row_dict[prediction_column]).argsort()[::-1]
-        target_order = np.array(row_dict[target_column]).argsort()[::-1]
+        predicted_relevances = row_dict["predicted_relevance"] # [1,0,0], [3,1,0,3]
+        ideal_relevances = sorted(row_dict["predicted_relevance"] + row_dict["ideal_relevance"], reverse=True) #[1,0,0], [3,3,1,0]
         dcg_vals = [
-            (rel / math.log(i + 2, 2)) for i, rel in enumerate(np.array(row_dict[target_column])[predicted_order][:k])
+            (rel / math.log(i + 2, 2)) for i, rel in enumerate(predicted_relevances[:k])
         ]
         idcg_vals = [
-            (rel / math.log(i + 2, 2)) for i, rel in enumerate(np.array(row_dict[target_column])[target_order][:k])
+            (rel / math.log(i + 2, 2)) for i, rel in enumerate(ideal_relevances[:k])
         ]
         return sum(dcg_vals) / sum(idcg_vals)
-
     formatted_data["norm_dis_cumul_gain_k_" + str(k)] = formatted_data.apply(_calculate_row_ndcg, args=(k,), axis=1)
-
     mAP_at_k = ki_dict.mean()
     hit_ratio = formatted_data["count_at_k"].apply(lambda x: bool(x)).sum() / len(formatted_data)
     mrr = (1 / formatted_data["top_rank"]).replace([np.inf], np.nan).mean()
-    ndcg = formatted_data["norm_dis_cumul_gain_k_" + str(k)].mean()
-
+    ndcg = formatted_data["norm_dis_cumul_gain" + ("_k_" + str(k) if k else "")].mean()
     result = log(pandas=output_data, schema=schema)
     result = result.merge(
         log(
@@ -123,8 +98,6 @@ def log_batch_ranking_metrics(
             schema=schema,
         )
     )
-
     if log_full_data:
         result = result.merge(log(pandas=data, schema=schema))
-
     return result


### PR DESCRIPTION
## Description

This PR:

- Adds ndcg value expecations to the tests, not just counts
- Changes convert_non_numeric=True to be used for string columns (integers, floats in scores and bools should use the default convert_non_numeric=False )
- adds score_column support: when a score is available, like in [this example](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.ndcg_score.html), one should use score_column and target_column , and not prediction_column (see 2 last tests on the sklearn examples)
 - Changes the logic to generate target column values to make it compatible with all scenarios
- Fixes prediction and ideal relevance calculation for non numeric case
- Handles DivisionbyZero edge case when idcg=0 (ndcg set to 1 if no relevant documents exist)
- If K is not passed, metrics will be calculated according to predictions cols's length (and metrics named accordingly - k is no longer omitted in the names when k is None)

For the Numeric case:
- If predictions+target or scores+target columns are both provided, they need to be of same length.
- If prediction_column is provided with target column, prediction col contains the rank of suggested items, starting with 1
- If only prediction column is provided, it is assumed that the order encodes the ranks of recommendations: first item in the list is the first recommendation. The value in the list encodes the relevance score

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
