### PR TITLE
Remove DataType definition

### DIFF
--- a/proto/src/whylogs_messages.proto
+++ b/proto/src/whylogs_messages.proto
@@ -7,19 +7,6 @@ option java_package = "com.whylogs.core.message";
 option java_outer_classname = "Messages";
 option java_multiple_files = true;
 
-message DataType {
-  enum Type {
-    UNKNOWN = 0;
-    NULL = 1;
-    FRACTIONAL = 2;
-    INTEGRAL = 3;
-    BOOLEAN = 4;
-    STRING = 5;
-  }
-
-  Type type = 1;
-}
-
 message HllSketchMessage {
   bytes sketch = 1;
 }


### PR DESCRIPTION
## Description

Removes unused `DataType` message definition.


## Related

Closes whylabs/whylogs#1583


- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
