### PR TITLE
Add ndcg and sum_gain in known ranking metrics for custom perf tagging

### DIFF
--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -86,6 +86,8 @@ KNOWN_CUSTOM_PERFORMANCE_METRICS = {
     "recall_k_": "mean",
     "top_rank": "mean",
     "average_precision_k_": "mean",
+    "norm_dis_cumul_gain_k_": "mean",
+    "sum_gain_k_": "mean", 
 }
 
 

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -87,7 +87,7 @@ KNOWN_CUSTOM_PERFORMANCE_METRICS = {
     "top_rank": "mean",
     "average_precision_k_": "mean",
     "norm_dis_cumul_gain_k_": "mean",
-    "sum_gain_k_": "mean", 
+    "sum_gain_k_": "mean",
 }
 
 


### PR DESCRIPTION
## Description

This PR adds ndcg and sum_gain in the list of known ranking metrics columns, so it will be automatically tagged as custom performance for whylabs.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
