### PR TITLE
Restore Writable-specific writer wrappers for back compat

### DIFF
--- a/python/whylogs/api/logger/result_set.py
+++ b/python/whylogs/api/logger/result_set.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from whylabs_client.model.segment_tag import SegmentTag
 
 from whylogs.api.reader import Reader, Readers
-from whylogs.api.writer.writer import Writable
+from whylogs.api.writer.writer import Writable, WriterWrapper
 from whylogs.core import DatasetProfile, DatasetProfileView, Segment
 from whylogs.core.metrics.metrics import Metric
 from whylogs.core.model_performance_metrics import ModelPerformanceMetrics
@@ -575,3 +575,6 @@ class SegmentedResultSet(ResultSet):
             return SegmentedResultSet(merged_segments, merged_partitions, metrics=merged_metrics, properties=properties)
         else:
             raise ValueError(f"Cannot merge incompatible SegmentedResultSet and {type(other)}")
+
+
+ResultSetWriter = WriterWrapper

--- a/python/whylogs/core/feature_weights.py
+++ b/python/whylogs/core/feature_weights.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from whylogs.api.writer.writer import Writable
+from whylogs.api.writer.writer import Writable, WriterWrapper
 from whylogs.core import Segment
 
 
@@ -36,3 +36,6 @@ class FeatureWeights(Writable):
 
     def to_dict(self) -> Dict[str, Union[Optional[Segment], Optional[float]]]:
         return {"segment": self.segment, "weights": self.weights}
+
+
+FeatureWeightWriter = WriterWrapper

--- a/python/whylogs/experimental/performance_estimation/estimation_results.py
+++ b/python/whylogs/experimental/performance_estimation/estimation_results.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from logging import getLogger
 from typing import Any, List, Optional, Tuple, Union
 
-from whylogs.api.writer import Writable
+from whylogs.api.writer import Writable, WriterWrapper
 
 logger = getLogger(__name__)
 
@@ -35,3 +35,6 @@ class EstimationResult(Writable):
 
     def write(self, path: Optional[str] = None, **kwargs: Any) -> Tuple[bool, Union[str, List[str]]]:
         raise ValueError("I'm not a real Writable")
+
+
+EstimationResultWriter = WriterWrapper  # only works with WhylabsWriter

--- a/python/whylogs/viz/extensions/reports/html_report.py
+++ b/python/whylogs/viz/extensions/reports/html_report.py
@@ -6,7 +6,7 @@ from typing import Any, List, Optional, Tuple, Union
 from IPython.core.display import HTML  # type: ignore
 
 from whylogs import DatasetProfileView
-from whylogs.api.writer.writer import Writable
+from whylogs.api.writer.writer import Writable, WriterWrapper
 from whylogs.viz.enums.enums import PageSpec
 
 
@@ -68,3 +68,6 @@ class HTMLReport(Writable, ABC):
 
     def _get_default_filename(self) -> str:
         return "html_reports/ProfileReport.html"
+
+
+HTMLReportWriter = WriterWrapper


### PR DESCRIPTION
## Description

Restores the Writable-specific writer wrappers for backwards compatibility. 

## Changes

Makes `ResultSetWriter`, `EstimationResultWriter`, `HTMLReportWriter`, and `FeatureWeightWriter` as aliases of `WriterWrapper`.

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
