### PR TITLE
Fix SegmentedResultSet::set_dataset_timestamp()

### DIFF
--- a/python/tests/api/logger/test_result_set.py
+++ b/python/tests/api/logger/test_result_set.py
@@ -61,7 +61,7 @@ def test_segmented_result_set_timestamp():
         assert results.view(segment).dataset_timestamp == timestamp
 
 
-def test_segmented_result_set_timestamp():
+def test_view_result_set_timestamp():
     results = ViewResultSet(DatasetProfileView(columns=dict(), dataset_timestamp=None, creation_timestamp=None))
     timestamp = datetime.now(tz=timezone.utc) - timedelta(days=1)
     results.set_dataset_timestamp(timestamp)

--- a/python/tests/api/logger/test_result_set.py
+++ b/python/tests/api/logger/test_result_set.py
@@ -39,6 +39,29 @@ def test_result_set_metadata_on_writables():
 
 
 def test_view_result_set_timestamp():
+    segment_column = "col1"
+    df = pd.DataFrame(data={segment_column: [1, 2]})
+    results: SegmentedResultSet = why.log(df, schema=DatasetSchema(segments=segment_on_column(segment_column)))
+    timestamp = datetime.now(tz=timezone.utc) - timedelta(days=1)
+    results.set_dataset_timestamp(timestamp)
+    segments = results.segments()
+    for segment in segments:
+        assert results.view(segment).dataset_timestamp == timestamp
+
+    # convert segment DatasetProfile to DatasetProfileView to test that case
+    first_partition = results.partitions[0]
+    segments = results.segments_in_partition(first_partition)
+    for segment_key in segments:
+        profile = segments[segment_key]
+        segments[segment_key] = profile.view()
+
+    results.set_dataset_timestamp(timestamp)
+    segments = results.segments()
+    for segment in segments:
+        assert results.view(segment).dataset_timestamp == timestamp
+
+
+def test_segmented_result_set_timestamp():
     results = ViewResultSet(DatasetProfileView(columns=dict(), dataset_timestamp=None, creation_timestamp=None))
     timestamp = datetime.now(tz=timezone.utc) - timedelta(days=1)
     results.set_dataset_timestamp(timestamp)

--- a/python/tests/api/logger/test_result_set.py
+++ b/python/tests/api/logger/test_result_set.py
@@ -38,7 +38,7 @@ def test_result_set_metadata_on_writables():
         assert profile.metadata[custom_metadata_key] == custom_metadata_value
 
 
-def test_view_result_set_timestamp():
+def test_segmented_result_set_timestamp():
     segment_column = "col1"
     df = pd.DataFrame(data={segment_column: [1, 2]})
     results: SegmentedResultSet = why.log(df, schema=DatasetSchema(segments=segment_on_column(segment_column)))

--- a/python/tests/api/logger/test_result_set.py
+++ b/python/tests/api/logger/test_result_set.py
@@ -55,6 +55,7 @@ def test_segmented_result_set_timestamp():
         profile = segments[segment_key]
         segments[segment_key] = profile.view()
 
+timestamp = datetime.now(tz=timezone.utc) - timedelta(days=2)
     results.set_dataset_timestamp(timestamp)
     segments = results.segments()
     for segment in segments:

--- a/python/tests/api/logger/test_result_set.py
+++ b/python/tests/api/logger/test_result_set.py
@@ -55,7 +55,7 @@ def test_segmented_result_set_timestamp():
         profile = segments[segment_key]
         segments[segment_key] = profile.view()
 
-timestamp = datetime.now(tz=timezone.utc) - timedelta(days=2)
+    timestamp = datetime.now(tz=timezone.utc) - timedelta(days=2)
     results.set_dataset_timestamp(timestamp)
     segments = results.segments()
     for segment in segments:

--- a/python/whylogs/core/dataset_profile.py
+++ b/python/whylogs/core/dataset_profile.py
@@ -9,7 +9,7 @@ from whylogs.core.model_performance_metrics.model_performance_metrics import (
     ModelPerformanceMetrics,
 )
 from whylogs.core.preprocessing import ColumnProperties
-from whylogs.core.utils.utils import deprecated_alias
+from whylogs.core.utils.utils import deprecated_alias, ensure_timezone
 
 from .column_profile import ColumnProfile
 from .input_resolver import _pandas_or_dict
@@ -84,9 +84,7 @@ class DatasetProfile(Writable):
         return self._metadata
 
     def set_dataset_timestamp(self, dataset_timestamp: datetime) -> None:
-        if dataset_timestamp.tzinfo is None:
-            logger.warning("No timezone set in the datetime_timestamp object. Default to local timezone")
-
+        ensure_timezone(dataset_timestamp)
         self._dataset_timestamp = dataset_timestamp.astimezone(tz=timezone.utc)
 
     def add_metric(self, col_name: str, metric: Metric) -> None:

--- a/python/whylogs/core/view/dataset_profile_view.py
+++ b/python/whylogs/core/view/dataset_profile_view.py
@@ -77,6 +77,12 @@ class DatasetProfileView(Writable):
         self._dataset_timestamp = date
         return self
 
+    def set_dataset_timestamp(self, dataset_timestamp: datetime) -> None:
+        if dataset_timestamp.tzinfo is None:
+            logger.warning("No timezone set in the datetime_timestamp object. Default to local timezone")
+
+        self._dataset_timestamp = dataset_timestamp.astimezone(tz=timezone.utc)
+
     @property
     def creation_timestamp(self) -> Optional[datetime]:
         return self._creation_timestamp

--- a/python/whylogs/core/view/dataset_profile_view.py
+++ b/python/whylogs/core/view/dataset_profile_view.py
@@ -78,9 +78,7 @@ class DatasetProfileView(Writable):
         return self
 
     def set_dataset_timestamp(self, dataset_timestamp: datetime) -> None:
-        if dataset_timestamp.tzinfo is None:
-            logger.warning("No timezone set in the datetime_timestamp object. Default to local timezone")
-
+        ensure_timezone(dataset_timestamp)
         self._dataset_timestamp = dataset_timestamp.astimezone(tz=timezone.utc)
 
     @property


### PR DESCRIPTION
## Description

`SegmentedResultSet::set_dataset_timestamp()` calls the `set_dataset_timestamp()` method on its contained segments. However, sometimes the segments are `DatasetProfileView`s rather than `DatasetProfile`s (seems to be the case with pyspark). `DatasetProfileView` is weird in that it has a `dataset_timestamp` property setter instead of a `set_dataset_timestamp()` method like everything else. This adds the method.

Perhaps we should deprecate the setter for API consistency?

## Changes

Adds `DatasetProfileView::set_dataset_timestamp()`

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
