### PR TITLE
Set a whylogs user agent on the S3 reader and writer clients

### DIFF
--- a/python/tests/api/reader/test_s3.py
+++ b/python/tests/api/reader/test_s3.py
@@ -49,6 +49,10 @@ class TestS3Reader(object):
         assert isinstance(profile_option, ResultSet)
         assert isinstance(profile_option.view(), DatasetProfileView)
 
+    def test_s3_reader_sets_whylogs_user_agent(self):
+        reader = S3Reader()
+        assert "whylogs/python/" in reader.s3_client.meta.config.user_agent_extra
+
     def test_empty_bucket_failure(self, object_path):
         reader = S3Reader(bucket_name=None, object_name=object_path)
         with pytest.raises(ParamValidationError):

--- a/python/tests/api/writer/test_s3.py
+++ b/python/tests/api/writer/test_s3.py
@@ -46,6 +46,10 @@ class TestS3Writer(object):
         objects = writer.s3_client.list_objects(Bucket=BUCKET_NAME)
         assert tmp_path.name in [obj["Key"] for obj in objects.get("Contents", [])]
 
+    def test_s3_writer_sets_whylogs_user_agent(self):
+        writer = S3Writer()
+        assert "whylogs/python/" in writer.s3_client.meta.config.user_agent_extra
+
     def test_empty_string_bucket_name_raises_exception(self, result_set):
         with pytest.raises(ParamValidationError):
             response = result_set.writer("s3").option(bucket_name="").write()

--- a/python/whylogs/api/reader/s3.py
+++ b/python/whylogs/api/reader/s3.py
@@ -18,6 +18,10 @@ class S3Reader(Reader):
     >**IMPORTANT**: In order to correctly connect to your Amazon S3 bucket, make sure you have
     the following environment variables set: `[AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY]`.
 
+    To read from an S3-compatible object store instead (for example Backblaze B2, Cloudflare R2,
+    or MinIO), pass a client built with that store's endpoint, such as
+    `S3Reader(s3_client=boto3.client("s3", endpoint_url="https://s3.example-region.example.com"))`.
+
     Parameters
     ----------
     bucket_name: str, optional

--- a/python/whylogs/api/reader/s3.py
+++ b/python/whylogs/api/reader/s3.py
@@ -3,9 +3,12 @@ from typing import Optional
 
 import boto3
 from botocore.client import BaseClient
+from botocore.config import Config
 
-from whylogs import ResultSet
+from whylogs import ResultSet, __version__
 from whylogs.api.reader.reader import Reader
+
+_USER_AGENT_EXTRA = f"whylogs/python/{__version__}"
 
 
 class S3Reader(Reader):
@@ -41,7 +44,7 @@ class S3Reader(Reader):
         bucket_name: Optional[str] = None,
         s3_client: Optional[BaseClient] = None,
     ):
-        self.s3_client = s3_client or boto3.client("s3")
+        self.s3_client = s3_client or boto3.client("s3", config=Config(user_agent_extra=_USER_AGENT_EXTRA))
         self.object_name = object_name or None
         self.bucket_name = bucket_name or ""
 

--- a/python/whylogs/api/writer/s3.py
+++ b/python/whylogs/api/writer/s3.py
@@ -4,13 +4,17 @@ from typing import Any, List, Optional, Tuple, Union
 
 import boto3
 from botocore.client import BaseClient
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
+from whylogs import __version__
 from whylogs.api.writer import Writer
 from whylogs.api.writer.writer import _Writable
 from whylogs.core.utils import deprecated_alias
 
 logger = logging.getLogger(__name__)
+
+_USER_AGENT_EXTRA = f"whylogs/python/{__version__}"
 
 
 class S3Writer(Writer):
@@ -58,7 +62,7 @@ class S3Writer(Writer):
         bucket_name: Optional[str] = None,
         object_name: Optional[str] = None,
     ):
-        self.s3_client = s3_client or boto3.client("s3")
+        self.s3_client = s3_client or boto3.client("s3", config=Config(user_agent_extra=_USER_AGENT_EXTRA))
         self.base_prefix = base_prefix or "profile"
         self.bucket_name = bucket_name or ""
         self.object_name = object_name or None

--- a/python/whylogs/api/writer/s3.py
+++ b/python/whylogs/api/writer/s3.py
@@ -24,6 +24,10 @@ class S3Writer(Writer):
     >**IMPORTANT**: In order to correctly connect to your Amazon S3 bucket, make sure you have
     the following environment variables set: `[AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY]`
 
+    To write to an S3-compatible object store instead (for example Backblaze B2, Cloudflare R2,
+    or MinIO), pass a client built with that store's endpoint, such as
+    `S3Writer(s3_client=boto3.client("s3", endpoint_url="https://s3.example-region.example.com"))`.
+
     Parameters
     ----------
     s3_client: BaseClient, optional


### PR DESCRIPTION
## Description

This repository needs the boto3 S3 clients that whylogs builds for itself to identify whylogs in their user agent, the same way `WhyLabsClientCache` already labels the WhyLabs `ApiClient` with `whylogs/python/<version>`. Today an object storage access log cannot tell whylogs traffic apart from any other boto3 caller.

The commits in this pull request append `whylogs/python/<version>` to `user_agent_extra` on the client `S3Writer` and `S3Reader` construct when the caller does not supply one, document that either class can be pointed at an S3-compatible object store through the existing `s3_client` argument, and add one test per class covering the tag.

Verified locally with `pytest tests/api/writer/test_s3.py tests/api/reader/test_s3.py` (12 passed), plus black, isort and flake8 at the pinned pre-commit versions on the changed files. I also confirmed on the wire under moto that the resulting header is `Boto3/... Botocore/... whylogs/python/<version>`, so nothing is dropped from the default user agent.

## Changes

- Set whylogs user agent on reader and writer clients (70e2037)
  - `S3Writer` and `S3Reader` build their default client with `Config(user_agent_extra="whylogs/python/<version>")`.
  - The version comes from `whylogs.__version__`, so the tag matches the string already used for `ApiClient.user_agent` and inherits the existing non-raising fallback in `package_version()`.
  - botocore appends `user_agent_extra` instead of replacing the user agent, so the `Boto3/...` and `Botocore/...` tokens are preserved, and a caller-supplied `s3_client` is still used exactly as given.
- Note how to target S3-compatible object stores (20fceba)
  - Docstring note on both classes showing a client built with an `endpoint_url`. `s3_client` was already the only way to reach a non-AWS endpoint, it just was not written down.
- Cover the user agent on reader and writer clients (14b94a4)
  - One test per class asserting `whylogs/python/` is present on the default client.

## Related

No related issue.

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).