### PR TITLE
Remove redundancy between Whylabs writer and client

### DIFF
--- a/python/whylogs/api/writer/whylabs.py
+++ b/python/whylogs/api/writer/whylabs.py
@@ -178,16 +178,16 @@ class WhyLabsWriter(WhyLabsWriterBase):
         Zipped profiles are not supported
         Reference profiles are not supported
         """
-        if self._whylabs_client._transaction_id is not None:
+        if self._whylabs_client._transaction_id is not None:  # type: ignore
             logger.error("Must end current transaction with commit_transaction() before starting another")
-            return self._whylabs_client._transaction_id
+            return self._whylabs_client._transaction_id  # type: ignore
 
         if transaction_id is not None:
             self._whylabs_client._transaction_id = transaction_id  # type: ignore
             return transaction_id
 
         # initiate a new transaction
-        transaction_id : str = self._whylabs_client.get_transaction_id()  # type: ignore
+        transaction_id = self._whylabs_client.get_transaction_id()  # type: ignore
         self._whylabs_client._transaction_id = transaction_id  # type: ignore
         return transaction_id
 
@@ -196,11 +196,11 @@ class WhyLabsWriter(WhyLabsWriterBase):
         Ingest any profiles written since the previous start_transaction().
         Throws on failure.
         """
-        if self._whylabs_client._transaction_id is None:
+        if self._whylabs_client._transaction_id is None:  # type: ignore
             logger.error("Must call start_transaction() before commit_transaction()")
             return
 
-        id = self._whylabs_client._transaction_id
+        id = self._whylabs_client._transaction_id  # type: ignore
         self._whylabs_client._transaction_id = None  # type: ignore
         self._whylabs_client.commit_transaction(id)  # type: ignore
 

--- a/python/whylogs/api/writer/whylabs_base.py
+++ b/python/whylogs/api/writer/whylabs_base.py
@@ -9,7 +9,6 @@ from whylabs_client import ApiClient
 from whylabs_client.model.segment_tag import SegmentTag
 
 from whylogs.api.logger.result_set import ProfileResultSet, ResultSet, ViewResultSet
-from whylogs.api.whylabs.session.session_manager import default_init
 from whylogs.api.writer.whylabs_client import WhyLabsClient
 from whylogs.api.writer.writer import Writer, _Writable
 from whylogs.core import DatasetProfileView

--- a/python/whylogs/api/writer/whylabs_base.py
+++ b/python/whylogs/api/writer/whylabs_base.py
@@ -82,11 +82,6 @@ class WhyLabsWriterBase(Writer):
             ssl_ca_cert,
             _timeout_seconds,
         )
-        session = default_init()  # Force an init if the user didn't do it, it's idempotent
-        config = session.config
-
-        self._reference_profile_name = config.get_whylabs_refernce_profile_name()
-        self._transaction_id = None
 
     @property
     def _api_client(self) -> ApiClient:
