### PR TITLE
deprecate debug event argument

### DIFF
--- a/python/whylogs/api/logger/__init__.py
+++ b/python/whylogs/api/logger/__init__.py
@@ -31,12 +31,14 @@ from whylogs.core.model_performance_metrics.model_performance_metrics import (
     ModelPerformanceMetrics,
 )
 from whylogs.core.stubs import pd
+from whylogs.core.utils import deprecated_argument
 
 diagnostic_logger = logging.getLogger(__name__)
 
 Loggable = Union["pd.DataFrame", List[Dict[str, Any]]]
 
 
+@deprecated_argument("debug_event")
 def log(
     obj: Any = None,
     *,

--- a/python/whylogs/core/utils/__init__.py
+++ b/python/whylogs/core/utils/__init__.py
@@ -4,7 +4,7 @@ from .stats_calculations import (
     get_distribution_metrics,
     is_probably_unique,
 )
-from .utils import deprecated, deprecated_alias, ensure_timezone
+from .utils import deprecated, deprecated_alias, deprecated_argument, ensure_timezone
 
 __ALL__ = [  #
     read_delimited_protobuf,
@@ -13,6 +13,7 @@ __ALL__ = [  #
     is_probably_unique,
     get_cardinality_estimate,
     deprecated_alias,
+    deprecated_argument,
     deprecated,
     ensure_timezone,  #
 ]

--- a/python/whylogs/core/utils/utils.py
+++ b/python/whylogs/core/utils/utils.py
@@ -37,7 +37,7 @@ def deprecated_argument(arg_name: str, message: Optional[str] = None):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             if arg_name in kwargs:
-                warnings.warn(f"Argument {arg_name} is deprecated, {message if message else 'do not use it'}.")
+                warnings.warn(f"Argument {arg_name} is deprecated, {message if message else 'it will be removed in the next major version of whylogs'}.")
             return func(*args, **kwargs)
 
         return wrapper

--- a/python/whylogs/core/utils/utils.py
+++ b/python/whylogs/core/utils/utils.py
@@ -37,7 +37,9 @@ def deprecated_argument(arg_name: str, message: Optional[str] = None):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             if arg_name in kwargs:
-                warnings.warn(f"Argument {arg_name} is deprecated, {message if message else 'it will be removed in the next major version of whylogs'}.")
+                warnings.warn(
+                    f"Argument {arg_name} is deprecated, {message if message else 'it will be removed in the next major version of whylogs'}."
+                )
             return func(*args, **kwargs)
 
         return wrapper

--- a/python/whylogs/core/utils/utils.py
+++ b/python/whylogs/core/utils/utils.py
@@ -1,7 +1,7 @@
 import datetime
 import functools
 import warnings
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 from urllib.parse import urlparse
 
 from urllib3 import util
@@ -26,6 +26,19 @@ def deprecated_alias(**aliases: str) -> Callable:
         def wrapper(*args, **kwargs):
             rename_kwargs(method.__name__, kwargs, aliases)
             return method(*args, **kwargs)
+
+        return wrapper
+
+    return deprecated_decorator
+
+
+def deprecated_argument(arg_name: str, message: Optional[str] = None):
+    def deprecated_decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if arg_name in kwargs:
+                warnings.warn(f"Argument {arg_name} is deprecated, {message if message else 'do not use it'}.")
+            return func(*args, **kwargs)
 
         return wrapper
 


### PR DESCRIPTION
## Description

deprecate `debug_event` argument.

## Changes

- adds a `deprecate_argument` decorator to issue a warning if a deprecated keyword argument is used.


- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
