### PR TITLE
Tag custom ranking metrics as output columns

### DIFF
--- a/python/tests/api/writer/test_whylabs_integration.py
+++ b/python/tests/api/writer/test_whylabs_integration.py
@@ -170,16 +170,16 @@ def test_performance_column():
     model_api = ModelsApi(writer._api_client)
     response: EntitySchema = model_api.get_entity_schema(ORG_ID, MODEL_ID)
     assert (
-        response["metrics"]["perf column"]["column"] == "col1"
-        and response["metrics"]["perf column"]["default_metric"] == "mean"
-        and response["metrics"]["perf column"]["label"] == "perf column"
+        response["metrics"]["perf_column"]["column"] == "col1"
+        and response["metrics"]["perf_column"]["default_metric"] == "mean"
+        and response["metrics"]["perf_column"]["label"] == "perf column"
     )
 
     # change it so we won't accidentally pass from previous state
     status, _ = writer.tag_custom_performance_column("col1", "perf column", "median")
     assert status
     response = model_api.get_entity_schema(ORG_ID, MODEL_ID)
-    assert response["metrics"]["perf column"]["default_metric"] == "median"
+    assert response["metrics"]["perf_column"]["default_metric"] == "median"
 
 
 @pytest.mark.load

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -689,7 +689,7 @@ class WhyLabsWriter(Writer):
                         data_type = KNOWN_CUSTOM_OUTPUT_METRICS[perf_col][0]
                         discreteness = KNOWN_CUSTOM_OUTPUT_METRICS[perf_col][1]
                         column_schema: ColumnSchema = ColumnSchema(
-                            classifier="output", data_type=data_type, discreteness=discreteness # type: ignore
+                            classifier="output", data_type=data_type, discreteness=discreteness  # type: ignore
                         )
                         self._set_column_schema(column_name, column_schema=column_schema)
         return
@@ -1058,7 +1058,7 @@ class WhyLabsWriter(Writer):
         model_api_instance = self._get_or_create_models_client()
         try:
             # TODO: remove when whylabs supports merge writes.
-            model_api_instance.put_entity_schema_column( # type: ignore
+            model_api_instance.put_entity_schema_column(  # type: ignore
                 self._org_id, self._dataset_id, column_name, column_schema=column_schema
             )
             return (

--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -91,15 +91,15 @@ KNOWN_CUSTOM_PERFORMANCE_METRICS = {
 }
 
 KNOWN_CUSTOM_OUTPUT_METRICS = {
-    "mean_average_precision_k_": ("fractional","continuous"),
-    "accuracy_k_": ("fractional","continuous"),
-    "reciprocal_rank": ("fractional","continuous"),
-    "precision_k_": ("fractional","continuous"),
-    "recall_k_": ("fractional","continuous"),
-    "top_rank": ("integral","continuous"),
-    "average_precision_k_": ("fractional","continuous"),
-    "norm_dis_cumul_gain_k_": ("fractional","continuous"),
-    "sum_gain_k_": ("fractional","continuous"), 
+    "mean_average_precision_k_": ("fractional", "continuous"),
+    "accuracy_k_": ("fractional", "continuous"),
+    "reciprocal_rank": ("fractional", "continuous"),
+    "precision_k_": ("fractional", "continuous"),
+    "recall_k_": ("fractional", "continuous"),
+    "top_rank": ("integral", "continuous"),
+    "average_precision_k_": ("fractional", "continuous"),
+    "norm_dis_cumul_gain_k_": ("fractional", "continuous"),
+    "sum_gain_k_": ("fractional", "continuous"),
 }
 
 
@@ -688,10 +688,11 @@ class WhyLabsWriter(Writer):
                     if column_name.startswith(perf_col):
                         data_type = KNOWN_CUSTOM_OUTPUT_METRICS[perf_col][0]
                         discreteness = KNOWN_CUSTOM_OUTPUT_METRICS[perf_col][1]
-                        column_schema: ColumnSchema = ColumnSchema(classifier='output',data_type = data_type, discreteness = discreteness)
+                        column_schema: ColumnSchema = ColumnSchema(
+                            classifier="output", data_type=data_type, discreteness=discreteness # type: ignore
+                        )
                         self._set_column_schema(column_name, column_schema=column_schema)
         return
-
 
     def _tag_custom_perf_metrics(self, view: Union[DatasetProfileView, SegmentedDatasetProfileView]):
         if isinstance(view, DatasetProfileView):
@@ -1053,12 +1054,11 @@ class WhyLabsWriter(Writer):
             return True
         return existing_classification != new_classification
 
-
-    def _set_column_schema(self, column_name:str, column_schema: ColumnSchema):
+    def _set_column_schema(self, column_name: str, column_schema: ColumnSchema):
         model_api_instance = self._get_or_create_models_client()
         try:
             # TODO: remove when whylabs supports merge writes.
-            model_api_instance.put_entity_schema_column(
+            model_api_instance.put_entity_schema_column( # type: ignore
                 self._org_id, self._dataset_id, column_name, column_schema=column_schema
             )
             return (
@@ -1073,8 +1073,6 @@ class WhyLabsWriter(Writer):
                 f" with API token ID: {self.key_id}"
             )
             raise e
-
-
 
     def _put_column_schema(self, column_name: str, value: str) -> Tuple[int, str]:
         model_api_instance = self._get_or_create_models_client()


### PR DESCRIPTION
## Description

This PR:

- On write(), search for known custom ranking metrics and tag them as outputs
- tag_output_column requires the preexistence of columns, so a new _set_column_schema is created that can be called before the actual columns are uploaded
- incidental fix on integration tests for performance columns


- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
