### PR TITLE
Show adding ranking metrics to output tab in example notebook

### DIFF
--- a/python/examples/experimental/Writing_Ranking_Performance_Metrics_to_WhyLabs.ipynb
+++ b/python/examples/experimental/Writing_Ranking_Performance_Metrics_to_WhyLabs.ipynb
@@ -827,19 +827,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "id": "GtIW3274wbjq"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Using API Key ID:  \n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Configure WhyLabs info, if needed\n",
         "import getpass\n",
@@ -861,6 +853,27 @@
       "source": [
         "# Write the results to WhyLabs platform\n",
         "results.writer(\"whylabs\").write()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# You can tag these custom performance metrics to be treated as output features\n",
+        "ranking_metric_names = [\n",
+        "    \"accuracy_k_2\",\n",
+        "    \"average_precision_k_2\",\n",
+        "    \"mean_average_precision_k_2\",\n",
+        "    \"mean_reciprocal_rank\",\n",
+        "    \"precision_k_2\",\n",
+        "    \"raw_predictions\",\n",
+        "    \"raw_targets\",\n",
+        "    \"recall_k_2\",\n",
+        "    \"top_rank\"\n",
+        "]\n",
+        "results.writer(\"whylabs\").tag_output_columns(ranking_metric_names)"
       ]
     },
     {


### PR DESCRIPTION
## Description

Small update to ranking metrics example to mark the performance metrics as outputs so they aren't displayed as input features.

## Changes

- Add a tag_output_columns example for the ranking metrics after writing them to WhyLabs.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
