### PR TITLE
Remove size check on whylabs api keys

### DIFF
--- a/python/whylogs/api/whylabs/session/whylabs_client_cache.py
+++ b/python/whylogs/api/whylabs/session/whylabs_client_cache.py
@@ -24,8 +24,6 @@ class KeyRefresher(abc.ABC):
             raise ValueError("Missing API key. Set it via WHYLABS_API_KEY environment variable or as an api_key option")
         if len(api_key) < 12:
             raise ValueError("API key too short")
-        if len(api_key) > 80:
-            raise ValueError("API key too long")
         if api_key[10] != ".":
             raise ValueError("Invalid format. Expecting a dot at an index 10")
         return api_key[:10]


### PR DESCRIPTION
This constraint isn't true. Keys can actually be arbitrarily long now that they include the org id as well, which is customizable.
