### PR TITLE
fix: replace bare `except:` with `except ImportError:` in optional import guards

### DIFF
--- a/python/whylogs/core/datatypes.py
+++ b/python/whylogs/core/datatypes.py
@@ -6,7 +6,7 @@ from whylogs.core.stubs import is_not_stub, np
 
 try:
     from pandas.core.api import CategoricalDtype
-except:  # noqa
+except ImportError:  # noqa
     CategoricalDtype = None  # type: ignore
 
 NT = TypeVar("NT")

--- a/python/whylogs/core/preprocessing.py
+++ b/python/whylogs/core/preprocessing.py
@@ -12,7 +12,7 @@ logger = logging.getLogger("whylogs.core.views")
 
 try:
     import pandas.core.dtypes.common as pdc
-except:  # noqa
+except ImportError:  # noqa
     pass
 
 


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with specific `except ImportError:` in optional import guard blocks.

### Changes
- `python/whylogs/core/preprocessing.py`: The `try/except` block guards an optional `import pandas.core.dtypes.common` — catching only `ImportError` is more precise and avoids silently swallowing unexpected errors.
- `python/whylogs/core/datatypes.py`: The `try/except` block guards an optional `from pandas.core.api import CategoricalDtype` — same fix.

### Why
Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and programming errors like `SyntaxError`. For optional dependency imports, `except ImportError:` is the correct and intended exception to catch. This aligns with Python best practices (PEP 8) and makes error handling more explicit.

### Testing
These are import-time guard blocks with no behavioral change when pandas is/isn't installed. The only difference is that non-import errors are no longer silently swallowed.
