### PR TITLE
Fix auto-version bumping based on PR labels

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: "v$NEXT_PATCH_VERSION"
-tag-template: "v$NEXT_PATCH_VERSION"
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
 change-template: "- $TITLE #$NUMBER [@$AUTHOR]"
 
 categories:
@@ -45,8 +45,8 @@ version-resolver:
 
 template: |
 
-  ## whylogs release v$NEXT_PATCH_VERSION
-  Hi everyone! We’ve now released whylogs $NEXT_PATCH_VERSION 🚀.
+  ## whylogs release v$RESOLVED_VERSION
+  Hi everyone! We’ve now released whylogs $RESOLVED_VERSION 🚀.
   whylogs is the open standard for data and ML logging created by WhyLabs. 👩🏽‍🔬
   This version includes:
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,8 +6,13 @@ on:
     branches:
       - mainline
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "mainline"


### PR DESCRIPTION
## Description

Fixes version bumping in release drafter workflow. You can label a PR with `major`, `minor`, or `patch` to indicate which component of the version number the PR should increment (defaults to `patch` for unlabeled PRs). The release drafter will tag & name the draft release according to the maximum bumped version component of the set of PRs in the release.

## Changes

- Uses the correct variable for tagging & describing the draft release
- Updates some permissions in the action

- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
