### PR TITLE
condition count metric uncompounding types

### DIFF
--- a/python/tests/core/test_declarative_schema.py
+++ b/python/tests/core/test_declarative_schema.py
@@ -208,6 +208,25 @@ def test_declarative_schema_with_additional_resolvers(pandas_dataframe):
     }.issubset(colset)
 
 
+def test_declarative_schema_add_multiple_resolvers(pandas_dataframe):
+    schema = DeclarativeSchema([])
+    schema.add_resolver_spec("animal", None, [MetricSpec(StandardMetric.cardinality.value)])
+    schema.add_resolver_spec({"legs", "weight"}, None, [MetricSpec(StandardMetric.distribution.value)])
+    results = why.log(pandas_dataframe, schema=schema).view()
+    metrics = set(results.get_column("animal").get_metric_names())
+    assert metrics == {"cardinality"}
+    metrics = set(results.get_column("legs").get_metric_names())
+    assert metrics == {"distribution"}
+    metrics = set(results.get_column("weight").get_metric_names())
+    assert metrics == {"distribution"}
+
+
+def test_invalid_column_name():
+    schema = DeclarativeSchema([])
+    with pytest.raises(ValueError):
+        schema.add_resolver_spec(42)
+
+
 def test_additional_metrics_nonexistent(pandas_dataframe):
     count_spec = ResolverSpec(
         column_name="nonexistent_columns",

--- a/python/tests/migration/test_uncompound.py
+++ b/python/tests/migration/test_uncompound.py
@@ -141,3 +141,10 @@ def test_uncompounded_condition_count() -> None:
             assert metric.null.value == 0
             assert metric.nan.value == 0
             assert metric.inf.value == 0
+            metric = uncompounded._columns[column_name]._metrics["types"]
+            assert metric.integral.value == 2
+            assert metric.fractional.value == 0
+            assert metric.boolean.value == 0
+            assert metric.string.value == 0
+            assert metric.object.value == 0
+            assert metric.tensor.value == 0

--- a/python/whylogs/core/schema.py
+++ b/python/whylogs/core/schema.py
@@ -236,7 +236,7 @@ class DeclarativeSchema(DatasetSchema):
         column_type: Optional[Any] = None,
         metrics: Optional[List[MetricSpec]] = None,
     ):
-        if not isinstance(column_name, (str, set)):
+        if column_name is not None and not isinstance(column_name, (str, set)):
             raise ValueError("column_name must be a stirng or set of strings")
 
         if isinstance(column_name, set):

--- a/python/whylogs/core/schema.py
+++ b/python/whylogs/core/schema.py
@@ -1,7 +1,7 @@
 import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Mapping, Optional, Tuple, TypeVar
+from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, TypeVar, Union
 
 import whylogs.core.resolvers as res
 from whylogs.core.datatypes import StandardTypeMapper, TypeMapper
@@ -232,10 +232,19 @@ class DeclarativeSchema(DatasetSchema):
 
     def add_resolver_spec(
         self,
-        column_name: Optional[str] = None,
+        column_name: Optional[Union[str, Set[str]]] = None,
         column_type: Optional[Any] = None,
         metrics: Optional[List[MetricSpec]] = None,
     ):
+        if not isinstance(column_name, (str, set)):
+            raise ValueError("column_name must be a stirng or set of strings")
+
+        if isinstance(column_name, set):
+            for name in column_name:
+                spec = ResolverSpec(column_name=name, column_type=column_type, metrics=metrics or [])
+                self.add_resolver(spec)
+            return
+
         spec = ResolverSpec(column_name=column_name, column_type=column_type, metrics=metrics or [])
         self.add_resolver(spec)
 


### PR DESCRIPTION
## Description

Adds type counter metric to uncompounded condition count metric columns.
Also allows `DeclarativeSchema::add_resolver_spec()` to accept a set of column names to apply the metrics to.

Closes whylabs/whylogs#1496
Closes whylabs/whylogs#1497

[ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
