### PR TITLE
Fix: Replace deprecated np.unicode_ with np.str_ for NumPy 2.0 compatibility

### DIFF
--- a/python/whylogs/core/datatypes.py
+++ b/python/whylogs/core/datatypes.py
@@ -101,7 +101,7 @@ class String(DataType[str]):
         if not isinstance(dtype_or_type, type):
             return False
 
-        if issubclass(dtype_or_type, (str, np.unicode_)):
+        if issubclass(dtype_or_type, (str, np.str_)):
             return True
 
         return False


### PR DESCRIPTION
### Summary
This PR fixes an issue where `np.unicode_` was removed in NumPy 2.0, causing an AttributeError.  
The fix replaces `np.unicode_` with `np.str_`, which is the recommended alternative.

### Changes
- Replaced `np.unicode_` with `np.str_` in the `String` class.

### Testing
- Ran `pytest` to ensure all tests pass.