### PR TITLE
Include timestamp in log_regression_metrics

### DIFF
--- a/python/whylogs/api/logger/__init__.py
+++ b/python/whylogs/api/logger/__init__.py
@@ -99,6 +99,8 @@ def _log_with_metrics(
         results = log(pandas=data, schema=schema, dataset_timestamp=dataset_timestamp)
     else:
         results = ProfileResultSet(DatasetProfile(schema=schema))
+        if dataset_timestamp is not None:
+            results.set_dataset_timestamp(dataset_timestamp)
 
     results.add_model_performance_metrics(metrics)
     return results


### PR DESCRIPTION
## Description

Include timestamp in `log_regression_metrics()` when `log_full_data` is `False`.

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