@@ -144,10 +139,6 @@ class WhyLabsWriterBase(Writer):
 
         """
         self._whylabs_client = self._whylabs_client.option(**kwargs)
-        if kwargs.get("reference_profile_name") is not None:
-            self._reference_profile_name = kwargs.get("reference_profile_name")
-        if kwargs.get("transaction_id") is not None:
-            self._transaction_id = kwargs.get("transaction_id")
         return self
 
     def _get_dataset_epoch(

--- a/python/whylogs/api/writer/whylabs_client.py
+++ b/python/whylogs/api/writer/whylabs_client.py
@@ -303,12 +303,16 @@ class WhyLabsClient:
         org_id the organization ID
         dataset_id the dataset Id
         api_key the API key
+        reference_profile_name the name of the reference profile
         configuration the additional configuration for the REST client
+        transaction_id to ID of currently active transaction
 
         org_id: Optional[str] = None,
         dataset_id: Optional[str] = None,
         api_key: Optional[str] = None,
+        reference_profile_name: Optional[str] = None,
         configuration: Optional[Configuration] = None,
+        transaction_id: Optional[str] = None,
         ssl_ca_cert: Optional[str] = None,
         api_client: Optional[ApiClient] = None,
         timeout_seconds: Optional[float] = None,
@@ -322,6 +326,7 @@ class WhyLabsClient:
         org_id = kwargs.get("org_id")
         dataset_id = kwargs.get("dataset_id")
         api_key = kwargs.get("api_key")
+        reference_profile_name = kwargs.get("reference_profile_name")
         configuration = kwargs.get("configuration")
         ssl_ca_cert = kwargs.get("ssl_ca_cert")
         api_client = kwargs.get("api_client")
@@ -334,6 +339,8 @@ class WhyLabsClient:
             self._org_id = org_id
         if api_key is not None:
             self._api_key = api_key
+        if reference_profile_name is not None:
+            self._reference_profile_name = reference_profile_name
         if configuration is not None:
             raise ValueError("Manual configuration is not supported. Please override the api_client instead")
         if api_client is not None:

--- a/python/whylogs/api/writer/whylabs_transaction_writer.py
+++ b/python/whylogs/api/writer/whylabs_transaction_writer.py
@@ -68,7 +68,6 @@ class WhyLabsTransactionWriter(WhyLabsWriterBase):
     ):
         super().__init__(org_id, api_key, dataset_id, api_client, ssl_ca_cert, _timeout_seconds, whylabs_client)
         transaction_id = transaction_id or self._whylabs_client.get_transaction_id()  # type: ignore
-        self._transaction_id = transaction_id
         self._whylabs_client._transaction_id = transaction_id  # type: ignore
         self._aborted: bool = False
 
@@ -93,11 +92,11 @@ class WhyLabsTransactionWriter(WhyLabsWriterBase):
                 view, profile_id, upload_url, dataset_timestamp_epoch, tags, **kwargs
             )
             if not bool_status:
-                self._whylabs_client.abort_transaction(self.transaction_id)  # type: ignore
+                self._whylabs_client.abort_transaction(self._whylabs_client._transaction_id)  # type: ignore
                 self._aborted = True
-                logger.info(f"Uploading {profile_id} failed; aborting transaction {self.transaction_id}")
+                logger.info(f"Uploading {profile_id} failed; aborting transaction {self._whylabs_client._transaction_id}")
             else:
-                logger.info(f"Added profile {profile_id} to transaction {self.transaction_id}")
+                logger.info(f"Added profile {profile_id} to transaction {self._whylabs_client._transaction_id}")
             and_status = and_status and bool_status
 
         logger.debug(f"Completed writing {len(views)} files!")
@@ -110,12 +109,12 @@ class WhyLabsTransactionWriter(WhyLabsWriterBase):
     ) -> Tuple[bool, str]:
         dataset_timestamp_epoch = self._get_dataset_epoch(view)
         profile_id, upload_url = self._whylabs_client.get_upload_url_transaction(dataset_timestamp_epoch)  # type: ignore
-        logger.info(f"Added profile {profile_id} to transaction {self.transaction_id}")
+        logger.info(f"Added profile {profile_id} to transaction {self._whylabs_client._transaction_id}")
         success, message = self._upload_view(view, profile_id, upload_url, dataset_timestamp_epoch, **kwargs)
         if not success:
             self._whylabs_client.abort_transaction(self.transaction_id)  # type: ignore
             self._aborted = True
-            logger.info(f"Uploading {profile_id} failed; aborting transaction {self.transaction_id}")
+            logger.info(f"Uploading {profile_id} failed; aborting transaction {self._whylabs_client._transaction_id}")
         return success, message
 
     @deprecated_alias(profile="file")
@@ -123,9 +122,9 @@ class WhyLabsTransactionWriter(WhyLabsWriterBase):
         self, file: _Writable, dest: Optional[str] = None, **kwargs: Any
     ) -> Tuple[bool, Union[str, List[Tuple[bool, str]]]]:
         if self._aborted:
-            return False, f"Transaction {self.transaction_id} was aborted"
+            return False, f"Transaction {self._whylabs_client._transaction_id} was aborted"
 
-        transaction_id = kwargs.get("transaction_id") or self.transaction_id
+        transaction_id = kwargs.get("transaction_id") or self._whylabs_client._transaction_id
         if not transaction_id:
             raise ValueError("Missing transaction id")
 
@@ -139,14 +138,12 @@ class WhyLabsTransactionWriter(WhyLabsWriterBase):
         return self._write_view(view, **kwargs)
 
     def __enter__(self) -> "WhyLabsTransactionWriter":
-        if self.transaction_id is None:
-            self._transaction_id = self._whylabs_client.get_transaction_id()
-            self._whylabs_client._transaction_id = self._transaction_id
+        if self._whylabs_client._transaction_id is None:
+            self._whylabs_client._transaction_id = self._whylabs_client.get_transaction_id()
 
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb) -> None:
-        id = self.transaction_id
-        self._transaction_id = None
+        id = self._whylabs_client._transaction_id
         self._whylabs_client._transaction_id = None  # type: ignore
         self._whylabs_client.commit_transaction(id)  # type: ignore

--- a/python/whylogs/api/writer/whylabs_transaction_writer.py
+++ b/python/whylogs/api/writer/whylabs_transaction_writer.py
@@ -94,9 +94,11 @@ class WhyLabsTransactionWriter(WhyLabsWriterBase):
             if not bool_status:
                 self._whylabs_client.abort_transaction(self._whylabs_client._transaction_id)  # type: ignore
                 self._aborted = True
-                logger.info(f"Uploading {profile_id} failed; aborting transaction {self._whylabs_client._transaction_id}")
+                logger.info(
+                    f"Uploading {profile_id} failed; aborting transaction {self._whylabs_client._transaction_id}"  # type: ignore
+                )
             else:
-                logger.info(f"Added profile {profile_id} to transaction {self._whylabs_client._transaction_id}")
+                logger.info(f"Added profile {profile_id} to transaction {self._whylabs_client._transaction_id}")  # type: ignore
             and_status = and_status and bool_status
 
         logger.debug(f"Completed writing {len(views)} files!")
@@ -109,12 +111,12 @@ class WhyLabsTransactionWriter(WhyLabsWriterBase):
     ) -> Tuple[bool, str]:
         dataset_timestamp_epoch = self._get_dataset_epoch(view)
         profile_id, upload_url = self._whylabs_client.get_upload_url_transaction(dataset_timestamp_epoch)  # type: ignore
-        logger.info(f"Added profile {profile_id} to transaction {self._whylabs_client._transaction_id}")
+        logger.info(f"Added profile {profile_id} to transaction {self._whylabs_client._transaction_id}")  # type: ignore
         success, message = self._upload_view(view, profile_id, upload_url, dataset_timestamp_epoch, **kwargs)
         if not success:
             self._whylabs_client.abort_transaction(self.transaction_id)  # type: ignore
             self._aborted = True
-            logger.info(f"Uploading {profile_id} failed; aborting transaction {self._whylabs_client._transaction_id}")
+            logger.info(f"Uploading {profile_id} failed; aborting transaction {self._whylabs_client._transaction_id}")  # type: ignore
         return success, message
 
     @deprecated_alias(profile="file")
@@ -122,9 +124,9 @@ class WhyLabsTransactionWriter(WhyLabsWriterBase):
         self, file: _Writable, dest: Optional[str] = None, **kwargs: Any
     ) -> Tuple[bool, Union[str, List[Tuple[bool, str]]]]:
         if self._aborted:
-            return False, f"Transaction {self._whylabs_client._transaction_id} was aborted"
+            return False, f"Transaction {self._whylabs_client._transaction_id} was aborted"  # type: ignore
 
-        transaction_id = kwargs.get("transaction_id") or self._whylabs_client._transaction_id
+        transaction_id = kwargs.get("transaction_id") or self._whylabs_client._transaction_id  # type: ignore
         if not transaction_id:
             raise ValueError("Missing transaction id")
 


### PR DESCRIPTION
## Description

Continued writer refactor cleanup. 

## Changes

- Move duplicated state to `WhyLabsClient`
- Remove support for zipped reference profiles

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
